### PR TITLE
Add autonomous LLM strategy agent (API key + Claude Code OAuth backends)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,76 @@ source .env.local
 set +a
 npm run sim
 ```
+
+## LLM-driven autonomous agent
+
+`examples/agents/claude-llm.ts` is an agent whose strategy is generated and revised by Claude Sonnet 4.6 at runtime. There is no hand-written trading logic — Claude writes both the natural-language plan and a TypeScript executor function that runs each round in a `vm.Script` sandbox.
+
+### Architecture
+- **Slow tier (Claude API)**: called once at startup to design an initial strategy, then again every `ERIS_LLM_REVIEW_EVERY` rounds (default 10) or when realized PnL drops below `1 - ERIS_LLM_DRAWDOWN_RATIO` of starting USD (default 5%). Calls run in the background and never block the round response.
+- **Fast tier (vm.Script)**: each round, the current executor body is evaluated against the observation with a 200 ms timeout. If the strategy is not yet ready (first ~10 sec while init is in flight) or the executor throws / returns an invalid action, the agent emits `noop` for that round and continues.
+- Strategies are written to `runs/<run_id>/agent-<id>/strategy-vN.{md,params.json,executor.ts}` so you can read what Claude is thinking. Per-round decisions and API call telemetry land in `decisions.jsonl` and `claude-calls.jsonl` in the same directory.
+
+### Three backends
+
+`ERIS_LLM_AUTH` selects which Claude transport to use. `auto` (the default) picks the best available, never crashes on missing credentials.
+
+| Mode | Auth | Use when |
+|---|---|---|
+| `subscription` | Claude Pro/Max OAuth (via Claude Code CLI) | You already have `claude` installed and logged in — zero per-token cost |
+| `apikey` | `ANTHROPIC_API_KEY` | CI, parallel sim runs, or when you want exact per-call billing |
+| `mock` | none | Offline smoke tests — always returns a noop strategy |
+| `auto` *(default)* | tries subscription → apikey → mock | Local dev where Claude Code is installed |
+
+### Run it (subscription, no API key)
+
+```bash
+# Make sure you've logged in once: `claude auth login` (uses your Pro/Max plan)
+set -a
+source .env.local
+set +a
+AGENTS_CONFIG=agents.claude-llm.json npm run sim
+```
+
+`auto` will detect the `claude` binary on PATH and route through the Claude Agent SDK. You'll see `[claude-llm] strategist=subscription (auto-detected Claude Code OAuth)` on stderr.
+
+### Run it (API key)
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+AGENTS_CONFIG=agents.claude-llm.json ERIS_LLM_AUTH=apikey npm run sim
+```
+
+`AGENT_TIMEOUT_MS` only matters if you want headroom — the LLM call is async and never holds up `requestAction`, so the default 5000 ms is fine in practice.
+
+### Offline mock
+
+Set `ERIS_LLM_MOCK=1` (or `ERIS_LLM_AUTH=mock`) to skip Claude entirely and use a hard-coded noop strategy. Useful for smoke-testing the harness without spending tokens or having any auth:
+
+```bash
+AGENTS_CONFIG=agents.claude-llm.json ERIS_LLM_MOCK=1 npm run sim
+```
+
+### Tuning
+
+Environment variables (set in the parent shell — `agentProcess.ts` forwards `ANTHROPIC_API_KEY` and any `ERIS_LLM_*` var to the child):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `ERIS_LLM_AUTH` | `auto` | `subscription` \| `apikey` \| `mock` \| `auto` — see backend table above |
+| `ERIS_LLM_MODEL` | `sonnet` (subscription) / `claude-sonnet-4-6` (apikey) | Claude model alias or id |
+| `ERIS_LLM_REVIEW_EVERY` | `10` | Scheduled revision cadence in rounds |
+| `ERIS_LLM_DRAWDOWN_RATIO` | `0.05` | Fractional PnL drop that triggers an off-schedule revision |
+| `ERIS_LLM_HISTORY_CAPACITY` | `30` | How many recent rounds to keep in the revision prompt |
+| `ERIS_LLM_EXECUTOR_TIMEOUT_MS` | `200` | Hard cap on per-round executor execution |
+| `ERIS_LLM_MOCK` | unset | If `1`, force the offline mock strategy (alias for `ERIS_LLM_AUTH=mock`) |
+
+Cost / latency comparison per call:
+
+| Backend | Wall time | Per-call cost | Cache | Rate limit |
+|---|---|---|---|---|
+| `apikey` | ~1–2s | ~$0.05 per 128-round run | ephemeral on `SIM_RULES` block | API tier |
+| `subscription` | ~4–8s (CLI cold start + harness prompt) | $0 — subscription absorbs | per-process; long-lived `query` not yet wired | Max weekly / 5h caps |
+| `mock` | <1ms | $0 | n/a | n/a |
+
+Subscription mode is best for local dev and ad-hoc runs; switch to `apikey` for unattended / parallel / CI runs that risk hitting Max weekly caps.

--- a/agents.claude-llm.json
+++ b/agents.claude-llm.json
@@ -1,0 +1,11 @@
+{
+  "agents": [
+    {
+      "id": "claude-llm",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/claude-llm.ts"],
+      "wallet": "AGENT0_PRIVATE_KEY",
+      "description": "Claude Sonnet 4.6 autonomous strategist (NL strategy + TS executor, async revisions). Requires ANTHROPIC_API_KEY in the parent shell, or set ERIS_LLM_MOCK=1 to use the offline mock."
+    }
+  ]
+}

--- a/examples/agents/claude-llm.ts
+++ b/examples/agents/claude-llm.ts
@@ -1,0 +1,6 @@
+import { run } from "../../src/llm/claudeAgent.js";
+
+run().catch((error) => {
+  process.stderr.write(`fatal: ${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "eris-competition",
       "version": "0.1.0",
       "dependencies": {
-        "viem": "^2.39.3"
+        "@anthropic-ai/claude-agent-sdk": "^0.3.150",
+        "@anthropic-ai/sdk": "^0.98.0",
+        "viem": "^2.39.3",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -21,6 +24,165 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.150.tgz",
+      "integrity": "sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.150"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.150.tgz",
+      "integrity": "sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.150.tgz",
+      "integrity": "sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.150.tgz",
+      "integrity": "sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.150.tgz",
+      "integrity": "sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.150.tgz",
+      "integrity": "sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.150.tgz",
+      "integrity": "sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.150.tgz",
+      "integrity": "sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.150.tgz",
+      "integrity": "sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -464,12 +626,64 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -540,6 +754,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -569,6 +789,270 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -613,11 +1097,176 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -634,6 +1283,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -646,6 +1341,124 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/isows": {
       "version": "1.0.7",
@@ -660,6 +1473,152 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/ox": {
@@ -707,6 +1666,104 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -716,6 +1773,206 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -735,6 +1992,37 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -758,6 +2046,24 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/viem": {
       "version": "2.48.8",
@@ -804,6 +2110,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -824,6 +2151,25 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
-    "viem": "^2.39.3"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.150",
+    "@anthropic-ai/sdk": "^0.98.0",
+    "viem": "^2.39.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/src/agentProcess.ts
+++ b/src/agentProcess.ts
@@ -10,21 +10,23 @@ export class AgentProcess {
   private stderr = "";
 
   constructor(readonly spec: AgentSpec, rpcUrl: string, agentAddress: string) {
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    // Strip parent Claude Code session vars so SDK-spawned claude
+    // subprocesses authenticate via their own OAuth rather than inheriting
+    // a foreign session id from the surrounding Claude Code harness.
+    for (const k of Object.keys(childEnv)) {
+      if (k.startsWith("CLAUDE_CODE_")) delete childEnv[k];
+    }
+    Object.assign(childEnv, spec.env ?? {});
+    childEnv.NODE_ENV = process.env.NODE_ENV ?? "development";
+    childEnv.ERIS_AGENT_ID = spec.id;
+    childEnv.ERIS_RPC_URL = rpcUrl;
+    childEnv.ERIS_AGENT_ADDRESS = agentAddress;
+    childEnv.REPORT_DIR = process.env.REPORT_DIR ?? "./runs";
+
     this.child = spawn(spec.command, spec.args ?? [], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: {
-        // Forward LLM-related vars from parent (spec.env can override below)
-        ...forwardedParentEnv(),
-        // Per-agent config from agents.<name>.json
-        ...(spec.env ?? {}),
-        // Always-forced values
-        PATH: process.env.PATH ?? "",
-        NODE_ENV: process.env.NODE_ENV ?? "development",
-        ERIS_AGENT_ID: spec.id,
-        ERIS_RPC_URL: rpcUrl,
-        ERIS_AGENT_ADDRESS: agentAddress,
-        REPORT_DIR: process.env.REPORT_DIR ?? "./runs"
-      }
+      env: childEnv
     });
 
     const stdout = createInterface({ input: this.child.stdout });
@@ -62,17 +64,3 @@ export class AgentProcess {
   }
 }
 
-/**
- * Forward a small whitelist of parent env vars to the child agent process.
- * Anything starting with ERIS_LLM_ is passed through (so users can do
- * `ERIS_LLM_MODEL=claude-haiku-4-5 npm run sim`), plus ANTHROPIC_API_KEY.
- * spec.env in the agents JSON overrides these.
- */
-function forwardedParentEnv(): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (process.env.ANTHROPIC_API_KEY) out.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-  for (const [k, v] of Object.entries(process.env)) {
-    if (k.startsWith("ERIS_LLM_") && v !== undefined) out[k] = v;
-  }
-  return out;
-}

--- a/src/agentProcess.ts
+++ b/src/agentProcess.ts
@@ -13,12 +13,17 @@ export class AgentProcess {
     this.child = spawn(spec.command, spec.args ?? [], {
       stdio: ["pipe", "pipe", "pipe"],
       env: {
+        // Forward LLM-related vars from parent (spec.env can override below)
+        ...forwardedParentEnv(),
+        // Per-agent config from agents.<name>.json
         ...(spec.env ?? {}),
+        // Always-forced values
         PATH: process.env.PATH ?? "",
         NODE_ENV: process.env.NODE_ENV ?? "development",
         ERIS_AGENT_ID: spec.id,
         ERIS_RPC_URL: rpcUrl,
-        ERIS_AGENT_ADDRESS: agentAddress
+        ERIS_AGENT_ADDRESS: agentAddress,
+        REPORT_DIR: process.env.REPORT_DIR ?? "./runs"
       }
     });
 
@@ -55,4 +60,19 @@ export class AgentProcess {
   getStderr(): string {
     return this.stderr;
   }
+}
+
+/**
+ * Forward a small whitelist of parent env vars to the child agent process.
+ * Anything starting with ERIS_LLM_ is passed through (so users can do
+ * `ERIS_LLM_MODEL=claude-haiku-4-5 npm run sim`), plus ANTHROPIC_API_KEY.
+ * spec.env in the agents JSON overrides these.
+ */
+function forwardedParentEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (process.env.ANTHROPIC_API_KEY) out.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("ERIS_LLM_") && v !== undefined) out[k] = v;
+  }
+  return out;
 }

--- a/src/llm/claudeAgent.ts
+++ b/src/llm/claudeAgent.ts
@@ -1,0 +1,338 @@
+import { createInterface } from "node:readline";
+import { mkdirSync, writeFileSync, appendFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { encodeFunctionData, parseUnits, formatUnits } from "viem";
+import type { AgentAction, AgentObservation } from "../types.js";
+import { History, buildRoundRecord } from "./history.js";
+import {
+  DEFAULT_ADDRESSES,
+  runExecutor,
+  type ExecutorHelpers,
+  type Strategy
+} from "./strategy.js";
+import {
+  ClaudeStrategist,
+  MockStrategist,
+  type ClaudeCallMeta,
+  type Strategist,
+  type StrategyResult
+} from "./claudeStrategist.js";
+import { ClaudeSubscriptionStrategist } from "./claudeSubscriptionStrategist.js";
+import type { ReviseReason } from "./prompts.js";
+
+const REVIEW_EVERY_N_ROUNDS = intEnv("ERIS_LLM_REVIEW_EVERY", 10);
+const DRAWDOWN_TRIGGER_RATIO = floatEnv("ERIS_LLM_DRAWDOWN_RATIO", 0.05);
+const HISTORY_CAPACITY = intEnv("ERIS_LLM_HISTORY_CAPACITY", 30);
+const EXECUTOR_TIMEOUT_MS = intEnv("ERIS_LLM_EXECUTOR_TIMEOUT_MS", 200);
+
+function reportDirRoot(): string {
+  return process.env.REPORT_DIR ?? "./runs";
+}
+
+export type State = {
+  strategy: Strategy | null;
+  pendingPhase: "init" | "revise" | null;
+  pending: Promise<void> | null;
+  history: History;
+  lastReviseRound: number;
+  agentId: string;
+  agentDir: string | null;
+  decisionsPath: string | null;
+  callsPath: string | null;
+};
+
+export function createState(agentId: string, historyCapacity = HISTORY_CAPACITY): State {
+  return {
+    strategy: null,
+    pendingPhase: null,
+    pending: null,
+    history: new History(historyCapacity),
+    lastReviseRound: -1,
+    agentId,
+    agentDir: null,
+    decisionsPath: null,
+    callsPath: null
+  };
+}
+
+const helpersBase: Omit<ExecutorHelpers, "log"> = {
+  parseUnits,
+  formatUnits,
+  encodeFunctionData,
+  ADDRESSES: DEFAULT_ADDRESSES
+};
+
+/**
+ * Pick a Strategist based on env. `ERIS_LLM_AUTH` (or legacy `ERIS_LLM_MOCK=1`)
+ * controls the choice:
+ *   mock          – offline, no network. Default when nothing else is available.
+ *   apikey        – ClaudeStrategist using ANTHROPIC_API_KEY.
+ *   subscription  – ClaudeSubscriptionStrategist via Claude Code OAuth (Pro/Max).
+ *   auto (default)– subscription if `claude` is reachable, else apikey if a key
+ *                   is set, else mock. Never throws on unavailability.
+ */
+export function selectStrategist(): Strategist {
+  const auth = (process.env.ERIS_LLM_AUTH ?? "auto").toLowerCase();
+  if (process.env.ERIS_LLM_MOCK === "1" || auth === "mock") {
+    emitStderr("[claude-llm] strategist=mock (ERIS_LLM_MOCK=1 or ERIS_LLM_AUTH=mock)\n");
+    return new MockStrategist();
+  }
+  if (auth === "apikey") {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      emitStderr("[claude-llm] strategist=mock (ERIS_LLM_AUTH=apikey but ANTHROPIC_API_KEY unset)\n");
+      return new MockStrategist();
+    }
+    emitStderr("[claude-llm] strategist=apikey\n");
+    return new ClaudeStrategist();
+  }
+  if (auth === "subscription") {
+    emitStderr("[claude-llm] strategist=subscription (Claude Code OAuth)\n");
+    return new ClaudeSubscriptionStrategist();
+  }
+  // auto
+  if (canUseSubscription()) {
+    emitStderr("[claude-llm] strategist=subscription (auto-detected Claude Code OAuth)\n");
+    return new ClaudeSubscriptionStrategist();
+  }
+  if (process.env.ANTHROPIC_API_KEY) {
+    emitStderr("[claude-llm] strategist=apikey (auto: no claude binary, ANTHROPIC_API_KEY present)\n");
+    return new ClaudeStrategist();
+  }
+  emitStderr("[claude-llm] strategist=mock (auto: no claude binary, no ANTHROPIC_API_KEY)\n");
+  return new MockStrategist();
+}
+
+/**
+ * Probe whether the `claude` CLI binary is reachable from PATH. If yes, we
+ * assume Claude Agent SDK will be able to use OAuth via the bundled binary.
+ * Cheap and synchronous so selectStrategist stays predictable.
+ */
+function canUseSubscription(): boolean {
+  try {
+    // Cross-platform "is `claude` on PATH?" probe. spawnSync's shell:true
+    // honors PATH and is cheap (~1ms).
+    const result = spawnSync("command -v claude", { shell: true, stdio: "ignore" });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Entry point. Spawned by AgentProcess; reads observations on stdin, writes actions on stdout.
+ * The strategist is consulted asynchronously and never blocks the per-round response.
+ */
+export async function run(strategist?: Strategist): Promise<void> {
+  const agentId = process.env.ERIS_AGENT_ID ?? "claude-llm";
+  const s = strategist ?? selectStrategist();
+  const state = createState(agentId);
+
+  const rl = createInterface({ input: process.stdin });
+  rl.on("line", (line) => {
+    handleLine(line, state, s).catch((error) => {
+      emitStderr(`unhandled error: ${error instanceof Error ? error.stack : String(error)}\n`);
+      emitAction({ type: "noop", reason: "unhandled internal error" });
+    });
+  });
+}
+
+export async function handleLine(line: string, state: State, strategist: Strategist): Promise<AgentAction> {
+  let obs: AgentObservation;
+  try {
+    obs = JSON.parse(line) as AgentObservation;
+  } catch (error) {
+    const fallback: AgentAction = { type: "noop", reason: `bad observation json: ${msg(error)}` };
+    emitAction(fallback);
+    return fallback;
+  }
+
+  ensureRunDirs(state, obs);
+  state.history.setInitialUsd(obs.inventory.valueUsdc);
+
+  // Kick off background strategy calls if needed. These do not block the response.
+  scheduleStrategyWorkIfNeeded(state, strategist, obs);
+
+  const decision = decideAction(state, obs);
+  state.history.push(
+    buildRoundRecord(obs, decision.action, decision.ok, decision.reason, decision.logs)
+  );
+  appendDecision(state, obs, decision);
+  emitAction(decision.action);
+  return decision.action;
+}
+
+type DecisionResult = {
+  action: AgentAction;
+  ok: boolean;
+  reason?: string;
+  logs: string[];
+  strategyVersion: number | null;
+};
+
+function decideAction(state: State, obs: AgentObservation): DecisionResult {
+  if (!state.strategy) {
+    const reason = state.pendingPhase === "init" ? "strategy init pending" : "no strategy yet";
+    return { action: { type: "noop", reason }, ok: false, reason, logs: [], strategyVersion: null };
+  }
+  const result = runExecutor(state.strategy, obs, helpersBase, EXECUTOR_TIMEOUT_MS);
+  if (!result.ok) {
+    return {
+      action: { type: "noop", reason: `executor error: ${result.reason}` },
+      ok: false,
+      reason: result.reason,
+      logs: result.logs,
+      strategyVersion: state.strategy.version
+    };
+  }
+  return { action: result.action, ok: true, logs: result.logs, strategyVersion: state.strategy.version };
+}
+
+function scheduleStrategyWorkIfNeeded(state: State, strategist: Strategist, obs: AgentObservation): void {
+  if (state.pendingPhase !== null) return;
+  if (!state.strategy) {
+    state.pendingPhase = "init";
+    state.pending = runStrategistInit(state, strategist, obs);
+    return;
+  }
+  const initialUsd = state.history.getInitialUsd() ?? obs.inventory.valueUsdc;
+  const currentUsd = obs.inventory.valueUsdc;
+  const reason = whichReviseReason(obs.round, state.lastReviseRound, currentUsd, initialUsd);
+  if (reason) {
+    state.pendingPhase = "revise";
+    state.lastReviseRound = obs.round;
+    state.pending = runStrategistRevise(state, strategist, obs, reason, initialUsd, currentUsd);
+  }
+}
+
+export function whichReviseReason(
+  round: number,
+  lastReviseRound: number,
+  currentUsd: number,
+  initialUsd: number
+): ReviseReason | null {
+  if (round > 0 && round !== lastReviseRound && round % REVIEW_EVERY_N_ROUNDS === 0) return "scheduled";
+  if (initialUsd > 0 && currentUsd < initialUsd * (1 - DRAWDOWN_TRIGGER_RATIO) && round !== lastReviseRound) {
+    return "pnl_drop";
+  }
+  return null;
+}
+
+async function runStrategistInit(state: State, strategist: Strategist, obs: AgentObservation): Promise<void> {
+  const version = nextVersion(state);
+  const result = await strategist.init(obs, version);
+  logClaudeCall(state, result, "init");
+  if (result.ok) {
+    state.strategy = result.strategy;
+    persistStrategy(state, result.strategy);
+    emitStderr(`[claude-llm] strategy v${result.strategy.version} initialized\n`);
+  } else {
+    emitStderr(`[claude-llm] init failed: ${result.reason}\n`);
+  }
+  state.pendingPhase = null;
+  state.pending = null;
+}
+
+async function runStrategistRevise(
+  state: State,
+  strategist: Strategist,
+  obs: AgentObservation,
+  reason: ReviseReason,
+  initialUsd: number,
+  currentUsd: number
+): Promise<void> {
+  if (!state.strategy) {
+    state.pendingPhase = null;
+    return;
+  }
+  const version = nextVersion(state);
+  const result = await strategist.revise(state.strategy, state.history.recent(), reason, initialUsd, currentUsd, version);
+  logClaudeCall(state, result, "revise");
+  if (result.ok) {
+    state.strategy = result.strategy;
+    persistStrategy(state, result.strategy);
+    emitStderr(`[claude-llm] strategy v${result.strategy.version} adopted (reason=${reason}, pnl=${currentUsd.toFixed(2)}/${initialUsd.toFixed(2)})\n`);
+  } else {
+    emitStderr(`[claude-llm] revise failed: ${result.reason} — keeping v${state.strategy.version}\n`);
+  }
+  state.pendingPhase = null;
+  state.pending = null;
+  void obs;
+}
+
+function nextVersion(state: State): number {
+  return state.strategy ? state.strategy.version + 1 : 1;
+}
+
+function ensureRunDirs(state: State, obs: AgentObservation): void {
+  if (state.agentDir) return;
+  state.agentDir = join(reportDirRoot(), obs.runId, `agent-${state.agentId}`);
+  if (!existsSync(state.agentDir)) mkdirSync(state.agentDir, { recursive: true });
+  state.decisionsPath = join(state.agentDir, "decisions.jsonl");
+  state.callsPath = join(state.agentDir, "claude-calls.jsonl");
+  writeFileSync(state.decisionsPath, "");
+  writeFileSync(state.callsPath, "");
+}
+
+function persistStrategy(state: State, strategy: Strategy): void {
+  if (!state.agentDir) return;
+  const base = join(state.agentDir, `strategy-v${strategy.version}`);
+  writeFileSync(`${base}.md`, `# Strategy v${strategy.version}\n\n${strategy.notes}\n`);
+  writeFileSync(`${base}.params.json`, `${JSON.stringify(strategy.params, null, 2)}\n`);
+  writeFileSync(`${base}.executor.ts`, `// Body of (obs, params, helpers) => AgentAction\n${strategy.executorTs}\n`);
+}
+
+function appendDecision(state: State, obs: AgentObservation, decision: DecisionResult): void {
+  if (!state.decisionsPath) return;
+  const row = {
+    ts: new Date().toISOString(),
+    round: obs.round,
+    strategyVersion: decision.strategyVersion,
+    actionType: decision.action.type,
+    ok: decision.ok,
+    reason: decision.reason,
+    logs: decision.logs,
+    pendingPhase: state.pendingPhase
+  };
+  appendFileSync(state.decisionsPath, `${JSON.stringify(row)}\n`);
+}
+
+function logClaudeCall(state: State, result: StrategyResult, phase: "init" | "revise"): void {
+  if (!state.callsPath) return;
+  const meta: Partial<ClaudeCallMeta> = result.meta ?? { phase };
+  const row = {
+    ts: new Date().toISOString(),
+    phase,
+    ok: result.ok,
+    reason: result.ok ? undefined : result.reason,
+    strategyVersion: result.ok ? result.strategy.version : undefined,
+    ...meta
+  };
+  appendFileSync(state.callsPath, `${JSON.stringify(row)}\n`);
+}
+
+function emitAction(action: AgentAction): void {
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+}
+
+function emitStderr(text: string): void {
+  process.stderr.write(text);
+}
+
+function msg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function intEnv(name: string, fallback: number): number {
+  const v = process.env[name];
+  if (v === undefined || v === "") return fallback;
+  const n = Number(v);
+  return Number.isInteger(n) ? n : fallback;
+}
+
+function floatEnv(name: string, fallback: number): number {
+  const v = process.env[name];
+  if (v === undefined || v === "") return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}

--- a/src/llm/claudeStrategist.ts
+++ b/src/llm/claudeStrategist.ts
@@ -1,0 +1,146 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { AgentObservation } from "../types.js";
+import type { RoundRecord } from "./history.js";
+import { buildInitMessage, buildReviseMessage, SIM_RULES, SYSTEM_PROMPT, type Phase, type ReviseReason } from "./prompts.js";
+import { parseStrategyFromToolInput, type Strategy, type StrategyParseResult } from "./strategy.js";
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+export type ClaudeCallMeta = {
+  phase: Phase;
+  latencyMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+};
+
+export type StrategyResult =
+  | { ok: true; strategy: Strategy; meta: ClaudeCallMeta }
+  | { ok: false; reason: string; meta?: ClaudeCallMeta };
+
+export interface Strategist {
+  init(obs: AgentObservation, version: number): Promise<StrategyResult>;
+  revise(prev: Strategy, history: RoundRecord[], reason: ReviseReason, initialUsd: number, currentUsd: number, version: number): Promise<StrategyResult>;
+}
+
+const SET_STRATEGY_TOOL = {
+  name: "set_strategy",
+  description: "Define or revise the trading strategy for upcoming rounds.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      notes: {
+        type: "string",
+        description: "Markdown rationale: thesis, edge, risks, what would make you revise."
+      },
+      params: {
+        type: "object",
+        description: "JSON object of numeric/boolean parameters the executor reads at runtime."
+      },
+      executor_ts: {
+        type: "string",
+        description:
+          "TypeScript function body (no signature). Receives (obs, params, helpers) and must return an AgentAction. See SIM_RULES for the contract."
+      }
+    },
+    required: ["notes", "params", "executor_ts"]
+  }
+};
+
+export class ClaudeStrategist implements Strategist {
+  private client: Anthropic;
+  private model: string;
+
+  constructor(opts: { apiKey?: string; model?: string } = {}) {
+    this.client = new Anthropic({ apiKey: opts.apiKey ?? process.env.ANTHROPIC_API_KEY });
+    this.model = opts.model ?? process.env.ERIS_LLM_MODEL ?? DEFAULT_MODEL;
+  }
+
+  async init(obs: AgentObservation, version: number): Promise<StrategyResult> {
+    return this.call("init", buildInitMessage(obs), version);
+  }
+
+  async revise(
+    prev: Strategy,
+    history: RoundRecord[],
+    reason: ReviseReason,
+    initialUsd: number,
+    currentUsd: number,
+    version: number
+  ): Promise<StrategyResult> {
+    return this.call("revise", buildReviseMessage(prev, history, reason, initialUsd, currentUsd), version);
+  }
+
+  private async call(phase: Phase, userMessage: string, version: number): Promise<StrategyResult> {
+    const started = Date.now();
+    let meta: ClaudeCallMeta | undefined;
+    try {
+      const response = await this.client.messages.create({
+        model: this.model,
+        max_tokens: 8192,
+        system: [
+          { type: "text", text: SYSTEM_PROMPT },
+          { type: "text", text: SIM_RULES, cache_control: { type: "ephemeral" } }
+        ],
+        messages: [{ role: "user", content: userMessage }],
+        tools: [SET_STRATEGY_TOOL],
+        tool_choice: { type: "tool", name: "set_strategy" }
+      });
+      const latencyMs = Date.now() - started;
+      const usage = response.usage as {
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      };
+      meta = {
+        phase,
+        latencyMs,
+        inputTokens: usage.input_tokens ?? 0,
+        outputTokens: usage.output_tokens ?? 0,
+        cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+        cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0
+      };
+      const toolBlock = response.content.find((block) => block.type === "tool_use" && block.name === "set_strategy");
+      if (!toolBlock || toolBlock.type !== "tool_use") {
+        return { ok: false, reason: "model did not call set_strategy", meta };
+      }
+      const parsed: StrategyParseResult = parseStrategyFromToolInput(toolBlock.input, version);
+      if (!parsed.ok) return { ok: false, reason: parsed.reason, meta };
+      return { ok: true, strategy: parsed.strategy, meta };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: `claude call failed: ${error instanceof Error ? error.message : String(error)}`,
+        meta
+      };
+    }
+  }
+}
+
+/**
+ * Test/offline strategist. Returns a hard-coded spread-arb strategy.
+ * Activated by ERIS_LLM_MOCK=1.
+ */
+export class MockStrategist implements Strategist {
+  async init(_obs: AgentObservation, version: number): Promise<StrategyResult> {
+    return { ok: true, strategy: defaultMockStrategy(version), meta: mockMeta("init") };
+  }
+  async revise(_prev: Strategy, _h: RoundRecord[], _r: ReviseReason, _i: number, _c: number, version: number): Promise<StrategyResult> {
+    return { ok: true, strategy: defaultMockStrategy(version), meta: mockMeta("revise") };
+  }
+}
+
+function mockMeta(phase: Phase): ClaudeCallMeta {
+  return { phase, latencyMs: 0, inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 };
+}
+
+function defaultMockStrategy(version: number): Strategy {
+  return {
+    version,
+    notes: "Mock strategy: noop always. Replace with real ANTHROPIC_API_KEY.",
+    params: { minGapBps: 15 },
+    executorTs: `return { type: "noop", reason: "mock strategy v${version}" };`
+  };
+}

--- a/src/llm/claudeSubscriptionStrategist.ts
+++ b/src/llm/claudeSubscriptionStrategist.ts
@@ -1,0 +1,178 @@
+import { createSdkMcpServer, query, tool, type Options } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { AgentObservation } from "../types.js";
+import type { RoundRecord } from "./history.js";
+import {
+  buildInitMessage,
+  buildReviseMessage,
+  SIM_RULES,
+  SYSTEM_PROMPT,
+  type Phase,
+  type ReviseReason
+} from "./prompts.js";
+import { parseStrategyFromToolInput, type Strategy } from "./strategy.js";
+import type { ClaudeCallMeta, Strategist, StrategyResult } from "./claudeStrategist.js";
+
+const DEFAULT_MODEL = "sonnet"; // alias → claude-sonnet-4-6
+
+/**
+ * The set of built-in Claude Code tools we don't want the model to use during
+ * a strategy call. The model is supposed to only call our MCP set_strategy tool.
+ */
+const DISALLOWED_TOOLS = [
+  "Bash",
+  "Edit",
+  "Read",
+  "Write",
+  "Glob",
+  "Grep",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+  "SlashCommand",
+  "TodoWrite",
+  "BashOutput",
+  "KillShell",
+  "NotebookEdit"
+];
+
+/**
+ * Slim version of the SDK surface we depend on. Tests substitute a fake that
+ * captures the tool handler and returns scripted SDK messages.
+ */
+export type SdkLike = {
+  query: typeof query;
+  tool: typeof tool;
+  createSdkMcpServer: typeof createSdkMcpServer;
+};
+
+const REAL_SDK: SdkLike = { query, tool, createSdkMcpServer };
+
+/**
+ * Strategist that authenticates via the user's Claude Code OAuth/Keychain
+ * credentials (Pro/Max subscription). No ANTHROPIC_API_KEY required.
+ *
+ * Internally the SDK spawns the `claude` binary as a subprocess; cold start is
+ * ~1s on top of API latency. Per-call subprocess is fine for our cadence
+ * (~13 calls per 128-round run).
+ */
+export class ClaudeSubscriptionStrategist implements Strategist {
+  private model: string;
+  private sdk: SdkLike;
+
+  constructor(opts: { model?: string; sdk?: SdkLike } = {}) {
+    this.model = opts.model ?? process.env.ERIS_LLM_MODEL ?? DEFAULT_MODEL;
+    this.sdk = opts.sdk ?? REAL_SDK;
+  }
+
+  async init(obs: AgentObservation, version: number): Promise<StrategyResult> {
+    return this.call("init", buildInitMessage(obs), version);
+  }
+
+  async revise(
+    prev: Strategy,
+    history: RoundRecord[],
+    reason: ReviseReason,
+    initialUsd: number,
+    currentUsd: number,
+    version: number
+  ): Promise<StrategyResult> {
+    return this.call("revise", buildReviseMessage(prev, history, reason, initialUsd, currentUsd), version);
+  }
+
+  private async call(phase: Phase, userMessage: string, version: number): Promise<StrategyResult> {
+    const started = Date.now();
+    let captured: unknown;
+    let meta: ClaudeCallMeta | undefined;
+
+    const strategyServer = this.sdk.createSdkMcpServer({
+      name: "strategy",
+      alwaysLoad: true,
+      tools: [
+        this.sdk.tool(
+          "set_strategy",
+          "Define or revise the trading strategy for upcoming rounds.",
+          {
+            notes: z.string().describe("Markdown rationale: thesis, edge, risks, what would make you revise."),
+            params: z.record(z.string(), z.any()).describe("JSON object of numeric/boolean parameters the executor reads."),
+            executor_ts: z
+              .string()
+              .describe(
+                "TypeScript function body (no signature). Receives (obs, params, helpers) and must return an AgentAction."
+              )
+          },
+          async (args) => {
+            captured = args;
+            return { content: [{ type: "text", text: "ok" }] };
+          }
+        )
+      ]
+    });
+
+    const options: Options = {
+      model: this.model,
+      systemPrompt: `${SYSTEM_PROMPT}\n\n${SIM_RULES}`,
+      mcpServers: { strategy: strategyServer },
+      allowedTools: ["mcp__strategy__set_strategy"],
+      disallowedTools: DISALLOWED_TOOLS,
+      permissionMode: "bypassPermissions",
+      maxTurns: 2
+    };
+
+    try {
+      for await (const msg of this.sdk.query({ prompt: userMessage, options })) {
+        if (msg.type === "result") {
+          meta = readUsage(phase, started, msg);
+          if (msg.subtype !== "success") {
+            return { ok: false, reason: `claude returned ${msg.subtype}`, meta };
+          }
+        }
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        reason: `claude call failed: ${error instanceof Error ? error.message : String(error)}`,
+        meta
+      };
+    }
+
+    if (!captured) return { ok: false, reason: "model did not call set_strategy", meta };
+    const parsed = parseStrategyFromToolInput(captured, version);
+    if (!parsed.ok) return { ok: false, reason: parsed.reason, meta };
+    return { ok: true, strategy: parsed.strategy, meta: meta ?? zeroMeta(phase, started) };
+  }
+}
+
+function zeroMeta(phase: Phase, started: number): ClaudeCallMeta {
+  return {
+    phase,
+    latencyMs: Date.now() - started,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0
+  };
+}
+
+type ResultLike = {
+  type: "result";
+  duration_ms?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+};
+
+function readUsage(phase: Phase, started: number, msg: ResultLike): ClaudeCallMeta {
+  const usage = msg.usage ?? {};
+  return {
+    phase,
+    latencyMs: msg.duration_ms ?? Date.now() - started,
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+    cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0
+  };
+}

--- a/src/llm/claudeSubscriptionStrategist.ts
+++ b/src/llm/claudeSubscriptionStrategist.ts
@@ -109,6 +109,11 @@ export class ClaudeSubscriptionStrategist implements Strategist {
       ]
     });
 
+    const cleanEnv: Record<string, string | undefined> = { ...process.env };
+    for (const key of Object.keys(cleanEnv)) {
+      if (key.startsWith("CLAUDE_CODE_")) delete cleanEnv[key];
+    }
+
     const options: Options = {
       model: this.model,
       systemPrompt: `${SYSTEM_PROMPT}\n\n${SIM_RULES}`,
@@ -116,7 +121,14 @@ export class ClaudeSubscriptionStrategist implements Strategist {
       allowedTools: ["mcp__strategy__set_strategy"],
       disallowedTools: DISALLOWED_TOOLS,
       permissionMode: "bypassPermissions",
-      maxTurns: 2
+      maxTurns: 2,
+      env: cleanEnv,
+      // Isolation mode — do not inherit user/project skills, plugins, MCP
+      // servers, hooks, or settings.json. The agent only needs OAuth credentials
+      // from disk; loading 70+ user skills per call adds seconds and pollutes
+      // the system prompt context budget.
+      settingSources: [],
+      ...(process.env.ERIS_CLAUDE_BIN ? { pathToClaudeCodeExecutable: process.env.ERIS_CLAUDE_BIN } : {})
     };
 
     try {

--- a/src/llm/history.ts
+++ b/src/llm/history.ts
@@ -1,0 +1,96 @@
+import type { AgentAction, AgentObservation } from "../types.js";
+
+export type RoundRecord = {
+  round: number;
+  poolPrice: number;
+  fairPrice: number;
+  inventoryUsd: number;
+  weth: number;
+  usdc: number;
+  eth: number;
+  openPositions: number;
+  action: { type: string; summary?: string };
+  executorLogs: string[];
+  executorOk: boolean;
+  executorReason?: string;
+};
+
+/**
+ * Ring buffer of the last N round records. Used to give Claude context
+ * during revision without blowing up the prompt size.
+ */
+export class History {
+  private buf: RoundRecord[] = [];
+  private initialUsd: number | null = null;
+
+  constructor(readonly capacity = 30) {}
+
+  setInitialUsd(usd: number): void {
+    if (this.initialUsd === null) this.initialUsd = usd;
+  }
+
+  getInitialUsd(): number | null {
+    return this.initialUsd;
+  }
+
+  push(record: RoundRecord): void {
+    this.buf.push(record);
+    if (this.buf.length > this.capacity) this.buf.shift();
+  }
+
+  recent(): RoundRecord[] {
+    return [...this.buf];
+  }
+
+  latest(): RoundRecord | null {
+    return this.buf.length === 0 ? null : this.buf[this.buf.length - 1];
+  }
+
+  size(): number {
+    return this.buf.length;
+  }
+}
+
+/**
+ * Summarize an AgentAction down to a small, prompt-friendly string.
+ * Keeps token usage low while preserving the decision shape.
+ */
+export function summarizeAction(action: AgentAction): { type: string; summary?: string } {
+  if (action.type === "noop") return { type: "noop", summary: action.reason };
+  if (action.type === "swap") return { type: "swap", summary: `${action.tokenIn} in=${action.amountIn}` };
+  if (action.type === "mintLiquidity") {
+    return { type: "mintLiquidity", summary: `ticks=[${action.tickLower},${action.tickUpper}] weth=${action.amountWethDesired} usdc=${action.amountUsdcDesired}` };
+  }
+  if (action.type === "removeLiquidity") return { type: "removeLiquidity", summary: `id=${action.tokenId} liq=${action.liquidity}` };
+  if (action.type === "collectFees") return { type: "collectFees", summary: `id=${action.tokenId}` };
+  if (action.type === "bundle") return { type: "bundle", summary: `${action.actions.length} actions` };
+  if (action.type === "rawTx") return { type: "rawTx", summary: `to=${action.tx.to}` };
+  if (action.type === "rawBundle") return { type: "rawBundle", summary: `${action.txs.length} txs` };
+  return { type: "unknown" };
+}
+
+/**
+ * Build a RoundRecord from this round's observation + the action we are about to emit.
+ */
+export function buildRoundRecord(
+  obs: AgentObservation,
+  action: AgentAction,
+  executorOk: boolean,
+  executorReason: string | undefined,
+  executorLogs: string[]
+): RoundRecord {
+  return {
+    round: obs.round,
+    poolPrice: obs.pool.priceUsdcPerWeth,
+    fairPrice: obs.fairPriceUsdcPerWeth,
+    inventoryUsd: obs.inventory.valueUsdc,
+    weth: obs.inventory.weth,
+    usdc: obs.inventory.usdc,
+    eth: obs.inventory.eth,
+    openPositions: obs.positions.length,
+    action: summarizeAction(action),
+    executorLogs,
+    executorOk,
+    executorReason
+  };
+}

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -1,0 +1,192 @@
+import type { AgentObservation } from "../types.js";
+import type { RoundRecord } from "./history.js";
+import type { Strategy } from "./strategy.js";
+
+export const SYSTEM_PROMPT = `You are an autonomous trading agent strategist for a Uniswap V3 (WETH/USDC 0.05% fee) simulation on a forked Ethereum L1.
+
+Your job has two phases:
+
+1. INITIAL STRATEGY: When given the rules and the first observation, design a strategy from scratch. Output (via the set_strategy tool):
+   - notes: markdown describing your thesis, what edge you are trying to exploit, the risks, and what would make you revise.
+   - params: a JSON object of numeric parameters your executor reads (thresholds, tick widths, fractions). Keep keys descriptive.
+   - executor_ts: a TypeScript function BODY (no signature, no enclosing braces) that takes (obs, params, helpers) and returns an AgentAction. This runs every round in a sandbox with a 200ms timeout.
+
+2. REVISION: When given the previous strategy plus the last N round records and a reason ("scheduled" or "pnl_drop"), produce a new strategy version. You may keep the executor the same and only tune params, or rewrite the executor entirely. Explain in notes what you changed and why.
+
+Be opinionated. Start simple. Iterate.`;
+
+export const SIM_RULES = `# Simulation Rules
+
+## Round loop
+Each round you receive an AgentObservation and must return an AgentAction. Your executor is called synchronously by the agent process; the LLM is only consulted for strategy creation and revision (not every round).
+
+## AgentObservation (input to your executor as 'obs')
+\`\`\`ts
+type AgentObservation = {
+  kind: "observation";
+  runId: string;
+  round: number;
+  blockNumber: string;
+  agentAddress: string;
+  pool: { pair: "WETH/USDC"; fee: 500; priceUsdcPerWeth: number; tick: number; tickSpacing: number };
+  positions: Array<{ tokenId: string; tickLower: number; tickUpper: number; liquidity: string;
+                    tokensOwedWethWei: string; tokensOwedUsdcUnits: string;
+                    amountWethWei: string; amountUsdcUnits: string; valueUsdc: number }>;
+  fairPriceUsdcPerWeth: number;
+  balances: { ethWei: string; wethWei: string; usdcUnits: string };  // decimal integer strings
+  inventory: { valueUsdc: number; weth: number; usdc: number; eth: number };
+  history: Array<{ round: number; poolPriceUsdcPerWeth: number; fairPriceUsdcPerWeth: number }>; // last 20
+  limits: {
+    maxWethInWei: string; maxUsdcInUnits: string;
+    defaultPriorityFeePerGasWei: string; maxPriorityFeePerGasWei: string;
+    defaultSlippageBps: number;
+    maxBundleActions: number;
+    maxLpWethWei: string; maxLpUsdcUnits: string;
+    maxOpenPositions: number;
+  };
+};
+\`\`\`
+
+## AgentAction (what your executor must return)
+\`\`\`ts
+type AgentAction =
+  | { type: "noop"; reason?: string }
+  | { type: "swap"; tokenIn: "WETH"|"USDC"; amountIn: string;            // decimal integer string in token base units
+      slippageBps?: number; maxPriorityFeePerGasWei?: string }
+  | { type: "mintLiquidity"; tickLower: number; tickUpper: number;       // both multiples of pool.tickSpacing (10)
+      amountWethDesired: string; amountUsdcDesired: string;
+      slippageBps?: number; maxPriorityFeePerGasWei?: string }
+  | { type: "removeLiquidity"; tokenId: string; liquidity: string;
+      amountWethMin?: string; amountUsdcMin?: string;
+      maxPriorityFeePerGasWei?: string }
+  | { type: "collectFees"; tokenId: string; maxPriorityFeePerGasWei?: string }
+  | { type: "bundle"; actions: Array<SwapAction|MintLiquidityAction|RemoveLiquidityAction|CollectFeesAction>;
+      maxPriorityFeePerGasWei?: string }
+  | { type: "rawTx"; tx: { to: \`0x\${string}\`; data: \`0x\${string}\`; value?: string };
+      maxPriorityFeePerGasWei?: string }
+  | { type: "rawBundle"; txs: Array<{ to,data,value? }>; maxPriorityFeePerGasWei?: string };
+\`\`\`
+
+## Validator constraints (return noop if violated; otherwise the round is wasted)
+- swap.amountIn must be > 0, <= limits.max{Weth|Usdc}In{Wei|Units}, AND <= current balance
+- mintLiquidity ticks must be multiples of obs.pool.tickSpacing (10) and tickLower < tickUpper
+- mintLiquidity desired amounts <= obs.limits.maxLp{...} AND <= current balance
+- bundle.actions.length <= obs.limits.maxBundleActions (typically 5)
+- priorityFee <= obs.limits.maxPriorityFeePerGasWei
+- removeLiquidity.tokenId must exist in obs.positions
+
+## Helpers (passed as third arg)
+\`\`\`ts
+helpers.parseUnits(decimal: string, decimals: number): bigint
+helpers.formatUnits(wei: bigint, decimals: number): string
+helpers.encodeFunctionData({ abi, functionName, args }): \`0x\${string}\`     // viem
+helpers.ADDRESSES: {
+  USDC: "0xA0b...EB48",                       // 6 decimals
+  WETH: "0xC02...56Cc2",                      // 18 decimals
+  UNIV3_POOL_500: "0x88e...3f5640",
+  SWAP_ROUTER: "0xE592...61564",              // ISwapRouter (Uniswap V3)
+  QUOTER_V2: "0x61fF...30B21e",
+  NFT_POSITION_MANAGER: "0xC36...11FE88",
+  AAVE_POOL: "0x8787...fA4E2"                 // Aave V3
+};
+helpers.log(msg: string): void                // logged to decisions.jsonl
+\`\`\`
+
+## Executor body rules
+- The body runs as: \`((obs, params, helpers) => { <YOUR BODY> })(obs, params, helpers)\`
+- Body MUST end with \`return <AgentAction>\`.
+- Allowed: arithmetic, BigInt, helpers.*, params.*, obs.*, Math, JSON.
+- NOT allowed: require, import, fetch, process, fs, setTimeout, network calls. The vm context exposes nothing else.
+- Soft timeout: 200ms. Keep logic O(positions) at worst.
+- If you want to call an arbitrary contract (e.g. Aave supply/withdraw, exactInputSingle), return a rawTx or rawBundle and the coordinator submits it from the agent wallet.
+
+## Tokens
+- WETH: 18 decimals; balances.wethWei is the decimal integer string for wei.
+- USDC: 6 decimals; balances.usdcUnits is the decimal integer string for base units.
+- Price obs.pool.priceUsdcPerWeth is a float in USDC-per-WETH (no decimals).
+
+## Strategy ideas (non-exhaustive — invent your own)
+- Spread arbitrage: when |fair/pool - 1| > threshold, swap into the underpriced side proportionally to the gap.
+- Concentrated LP: mint a tight range around the current tick when realized volatility is low; remove when price exits range.
+- Aave park: idle USDC supplied to Aave to earn yield while waiting for arb signals. Withdraw before swap.
+- Inventory rebalance: keep WETH:USDC value ratio near a target.
+
+## What a good executor looks like
+\`\`\`ts
+// Body of (obs, params, helpers) => AgentAction
+const gap = obs.fairPriceUsdcPerWeth / obs.pool.priceUsdcPerWeth - 1;
+if (Math.abs(gap) < params.minGapBps / 10000) {
+  return { type: "noop", reason: "gap below threshold" };
+}
+const tokenIn = gap > 0 ? "USDC" : "WETH";
+const maxLimit = BigInt(tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+const balance = BigInt(tokenIn === "WETH" ? obs.balances.wethWei : obs.balances.usdcUnits);
+const cap = balance < maxLimit ? balance : maxLimit;
+const sizeBps = Math.min(params.maxSizeBps, Math.floor(Math.abs(gap) * params.sizeGain));
+const amountIn = (cap * BigInt(sizeBps)) / 10000n;
+if (amountIn <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log(\`gap=\${gap.toFixed(4)} sizeBps=\${sizeBps}\`);
+return { type: "swap", tokenIn, amountIn: amountIn.toString(), slippageBps: params.slippageBps };
+\`\`\`
+`;
+
+export type Phase = "init" | "revise";
+
+export type ReviseReason = "scheduled" | "pnl_drop";
+
+export function buildInitMessage(obs: AgentObservation): string {
+  return `# Initial strategy request
+
+You are starting a fresh run. Design your strategy from scratch.
+
+## Current observation (round ${obs.round})
+- Pool price: ${obs.pool.priceUsdcPerWeth.toFixed(2)} USDC/WETH (tick=${obs.pool.tick}, spacing=${obs.pool.tickSpacing})
+- Fair price: ${obs.fairPriceUsdcPerWeth.toFixed(2)} USDC/WETH (gap=${((obs.fairPriceUsdcPerWeth / obs.pool.priceUsdcPerWeth - 1) * 100).toFixed(3)}%)
+- Inventory: ${obs.inventory.valueUsdc.toFixed(2)} USDC total (WETH=${obs.inventory.weth.toFixed(4)}, USDC=${obs.inventory.usdc.toFixed(2)}, ETH=${obs.inventory.eth.toFixed(4)})
+- Limits: maxSwapIn WETH=${obs.limits.maxWethInWei}wei, USDC=${obs.limits.maxUsdcInUnits}units; bundle<=${obs.limits.maxBundleActions}; positions<=${obs.limits.maxOpenPositions}
+
+## Your task
+Call set_strategy with notes + params + executor_ts. Pick a strategy you can iterate on as evidence accumulates.`;
+}
+
+export function buildReviseMessage(
+  prev: Strategy,
+  history: RoundRecord[],
+  reason: ReviseReason,
+  initialUsd: number,
+  currentUsd: number
+): string {
+  const pnlPct = ((currentUsd - initialUsd) / initialUsd) * 100;
+  const recent = history.slice(-12);
+  const lines = recent.map(
+    (r) =>
+      `  r${r.round}: pool=${r.poolPrice.toFixed(2)} fair=${r.fairPrice.toFixed(2)} usd=${r.inventoryUsd.toFixed(2)} action=${r.action.type}${r.action.summary ? ` (${r.action.summary})` : ""}${r.executorOk ? "" : ` [ERR: ${r.executorReason ?? ""}]`}`
+  );
+  return `# Strategy revision request
+
+Reason: **${reason}**
+PnL since start: ${pnlPct.toFixed(2)}% (initial=${initialUsd.toFixed(2)} → current=${currentUsd.toFixed(2)} USDC)
+
+## Previous strategy (v${prev.version})
+### notes
+${prev.notes}
+
+### params
+\`\`\`json
+${JSON.stringify(prev.params, null, 2)}
+\`\`\`
+
+### executor_ts
+\`\`\`ts
+${prev.executorTs}
+\`\`\`
+
+## Recent ${recent.length} rounds
+${lines.join("\n")}
+
+## Your task
+Call set_strategy with an updated version. You can:
+- Keep executor the same and only tune params.
+- Rewrite executor entirely if the thesis was wrong.
+Briefly explain in notes what changed vs v${prev.version} and why.`;
+}

--- a/src/llm/strategy.ts
+++ b/src/llm/strategy.ts
@@ -1,0 +1,146 @@
+import { Script, createContext } from "node:vm";
+import { encodeFunctionData, parseUnits, formatUnits } from "viem";
+import type { AgentAction, AgentObservation } from "../types.js";
+import { parseAction } from "../action.js";
+
+export type Strategy = {
+  version: number;
+  notes: string;
+  params: Record<string, unknown>;
+  executorTs: string;
+};
+
+export type ExecutorHelpers = {
+  parseUnits: typeof parseUnits;
+  formatUnits: typeof formatUnits;
+  encodeFunctionData: typeof encodeFunctionData;
+  ADDRESSES: {
+    USDC: `0x${string}`;
+    WETH: `0x${string}`;
+    UNIV3_POOL_500: `0x${string}`;
+    SWAP_ROUTER: `0x${string}`;
+    QUOTER_V2: `0x${string}`;
+    NFT_POSITION_MANAGER: `0x${string}`;
+    AAVE_POOL: `0x${string}`;
+  };
+  log: (msg: string) => void;
+};
+
+export const DEFAULT_ADDRESSES: ExecutorHelpers["ADDRESSES"] = {
+  USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+  UNIV3_POOL_500: "0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640",
+  SWAP_ROUTER: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+  QUOTER_V2: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+  NFT_POSITION_MANAGER: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+  AAVE_POOL: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+};
+
+export type StrategyParseError = { ok: false; reason: string };
+export type StrategyParseOk = { ok: true; strategy: Strategy };
+export type StrategyParseResult = StrategyParseOk | StrategyParseError;
+
+/**
+ * Validate a Claude tool-use payload against the Strategy schema.
+ * - notes: non-empty string
+ * - params: object (JSON-serializable)
+ * - executor_ts: string, must parse as a function body without syntax errors
+ */
+export function parseStrategyFromToolInput(input: unknown, version: number): StrategyParseResult {
+  if (!input || typeof input !== "object") return { ok: false, reason: "tool input must be an object" };
+  const obj = input as Record<string, unknown>;
+  if (typeof obj.notes !== "string" || obj.notes.trim() === "") return { ok: false, reason: "notes must be a non-empty string" };
+  if (!obj.params || typeof obj.params !== "object" || Array.isArray(obj.params)) {
+    return { ok: false, reason: "params must be a plain object" };
+  }
+  if (typeof obj.executor_ts !== "string" || obj.executor_ts.trim() === "") {
+    return { ok: false, reason: "executor_ts must be a non-empty string" };
+  }
+  const syntaxCheck = checkExecutorSyntax(obj.executor_ts);
+  if (!syntaxCheck.ok) return syntaxCheck;
+  // params must be JSON-serializable
+  try {
+    JSON.parse(JSON.stringify(obj.params));
+  } catch {
+    return { ok: false, reason: "params must be JSON-serializable" };
+  }
+  return {
+    ok: true,
+    strategy: {
+      version,
+      notes: obj.notes,
+      params: obj.params as Record<string, unknown>,
+      executorTs: obj.executor_ts
+    }
+  };
+}
+
+/**
+ * Verify the executor source compiles. We wrap it in a function and try to construct it.
+ * `new Function` throws on syntax errors but does not execute the body.
+ */
+export function checkExecutorSyntax(source: string): { ok: true } | StrategyParseError {
+  try {
+    // Wrap exactly the way runExecutor wraps it so the parser sees the same shape.
+    new Function("obs", "params", "helpers", source);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: `executor_ts syntax error: ${errorMessage(error)}` };
+  }
+}
+
+export type ExecutorRunOk = { ok: true; action: AgentAction; logs: string[] };
+export type ExecutorRunError = { ok: false; reason: string; logs: string[] };
+export type ExecutorRunResult = ExecutorRunOk | ExecutorRunError;
+
+/**
+ * Evaluate strategy.executorTs in a sandboxed vm context.
+ * - timeout: hard cap on execution time (ms)
+ * - The wrapped expression must assign its result to __result.
+ * - We pre-validate via parseAction so executor bugs are caught locally before stdout.
+ */
+export function runExecutor(
+  strategy: Strategy,
+  obs: AgentObservation,
+  helpersBase: Omit<ExecutorHelpers, "log">,
+  timeoutMs = 200
+): ExecutorRunResult {
+  const logs: string[] = [];
+  const helpers: ExecutorHelpers = {
+    ...helpersBase,
+    log: (msg: string) => {
+      if (typeof msg === "string" && logs.length < 32) logs.push(msg.slice(0, 500));
+    }
+  };
+  const ctx = createContext({
+    obs,
+    params: strategy.params,
+    helpers,
+    __result: undefined,
+    console: { log: helpers.log }
+  });
+  const wrapped = `__result = ((obs, params, helpers) => { ${strategy.executorTs} })(obs, params, helpers);`;
+  try {
+    new Script(wrapped, { filename: `strategy-v${strategy.version}.executor.js` }).runInContext(ctx, {
+      timeout: timeoutMs,
+      displayErrors: true
+    });
+  } catch (error) {
+    return { ok: false, reason: `executor threw: ${errorMessage(error)}`, logs };
+  }
+  if ((ctx as { __result: unknown }).__result === undefined) {
+    return { ok: false, reason: "executor returned undefined (must return AgentAction)", logs };
+  }
+  let action: AgentAction;
+  try {
+    action = parseAction((ctx as { __result: unknown }).__result);
+  } catch (error) {
+    return { ok: false, reason: `invalid AgentAction: ${errorMessage(error)}`, logs };
+  }
+  return { ok: true, action, logs };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/test/llm-agent.test.ts
+++ b/test/llm-agent.test.ts
@@ -1,0 +1,227 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createState,
+  handleLine,
+  whichReviseReason
+} from "../src/llm/claudeAgent.js";
+import type { Strategist, StrategyResult } from "../src/llm/claudeStrategist.js";
+import type { Strategy } from "../src/llm/strategy.js";
+import type { AgentObservation } from "../src/types.js";
+import type { ReviseReason } from "../src/llm/prompts.js";
+import type { RoundRecord } from "../src/llm/history.js";
+
+function makeObs(round: number, valueUsdc = 100, runId = `test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`): AgentObservation {
+  return {
+    kind: "observation",
+    runId,
+    round,
+    blockNumber: String(round + 1),
+    agentAddress: "0x0000000000000000000000000000000000000001",
+    pool: { pair: "WETH/USDC", fee: 500, priceUsdcPerWeth: 3000, tick: 0, tickSpacing: 10 },
+    positions: [],
+    fairPriceUsdcPerWeth: 3030,
+    balances: { ethWei: "1000000000000000000", wethWei: "10000000000000000000", usdcUnits: "25000000000" },
+    inventory: { valueUsdc, weth: 10, usdc: 25000, eth: 1 },
+    history: [],
+    limits: {
+      maxWethInWei: "1000000000000000000",
+      maxUsdcInUnits: "5000000000",
+      defaultPriorityFeePerGasWei: "100000000",
+      maxPriorityFeePerGasWei: "5000000000",
+      defaultSlippageBps: 50,
+      maxBundleActions: 5,
+      maxLpWethWei: "1000000000000000000",
+      maxLpUsdcUnits: "5000000000",
+      maxOpenPositions: 10
+    }
+  };
+}
+
+/**
+ * Strategist stub that can either resolve immediately or defer until the test
+ * calls .release(). Deferral lets the test observe state.pendingPhase mid-flight.
+ */
+class StubStrategist implements Strategist {
+  initCount = 0;
+  reviseCount = 0;
+  lastReviseReason: ReviseReason | null = null;
+  fail = false;
+  defer = false;
+  private queue: Array<{ resolve: (r: StrategyResult) => void; phase: "init" | "revise"; version: number; reason?: ReviseReason }> = [];
+  constructor(private executorTs = `return { type: "noop", reason: "stub v" + params.v };`) {}
+
+  init(_obs: AgentObservation, version: number): Promise<StrategyResult> {
+    this.initCount++;
+    return this.build("init", version);
+  }
+  revise(_p: Strategy, _h: RoundRecord[], reason: ReviseReason, _i: number, _c: number, version: number): Promise<StrategyResult> {
+    this.reviseCount++;
+    this.lastReviseReason = reason;
+    return this.build("revise", version, reason);
+  }
+  private build(phase: "init" | "revise", version: number, reason?: ReviseReason): Promise<StrategyResult> {
+    const make = (): StrategyResult => this.fail
+      ? { ok: false, reason: "stub failure" }
+      : {
+          ok: true,
+          strategy: { version, notes: `stub ${phase}${reason ? ` (${reason})` : ""}`, params: { v: version }, executorTs: this.executorTs },
+          meta: { phase, latencyMs: 0, inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 }
+        };
+    if (!this.defer) return Promise.resolve(make());
+    return new Promise<StrategyResult>((resolve) => {
+      this.queue.push({ resolve: () => resolve(make()), phase, version, reason });
+    });
+  }
+  release(): void {
+    const items = this.queue;
+    this.queue = [];
+    for (const item of items) item.resolve(undefined as unknown as StrategyResult);
+  }
+}
+
+function withTmpReportDir<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.REPORT_DIR;
+  const dir = mkdtempSync(join(tmpdir(), "eris-llm-test-"));
+  process.env.REPORT_DIR = dir;
+  return fn().finally(() => {
+    if (prev === undefined) delete process.env.REPORT_DIR;
+    else process.env.REPORT_DIR = prev;
+  });
+}
+
+test("first observation returns noop and init runs in the background", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist();
+    strategist.defer = true;
+    const action = await handleLine(JSON.stringify(makeObs(0)), state, strategist);
+    assert.equal(action.type, "noop");
+    if (action.type === "noop") assert.match(action.reason ?? "", /strategy init pending/);
+    // While deferred, pendingPhase is still "init" and strategy is unset.
+    assert.equal(state.pendingPhase, "init");
+    assert.equal(state.strategy === null, true);
+    strategist.release();
+    await state.pending;
+    assert.equal(state.strategy?.version, 1);
+    assert.equal(state.pendingPhase, null);
+  });
+});
+
+test("after init, executor produces real actions on subsequent rounds", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist(`return { type: "swap", tokenIn: "WETH", amountIn: "1000000000" };`);
+    await handleLine(JSON.stringify(makeObs(0)), state, strategist);
+    await state.pending;
+    const action = await handleLine(JSON.stringify(makeObs(1)), state, strategist);
+    assert.equal(action.type, "swap");
+  });
+});
+
+test("strategy revision fires on the scheduled round and bumps version", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist();
+    await handleLine(JSON.stringify(makeObs(0)), state, strategist);
+    await state.pending;
+    assert.equal(state.strategy?.version, 1);
+
+    strategist.defer = true;
+    await handleLine(JSON.stringify(makeObs(10)), state, strategist);
+    assert.equal(state.pendingPhase, "revise");
+    strategist.release();
+    await state.pending;
+    assert.equal(state.strategy?.version, 2);
+    assert.equal(strategist.lastReviseReason, "scheduled");
+  });
+});
+
+test("strategy revision fires on PnL drop", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist();
+    await handleLine(JSON.stringify(makeObs(0, 100)), state, strategist);
+    await state.pending;
+    strategist.defer = true;
+    await handleLine(JSON.stringify(makeObs(3, 90)), state, strategist);
+    assert.equal(state.pendingPhase, "revise");
+    strategist.release();
+    await state.pending;
+    assert.equal(strategist.lastReviseReason, "pnl_drop");
+    assert.equal(state.strategy?.version, 2);
+  });
+});
+
+test("failed init leaves no strategy and retries on next round", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist();
+    strategist.fail = true;
+    await handleLine(JSON.stringify(makeObs(0)), state, strategist);
+    await state.pending;
+    assert.equal(state.strategy, null);
+    assert.equal(state.pendingPhase, null);
+    assert.equal(strategist.initCount, 1);
+
+    await handleLine(JSON.stringify(makeObs(1)), state, strategist);
+    await state.pending;
+    assert.equal(strategist.initCount, 2, "second round retries init");
+  });
+});
+
+test("failed revise keeps the previous strategy", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("test-agent");
+    const strategist = new StubStrategist();
+    await handleLine(JSON.stringify(makeObs(0)), state, strategist);
+    await state.pending;
+    assert.equal(state.strategy?.version, 1);
+    strategist.fail = true;
+    await handleLine(JSON.stringify(makeObs(10)), state, strategist);
+    await state.pending;
+    assert.equal(state.strategy?.version, 1, "old strategy retained when revise fails");
+    assert.equal(strategist.reviseCount, 1);
+  });
+});
+
+test("strategy + decisions + claude-calls files land under REPORT_DIR/runId/agent-<id>", async () => {
+  await withTmpReportDir(async () => {
+    const state = createState("persist-agent");
+    const strategist = new StubStrategist();
+    const obs = makeObs(0);
+    await handleLine(JSON.stringify(obs), state, strategist);
+    await state.pending;
+    const dir = join(process.env.REPORT_DIR!, obs.runId, "agent-persist-agent");
+    assert.ok(existsSync(dir), `expected dir ${dir}`);
+    const files = readdirSync(dir);
+    assert.ok(files.includes("strategy-v1.md"));
+    assert.ok(files.includes("strategy-v1.params.json"));
+    assert.ok(files.includes("strategy-v1.executor.ts"));
+    assert.ok(files.includes("decisions.jsonl"));
+    assert.ok(files.includes("claude-calls.jsonl"));
+    const md = readFileSync(join(dir, "strategy-v1.md"), "utf8");
+    assert.match(md, /Strategy v1/);
+    const calls = readFileSync(join(dir, "claude-calls.jsonl"), "utf8").trim().split("\n");
+    assert.equal(calls.length, 1);
+    const callRow = JSON.parse(calls[0]);
+    assert.equal(callRow.phase, "init");
+    assert.equal(callRow.ok, true);
+    assert.equal(callRow.strategyVersion, 1);
+  });
+});
+
+test("whichReviseReason cadence and drawdown logic", () => {
+  // Cadence: round % 10 == 0 and round > 0
+  assert.equal(whichReviseReason(0, -1, 100, 100), null);
+  assert.equal(whichReviseReason(10, -1, 100, 100), "scheduled");
+  assert.equal(whichReviseReason(10, 10, 100, 100), null, "no double-fire on the same round");
+  // Drawdown -5%
+  assert.equal(whichReviseReason(3, -1, 95, 100), null, "boundary: -5% exactly is not triggered");
+  assert.equal(whichReviseReason(3, -1, 94.9, 100), "pnl_drop");
+  // Initial 0 → never trigger drawdown
+  assert.equal(whichReviseReason(3, -1, -10, 0), null);
+});

--- a/test/llm-history.test.ts
+++ b/test/llm-history.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { History, summarizeAction, buildRoundRecord } from "../src/llm/history.js";
+import type { AgentAction, AgentObservation } from "../src/types.js";
+
+const baseObs: AgentObservation = {
+  kind: "observation",
+  runId: "r",
+  round: 0,
+  blockNumber: "1",
+  agentAddress: "0x0000000000000000000000000000000000000001",
+  pool: { pair: "WETH/USDC", fee: 500, priceUsdcPerWeth: 3000, tick: 0, tickSpacing: 10 },
+  positions: [],
+  fairPriceUsdcPerWeth: 3000,
+  balances: { ethWei: "0", wethWei: "0", usdcUnits: "0" },
+  inventory: { valueUsdc: 100, weth: 0, usdc: 0, eth: 0 },
+  history: [],
+  limits: {
+    maxWethInWei: "0", maxUsdcInUnits: "0",
+    defaultPriorityFeePerGasWei: "0", maxPriorityFeePerGasWei: "0",
+    defaultSlippageBps: 0, maxBundleActions: 5,
+    maxLpWethWei: "0", maxLpUsdcUnits: "0", maxOpenPositions: 0
+  }
+};
+
+test("History keeps initial USD once set", () => {
+  const h = new History(5);
+  h.setInitialUsd(100);
+  h.setInitialUsd(200); // ignored
+  assert.equal(h.getInitialUsd(), 100);
+});
+
+test("History ring buffer caps at capacity", () => {
+  const h = new History(3);
+  for (let i = 0; i < 5; i++) {
+    h.push(buildRoundRecord({ ...baseObs, round: i }, { type: "noop" }, true, undefined, []));
+  }
+  const recent = h.recent();
+  assert.equal(recent.length, 3);
+  assert.deepEqual(recent.map((r) => r.round), [2, 3, 4]);
+});
+
+test("summarizeAction collapses each AgentAction shape", () => {
+  const cases: Array<[AgentAction, string]> = [
+    [{ type: "noop", reason: "x" }, "noop"],
+    [{ type: "swap", tokenIn: "WETH", amountIn: "1" }, "swap"],
+    [{ type: "mintLiquidity", tickLower: -10, tickUpper: 10, amountWethDesired: "1", amountUsdcDesired: "1" }, "mintLiquidity"],
+    [{ type: "removeLiquidity", tokenId: "1", liquidity: "1" }, "removeLiquidity"],
+    [{ type: "collectFees", tokenId: "1" }, "collectFees"],
+    [{ type: "bundle", actions: [{ type: "swap", tokenIn: "WETH", amountIn: "1" }] }, "bundle"],
+    [{ type: "rawTx", tx: { to: "0xabc", data: "0x" } }, "rawTx"],
+    [{ type: "rawBundle", txs: [{ to: "0xabc", data: "0x" }] }, "rawBundle"]
+  ];
+  for (const [action, expected] of cases) {
+    assert.equal(summarizeAction(action).type, expected);
+  }
+});
+
+test("buildRoundRecord captures executor failure", () => {
+  const record = buildRoundRecord(
+    baseObs,
+    { type: "noop", reason: "executor error: boom" },
+    false,
+    "boom",
+    ["log line"]
+  );
+  assert.equal(record.executorOk, false);
+  assert.equal(record.executorReason, "boom");
+  assert.deepEqual(record.executorLogs, ["log line"]);
+});

--- a/test/llm-strategy.test.ts
+++ b/test/llm-strategy.test.ts
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { encodeFunctionData, formatUnits, parseUnits } from "viem";
+import {
+  DEFAULT_ADDRESSES,
+  checkExecutorSyntax,
+  parseStrategyFromToolInput,
+  runExecutor,
+  type ExecutorHelpers,
+  type Strategy
+} from "../src/llm/strategy.js";
+import type { AgentObservation } from "../src/types.js";
+
+const helpersBase: Omit<ExecutorHelpers, "log"> = {
+  parseUnits,
+  formatUnits,
+  encodeFunctionData,
+  ADDRESSES: DEFAULT_ADDRESSES
+};
+
+const obs: AgentObservation = {
+  kind: "observation",
+  runId: "test-run",
+  round: 1,
+  blockNumber: "1",
+  agentAddress: "0x0000000000000000000000000000000000000001",
+  pool: { pair: "WETH/USDC", fee: 500, priceUsdcPerWeth: 3000, tick: 0, tickSpacing: 10 },
+  positions: [],
+  fairPriceUsdcPerWeth: 3030, // +1% gap
+  balances: { ethWei: "1000000000000000000", wethWei: "10000000000000000000", usdcUnits: "25000000000" },
+  inventory: { valueUsdc: 55000, weth: 10, usdc: 25000, eth: 1 },
+  history: [],
+  limits: {
+    maxWethInWei: "1000000000000000000",
+    maxUsdcInUnits: "5000000000",
+    defaultPriorityFeePerGasWei: "100000000",
+    maxPriorityFeePerGasWei: "5000000000",
+    defaultSlippageBps: 50,
+    maxBundleActions: 5,
+    maxLpWethWei: "1000000000000000000",
+    maxLpUsdcUnits: "5000000000",
+    maxOpenPositions: 10
+  }
+};
+
+test("parseStrategyFromToolInput accepts a valid payload", () => {
+  const result = parseStrategyFromToolInput(
+    {
+      notes: "Spread arb threshold strategy",
+      params: { minGapBps: 15 },
+      executor_ts: `return { type: "noop", reason: "n/a" };`
+    },
+    1
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.strategy.version, 1);
+    assert.equal(result.strategy.params.minGapBps, 15);
+  }
+});
+
+test("parseStrategyFromToolInput rejects empty notes", () => {
+  const result = parseStrategyFromToolInput({ notes: "", params: {}, executor_ts: "return { type: \"noop\" };" }, 1);
+  assert.equal(result.ok, false);
+});
+
+test("parseStrategyFromToolInput rejects non-object params", () => {
+  const result = parseStrategyFromToolInput({ notes: "x", params: [1, 2], executor_ts: "return { type: \"noop\" };" }, 1);
+  assert.equal(result.ok, false);
+});
+
+test("checkExecutorSyntax catches syntax errors", () => {
+  const bad = checkExecutorSyntax("return { type: 'noop' "); // unclosed brace
+  assert.equal(bad.ok, false);
+  const good = checkExecutorSyntax("return { type: 'noop' };");
+  assert.equal(good.ok, true);
+});
+
+test("runExecutor returns a valid swap AgentAction", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "swap on positive gap",
+    params: { minGapBps: 50, sizeBps: 1000 },
+    executorTs: `
+      const gap = obs.fairPriceUsdcPerWeth / obs.pool.priceUsdcPerWeth - 1;
+      if (Math.abs(gap) < params.minGapBps / 10000) return { type: "noop", reason: "tight" };
+      const tokenIn = gap > 0 ? "USDC" : "WETH";
+      const cap = BigInt(tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+      const amountIn = (cap * BigInt(params.sizeBps)) / 10000n;
+      helpers.log("placed swap");
+      return { type: "swap", tokenIn, amountIn: amountIn.toString(), slippageBps: 50 };
+    `
+  };
+  const result = runExecutor(strategy, obs, helpersBase);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.action.type, "swap");
+    if (result.action.type === "swap") {
+      assert.equal(result.action.tokenIn, "USDC");
+      assert.ok(BigInt(result.action.amountIn) > 0n);
+    }
+    assert.deepEqual(result.logs, ["placed swap"]);
+  }
+});
+
+test("runExecutor surfaces a noop fallback when executor throws", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "buggy",
+    params: {},
+    executorTs: `throw new Error("boom");`
+  };
+  const result = runExecutor(strategy, obs, helpersBase);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /executor threw/);
+});
+
+test("runExecutor rejects invalid AgentAction returned by executor", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "wrong",
+    params: {},
+    executorTs: `return { type: "swap", tokenIn: "FOO", amountIn: "1" };`
+  };
+  const result = runExecutor(strategy, obs, helpersBase);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /tokenIn/);
+});
+
+test("runExecutor rejects undefined return", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "no return",
+    params: {},
+    executorTs: `helpers.log("no return");`
+  };
+  const result = runExecutor(strategy, obs, helpersBase);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /undefined/);
+});
+
+test("runExecutor enforces timeout on infinite loop", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "spinner",
+    params: {},
+    executorTs: `while (true) {}`
+  };
+  const result = runExecutor(strategy, obs, helpersBase, 50);
+  assert.equal(result.ok, false);
+});
+
+test("runExecutor sandbox does not expose process or require", () => {
+  const strategy: Strategy = {
+    version: 1,
+    notes: "probe",
+    params: {},
+    executorTs: `
+      const hasProcess = typeof process !== "undefined";
+      const hasRequire = typeof require !== "undefined";
+      return { type: "noop", reason: "process=" + hasProcess + " require=" + hasRequire };
+    `
+  };
+  const result = runExecutor(strategy, obs, helpersBase);
+  assert.equal(result.ok, true);
+  if (result.ok && result.action.type === "noop") {
+    assert.equal(result.action.reason, "process=false require=false");
+  }
+});

--- a/test/llm-subscription-strategist.test.ts
+++ b/test/llm-subscription-strategist.test.ts
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ClaudeSubscriptionStrategist, type SdkLike } from "../src/llm/claudeSubscriptionStrategist.js";
+import type { AgentObservation } from "../src/types.js";
+
+const obs: AgentObservation = {
+  kind: "observation",
+  runId: "sub-test",
+  round: 0,
+  blockNumber: "1",
+  agentAddress: "0x0000000000000000000000000000000000000001",
+  pool: { pair: "WETH/USDC", fee: 500, priceUsdcPerWeth: 3000, tick: 0, tickSpacing: 10 },
+  positions: [],
+  fairPriceUsdcPerWeth: 3030,
+  balances: { ethWei: "1000000000000000000", wethWei: "10000000000000000000", usdcUnits: "25000000000" },
+  inventory: { valueUsdc: 55000, weth: 10, usdc: 25000, eth: 1 },
+  history: [],
+  limits: {
+    maxWethInWei: "1000000000000000000",
+    maxUsdcInUnits: "5000000000",
+    defaultPriorityFeePerGasWei: "100000000",
+    maxPriorityFeePerGasWei: "5000000000",
+    defaultSlippageBps: 50,
+    maxBundleActions: 5,
+    maxLpWethWei: "1000000000000000000",
+    maxLpUsdcUnits: "5000000000",
+    maxOpenPositions: 10
+  }
+};
+
+type FakeScript = {
+  callTool?: { args: Record<string, unknown> };
+  resultMessage?: Record<string, unknown> | null;
+  throwInsteadOf?: "query" | null;
+};
+
+/**
+ * Minimal fake of the SdkLike interface. The SDK's real `query` is replaced
+ * with one that invokes the registered handler (if `callTool` is provided)
+ * then yields a synthetic result message.
+ */
+function makeFakeSdk(script: FakeScript): { sdk: SdkLike; calls: { options: unknown }[] } {
+  const calls: { options: unknown }[] = [];
+  let registeredHandler: ((args: unknown) => Promise<unknown>) | null = null;
+
+  const sdk: SdkLike = {
+    createSdkMcpServer: ((opts: { name: string; tools?: Array<{ handler?: (args: unknown) => Promise<unknown> }> }) => {
+      // Pick the first tool's handler and stash it for the fake query.
+      const t = (opts.tools ?? [])[0];
+      registeredHandler = t?.handler ?? null;
+      return { type: "sdk", name: opts.name, instance: {} };
+    }) as unknown as SdkLike["createSdkMcpServer"],
+    tool: ((name: string, description: string, _schema: unknown, handler: (args: unknown) => Promise<unknown>) =>
+      ({ name, description, handler })) as unknown as SdkLike["tool"],
+    query: (({ options }: { options: unknown }) => {
+      calls.push({ options });
+      if (script.throwInsteadOf === "query") throw new Error("query exploded");
+
+      async function* generator() {
+        if (script.callTool && registeredHandler) {
+          await registeredHandler(script.callTool.args);
+        }
+        if (script.resultMessage !== null) {
+          yield (script.resultMessage ?? {
+            type: "result",
+            subtype: "success",
+            duration_ms: 4321,
+            usage: {
+              input_tokens: 12345,
+              output_tokens: 678,
+              cache_read_input_tokens: 9000,
+              cache_creation_input_tokens: 100
+            }
+          }) as unknown;
+        }
+      }
+      return generator();
+    }) as unknown as SdkLike["query"]
+  };
+  return { sdk, calls };
+}
+
+test("init captures the tool handler input and returns a Strategy", async () => {
+  const { sdk } = makeFakeSdk({
+    callTool: {
+      args: {
+        notes: "Spread arb",
+        params: { minGapBps: 25 },
+        executor_ts: `return { type: "noop", reason: "ok" };`
+      }
+    }
+  });
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const result = await strat.init(obs, 1);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.strategy.version, 1);
+    assert.equal(result.strategy.notes, "Spread arb");
+    assert.equal(result.strategy.params.minGapBps, 25);
+    assert.equal(result.meta.phase, "init");
+    assert.equal(result.meta.inputTokens, 12345);
+    assert.equal(result.meta.cacheReadInputTokens, 9000);
+    assert.equal(result.meta.latencyMs, 4321);
+  }
+});
+
+test("revise wires through buildReviseMessage and bumps version", async () => {
+  const { sdk, calls } = makeFakeSdk({
+    callTool: {
+      args: {
+        notes: "tighter",
+        params: { minGapBps: 50 },
+        executor_ts: `return { type: "noop", reason: "ok" };`
+      },
+    },
+    resultMessage: {
+      type: "result",
+      subtype: "success",
+      duration_ms: 1000,
+      usage: { input_tokens: 1, output_tokens: 2, cache_read_input_tokens: 3, cache_creation_input_tokens: 4 }
+    }
+  });
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const prev = {
+    version: 1,
+    notes: "v1",
+    params: { minGapBps: 25 },
+    executorTs: `return { type: "noop" };`
+  };
+  const result = await strat.revise(prev, [], "scheduled", 100, 90, 2);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.strategy.version, 2);
+    assert.equal(result.meta.phase, "revise");
+  }
+  // The user message in the prompt should be a single string; we just sanity-check
+  // that options propagated.
+  assert.equal(calls.length, 1);
+  const opts = calls[0].options as { allowedTools: string[]; disallowedTools: string[]; permissionMode: string };
+  assert.deepEqual(opts.allowedTools, ["mcp__strategy__set_strategy"]);
+  assert.ok(opts.disallowedTools.includes("Bash"));
+  assert.equal(opts.permissionMode, "bypassPermissions");
+});
+
+test("returns 'model did not call set_strategy' when handler never fires", async () => {
+  const { sdk } = makeFakeSdk({}); // no callTool
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const result = await strat.init(obs, 1);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /did not call set_strategy/);
+    assert.ok(result.meta, "still records meta from the result message");
+  }
+});
+
+test("propagates parse failures (invalid executor_ts)", async () => {
+  const { sdk } = makeFakeSdk({
+    callTool: {
+      args: {
+        notes: "broken",
+        params: {},
+        executor_ts: "return { type: 'noop' "   // unclosed
+      }
+    }
+  });
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const result = await strat.init(obs, 1);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /executor_ts syntax error/);
+});
+
+test("returns error when query throws", async () => {
+  const { sdk } = makeFakeSdk({ throwInsteadOf: "query" });
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const result = await strat.init(obs, 1);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.reason, /claude call failed: query exploded/);
+});
+
+test("surfaces error subtype from the SDK result message", async () => {
+  const { sdk } = makeFakeSdk({
+    resultMessage: {
+      type: "result",
+      subtype: "error_max_turns",
+      duration_ms: 500,
+      usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    }
+  });
+  const strat = new ClaudeSubscriptionStrategist({ sdk });
+  const result = await strat.init(obs, 1);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /claude returned error_max_turns/);
+    assert.equal(result.meta?.phase, "init");
+  }
+});


### PR DESCRIPTION
## Summary

- New agent `examples/agents/claude-llm.ts` whose trading strategy is written and revised by Claude itself — no hand-coded logic.
- Two-tier design: Claude produces a `Strategy { notes, params, executor_ts }` in the background; each round runs the TS executor body in a 200 ms `node:vm` sandbox. Round responses never block on the LLM.
- Three switchable backends via `ERIS_LLM_AUTH`:
  - `subscription` — Claude Pro/Max OAuth through `@anthropic-ai/claude-agent-sdk`, no API key. In-process MCP `set_strategy` tool reproduces the API `tool_use` forcing pattern.
  - `apikey` — `@anthropic-ai/sdk` with `ANTHROPIC_API_KEY`.
  - `mock` — offline noop strategy for smoke tests.
  - `auto` (default) — probes for the `claude` binary, falls back gracefully to `apikey` or `mock`.
- Strategy revisions trigger every `ERIS_LLM_REVIEW_EVERY` rounds (default 10) or on a >`ERIS_LLM_DRAWDOWN_RATIO` (default 5%) PnL drop from initial USD.
- Per-agent output under `runs/<runId>/agent-<id>/`: `strategy-vN.{md,params.json,executor.ts}`, `decisions.jsonl`, `claude-calls.jsonl`.
- `src/agentProcess.ts` forwards `ANTHROPIC_API_KEY`, any `ERIS_LLM_*` env var, and `REPORT_DIR` from parent to child.

## Commits

1. `9599bd8` Add Anthropic SDK and Claude Agent SDK dependencies
2. `8c41bfc` Add autonomous LLM strategy agent
3. `a597539` Document LLM strategy agent and backend selection in README

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 62/62 pass (29 new + 33 pre-existing)
- [x] `selectStrategist()` smoke: all 4 branches (`auto`, `apikey` no key, `apikey` with key, `subscription`, `mock`) verified via stderr
- [x] Headless agent smoke: stdin observation → stdout `noop` while init in flight → strategy files persisted under `REPORT_DIR/<runId>/agent-<id>/`
- [ ] Live E2E (manual, consumes Max quota): `unset ANTHROPIC_API_KEY && AGENTS_CONFIG=agents.claude-llm.json npm run sim` and inspect `strategy-v1.md` + `claude-calls.jsonl`
- [ ] API-key E2E (manual): `ANTHROPIC_API_KEY=sk-ant-... ERIS_LLM_AUTH=apikey npm run sim`
- [ ] Side-by-side with `noop` / `simple-rule` agents to confirm coordinator stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)