### PR TITLE
[strategy] statistical arb with z-score sizing & dynamic priority fee

### DIFF
--- a/agents.stat-arb.json
+++ b/agents.stat-arb.json
@@ -1,0 +1,58 @@
+{
+  "agents": [
+    {
+      "id": "stat-arb",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/stat-arb.ts"],
+      "wallet": "AGENT0_PRIVATE_KEY",
+      "env": {
+        "STAT_ARB_WINDOW": "64",
+        "STAT_ARB_Z_ENTER": "1.5",
+        "STAT_ARB_Z_AGGRESSIVE": "2.5",
+        "STAT_ARB_BID_ALPHA": "0.3",
+        "STAT_ARB_BURN_IN": "20"
+      },
+      "description": "rolling-stats arb — z-score sizing + EV-proportional priority fee"
+    },
+    {
+      "id": "arb-cautious",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/arb-bot.ts"],
+      "wallet": "AGENT1_PRIVATE_KEY",
+      "env": { "BID_PROFIT_FRACTION": "0.1" },
+      "description": "arb bot — 10% of EV routed to priority fee"
+    },
+    {
+      "id": "arb-low",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/arb-bot.ts"],
+      "wallet": "AGENT2_PRIVATE_KEY",
+      "env": { "BID_PROFIT_FRACTION": "0.2" },
+      "description": "arb bot — 20% of EV routed to priority fee"
+    },
+    {
+      "id": "arb-mid",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/arb-bot.ts"],
+      "wallet": "AUTO",
+      "env": { "BID_PROFIT_FRACTION": "0.3" },
+      "description": "arb bot — 30% of EV routed to priority fee"
+    },
+    {
+      "id": "arb-high",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/arb-bot.ts"],
+      "wallet": "AUTO",
+      "env": { "BID_PROFIT_FRACTION": "0.5" },
+      "description": "arb bot — 50% of EV routed to priority fee"
+    },
+    {
+      "id": "arb-aggressive",
+      "command": "node",
+      "args": ["--import", "tsx", "examples/agents/arb-bot.ts"],
+      "wallet": "AUTO",
+      "env": { "BID_PROFIT_FRACTION": "0.8" },
+      "description": "arb bot — 80% of EV routed to priority fee"
+    }
+  ]
+}

--- a/examples/agents/stat-arb.ts
+++ b/examples/agents/stat-arb.ts
@@ -1,0 +1,170 @@
+/**
+ * stat-arb: rolling-stats driven arb agent with z-score sizing and dynamic
+ *           priority fee bidding.
+ *
+ * Compared to arb-bot (fixed gap threshold, fixed sizing schedule):
+ *   - Threshold is data-driven: enter when |z(gap)| > STAT_ARB_Z_ENTER.
+ *   - Size scales with |z| (capped at 50% of per-round swap limit).
+ *   - Priority fee is EV-proportional: bid ≈ alpha * EV_wei / gasEstimate,
+ *     clamped to the simulator's [defaultPriorityFee, maxPriorityFee] band.
+ *   - During burn-in (rolling stats not yet meaningful) emit noop. The
+ *     observation's `history` field is replayed on startup so late-spawned
+ *     agents don't need a fresh N rounds of cold start.
+ *
+ * Env vars:
+ *   STAT_ARB_WINDOW         (default 64)  burn-in stats window metadata; the
+ *                                          Welford estimator is unbounded, so
+ *                                          this only labels the tuning window.
+ *   STAT_ARB_Z_ENTER        (default 1.5) minimum |z| to take a position.
+ *   STAT_ARB_Z_AGGRESSIVE   (default 2.5) |z| at which sizing saturates the
+ *                                          50% cap; below this, size scales
+ *                                          linearly from Z_ENTER → cap.
+ *   STAT_ARB_BID_ALPHA      (default 0.3) fraction of expected EV (wei) routed
+ *                                          to priority fee bidding.
+ *   STAT_ARB_BURN_IN        (default 20)  minimum sample count before trading.
+ */
+import { createInterface } from "node:readline";
+import { RollingStats } from "../lib/rolling-stats.js";
+
+type HistoryPoint = { round: number; poolPriceUsdcPerWeth: number; fairPriceUsdcPerWeth: number };
+
+type Observation = {
+  round: number;
+  pool: { priceUsdcPerWeth: number };
+  fairPriceUsdcPerWeth: number;
+  history?: HistoryPoint[];
+  limits: {
+    maxWethInWei: string;
+    maxUsdcInUnits: string;
+    defaultPriorityFeePerGasWei: string;
+    maxPriorityFeePerGasWei: string;
+  };
+};
+
+const WINDOW = Math.max(2, Math.floor(Number(process.env.STAT_ARB_WINDOW ?? "64")));
+const Z_ENTER = Number(process.env.STAT_ARB_Z_ENTER ?? "1.5");
+const Z_AGGRESSIVE = Number(process.env.STAT_ARB_Z_AGGRESSIVE ?? "2.5");
+const BID_ALPHA = Number(process.env.STAT_ARB_BID_ALPHA ?? "0.3");
+const BURN_IN = Math.max(2, Math.floor(Number(process.env.STAT_ARB_BURN_IN ?? "20")));
+
+const GAS_UNITS_ESTIMATE = 180_000n;
+const SIZE_CAP_BPS = 5000; // 50% of per-round swap limit
+const SIZE_FLOOR_BPS = 500; // 5% — when |z| barely clears Z_ENTER
+
+if (!Number.isFinite(Z_ENTER) || Z_ENTER <= 0) {
+  process.stderr.write(`invalid STAT_ARB_Z_ENTER: ${process.env.STAT_ARB_Z_ENTER}\n`);
+  process.exit(1);
+}
+if (!Number.isFinite(Z_AGGRESSIVE) || Z_AGGRESSIVE <= Z_ENTER) {
+  process.stderr.write(`invalid STAT_ARB_Z_AGGRESSIVE (must be > Z_ENTER): ${process.env.STAT_ARB_Z_AGGRESSIVE}\n`);
+  process.exit(1);
+}
+if (!Number.isFinite(BID_ALPHA) || BID_ALPHA < 0) {
+  process.stderr.write(`invalid STAT_ARB_BID_ALPHA: ${process.env.STAT_ARB_BID_ALPHA}\n`);
+  process.exit(1);
+}
+
+const stats = new RollingStats(WINDOW);
+const seenRounds = new Set<number>();
+
+function computeGap(pool: number, fair: number): number | null {
+  if (!Number.isFinite(pool) || pool <= 0) return null;
+  if (!Number.isFinite(fair) || fair <= 0) return null;
+  return fair / pool - 1;
+}
+
+function seedFromHistory(history: HistoryPoint[] | undefined): void {
+  if (!history || history.length === 0) return;
+  for (const point of history) {
+    if (seenRounds.has(point.round)) continue;
+    const gap = computeGap(point.poolPriceUsdcPerWeth, point.fairPriceUsdcPerWeth);
+    if (gap === null) continue;
+    stats.update(gap);
+    seenRounds.add(point.round);
+  }
+}
+
+function noop(reason: string): string {
+  return `${JSON.stringify({ type: "noop", reason })}\n`;
+}
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  let obs: Observation;
+  try {
+    obs = JSON.parse(line) as Observation;
+  } catch (err) {
+    process.stdout.write(noop(`parse error: ${(err as Error).message}`));
+    return;
+  }
+
+  seedFromHistory(obs.history);
+
+  const pool = obs.pool.priceUsdcPerWeth;
+  const fair = obs.fairPriceUsdcPerWeth;
+  const gap = computeGap(pool, fair);
+  if (gap === null) {
+    process.stdout.write(noop("invalid prices"));
+    return;
+  }
+
+  // Score against the current model BEFORE incorporating the new sample —
+  // otherwise the latest point pulls the mean toward itself and damps the
+  // signal. Then fold it in for next round.
+  const z = stats.zscore(gap);
+  stats.update(gap);
+  seenRounds.add(obs.round);
+
+  if (stats.count() < BURN_IN) {
+    process.stdout.write(noop(`burn-in (${stats.count()}/${BURN_IN})`));
+    return;
+  }
+
+  const absZ = Math.abs(z);
+  if (absZ < Z_ENTER) {
+    process.stdout.write(noop(`|z|=${absZ.toFixed(2)} < ${Z_ENTER}`));
+    return;
+  }
+
+  const tokenIn: "WETH" | "USDC" = gap > 0 ? "USDC" : "WETH";
+  const max = BigInt(tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+
+  // Linear ramp: SIZE_FLOOR_BPS at |z| = Z_ENTER, SIZE_CAP_BPS at |z| >= Z_AGGRESSIVE.
+  const span = Math.max(0.0001, Z_AGGRESSIVE - Z_ENTER);
+  const t = Math.max(0, Math.min(1, (absZ - Z_ENTER) / span));
+  const sizeBps = Math.max(SIZE_FLOOR_BPS, Math.min(SIZE_CAP_BPS, Math.floor(SIZE_FLOOR_BPS + (SIZE_CAP_BPS - SIZE_FLOOR_BPS) * t)));
+  const amountIn = (max * BigInt(sizeBps)) / 10_000n;
+
+  if (amountIn <= 0n) {
+    process.stdout.write(noop("size rounds to zero"));
+    return;
+  }
+
+  // EV in USDC ≈ size_usdc * |gap|. Convert to wei via fair price.
+  const sizeUsdc =
+    tokenIn === "USDC"
+      ? Number(amountIn) / 1e6
+      : (Number(amountIn) / 1e18) * fair;
+  const evUsdc = sizeUsdc * Math.abs(gap);
+  const evGwei = Math.max(0, Math.floor((evUsdc / fair) * 1e9));
+  const evWei = BigInt(evGwei) * 1_000_000_000n;
+
+  const alphaScale = 10_000n;
+  const alphaNum = BigInt(Math.max(0, Math.floor(BID_ALPHA * Number(alphaScale))));
+  const bidPerGasWei = (evWei * alphaNum) / alphaScale / GAS_UNITS_ESTIMATE;
+
+  const minBid = BigInt(obs.limits.defaultPriorityFeePerGasWei);
+  const maxBid = BigInt(obs.limits.maxPriorityFeePerGasWei);
+  const bid = bidPerGasWei < minBid ? minBid : bidPerGasWei > maxBid ? maxBid : bidPerGasWei;
+
+  process.stdout.write(
+    `${JSON.stringify({
+      type: "swap",
+      tokenIn,
+      amountIn: amountIn.toString(),
+      maxPriorityFeePerGasWei: bid.toString(),
+      slippageBps: 75
+    })}\n`
+  );
+});

--- a/examples/lib/rolling-stats.ts
+++ b/examples/lib/rolling-stats.ts
@@ -1,0 +1,64 @@
+/**
+ * RollingStats: Welford's online algorithm for streaming mean / variance.
+ *
+ * Numerically stable, unbounded sample count (no fixed window — see note).
+ * Used by stat-arb to feed pool/fair gap series and pull a z-score per round.
+ *
+ * Note: this implementation is unbounded; older samples are not evicted. The
+ * `windowHint` constructor argument is metadata only (callers can read it via
+ * `.windowHint`) so a single env var can express both "how long is the
+ * burn-in" and "what window were you tuned against".
+ *
+ * Usage:
+ *   const rs = new RollingStats();
+ *   rs.update(0.001);
+ *   rs.update(-0.0005);
+ *   rs.zscore(0.0008); // (0.0008 - mean) / std
+ */
+export class RollingStats {
+  private n = 0;
+  private mu = 0;
+  private m2 = 0;
+  readonly windowHint: number;
+
+  constructor(windowHint = 0) {
+    this.windowHint = windowHint;
+  }
+
+  update(x: number): void {
+    if (!Number.isFinite(x)) return;
+    this.n += 1;
+    const delta = x - this.mu;
+    this.mu += delta / this.n;
+    const delta2 = x - this.mu;
+    this.m2 += delta * delta2;
+  }
+
+  count(): number {
+    return this.n;
+  }
+
+  mean(): number {
+    return this.n > 0 ? this.mu : 0;
+  }
+
+  /**
+   * Sample standard deviation (n-1 denominator). Returns 0 if fewer than 2
+   * samples have been recorded.
+   */
+  std(): number {
+    if (this.n < 2) return 0;
+    const variance = this.m2 / (this.n - 1);
+    return variance > 0 ? Math.sqrt(variance) : 0;
+  }
+
+  /**
+   * Z-score of `x` against the running mean/std. Returns 0 if std is 0 (no
+   * spread observed yet) so callers can treat "uninformative" as "do nothing".
+   */
+  zscore(x: number): number {
+    const s = this.std();
+    if (s === 0) return 0;
+    return (x - this.mu) / s;
+  }
+}

--- a/scripts/analyze-priority-bids.ts
+++ b/scripts/analyze-priority-bids.ts
@@ -1,0 +1,216 @@
+/**
+ * analyze-priority-bids: aggregate per-agent priority-fee bids and inclusion
+ *                       order from a sim run's blocks.csv.
+ *
+ * Reads `runs/<id>/blocks.csv` (columns: round, blockNumber, txIndex, hash,
+ * from, priorityFeeWei, status, ownerId, role, actionType, bundleId,
+ * bundleIndex) and prints a per-ownerId table with:
+ *
+ *   - tx count, success count, revert count
+ *   - mean / p50 / p90 / max priority-fee bid (gwei)
+ *   - mean txIndex (lower = included earlier within a block)
+ *   - "win rate" = fraction of rounds where this owner had the lowest txIndex
+ *     among agent-role tx (informed/uninformed-flow excluded).
+ *
+ * Usage:
+ *   npx tsx scripts/analyze-priority-bids.ts runs/<run-id>
+ *   npx tsx scripts/analyze-priority-bids.ts runs/2026-06-01T15-23-07-473Z
+ *
+ * Output is plain-text columnar so it can be eyeballed or piped into other
+ * tools. Exits non-zero only on read/parse errors.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type Row = {
+  round: number;
+  blockNumber: number;
+  txIndex: number;
+  priorityFeeWei: bigint;
+  status: string;
+  ownerId: string;
+  role: string;
+  actionType: string;
+};
+
+function parseCsv(text: string): Row[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) return [];
+  const header = lines[0].split(",");
+  const idx = (name: string): number => {
+    const i = header.indexOf(name);
+    if (i < 0) throw new Error(`missing column '${name}' in blocks.csv header: ${header.join(",")}`);
+    return i;
+  };
+  const cRound = idx("round");
+  const cBlock = idx("blockNumber");
+  const cTxIdx = idx("txIndex");
+  const cFee = idx("priorityFeeWei");
+  const cStatus = idx("status");
+  const cOwner = idx("ownerId");
+  const cRole = idx("role");
+  const cAction = idx("actionType");
+
+  const rows: Row[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = lines[i].split(",");
+    if (cells.length < header.length) continue;
+    try {
+      rows.push({
+        round: Number(cells[cRound]),
+        blockNumber: Number(cells[cBlock]),
+        txIndex: Number(cells[cTxIdx]),
+        priorityFeeWei: BigInt(cells[cFee] || "0"),
+        status: cells[cStatus] ?? "",
+        ownerId: cells[cOwner] ?? "",
+        role: cells[cRole] ?? "",
+        actionType: cells[cAction] ?? ""
+      });
+    } catch {
+      // skip malformed line silently
+    }
+  }
+  return rows;
+}
+
+function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+type Agg = {
+  ownerId: string;
+  txCount: number;
+  successCount: number;
+  revertCount: number;
+  bidsGwei: number[];
+  txIndices: number[];
+  wins: number;
+  rounds: Set<number>;
+};
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+function padLeft(s: string, n: number): string {
+  return s.length >= n ? s : " ".repeat(n - s.length) + s;
+}
+
+function main(): void {
+  const runDir = process.argv[2];
+  if (!runDir) {
+    process.stderr.write("usage: tsx scripts/analyze-priority-bids.ts <run-dir>\n");
+    process.exit(2);
+  }
+  const csvPath = join(runDir, "blocks.csv");
+  let text: string;
+  try {
+    text = readFileSync(csvPath, "utf8");
+  } catch (err) {
+    process.stderr.write(`failed to read ${csvPath}: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+  const rows = parseCsv(text);
+  if (rows.length === 0) {
+    process.stdout.write(`no rows in ${csvPath}\n`);
+    return;
+  }
+
+  // Aggregate by ownerId. Per-round win = lowest agent-role txIndex.
+  const aggs = new Map<string, Agg>();
+  const agentRolesPerRound = new Map<number, Row[]>();
+
+  for (const r of rows) {
+    let agg = aggs.get(r.ownerId);
+    if (!agg) {
+      agg = {
+        ownerId: r.ownerId,
+        txCount: 0,
+        successCount: 0,
+        revertCount: 0,
+        bidsGwei: [],
+        txIndices: [],
+        wins: 0,
+        rounds: new Set()
+      };
+      aggs.set(r.ownerId, agg);
+    }
+    agg.txCount += 1;
+    if (r.status === "success") agg.successCount += 1;
+    else agg.revertCount += 1;
+    agg.bidsGwei.push(Number(r.priorityFeeWei) / 1e9);
+    agg.txIndices.push(r.txIndex);
+    agg.rounds.add(r.round);
+
+    if (r.role === "agent") {
+      const list = agentRolesPerRound.get(r.round) ?? [];
+      list.push(r);
+      agentRolesPerRound.set(r.round, list);
+    }
+  }
+
+  for (const [, list] of agentRolesPerRound) {
+    if (list.length === 0) continue;
+    let minIdx = Infinity;
+    for (const r of list) if (r.txIndex < minIdx) minIdx = r.txIndex;
+    const winners = new Set<string>();
+    for (const r of list) if (r.txIndex === minIdx) winners.add(r.ownerId);
+    for (const owner of winners) {
+      const agg = aggs.get(owner);
+      if (agg) agg.wins += 1;
+    }
+  }
+
+  const ordered = [...aggs.values()].sort((a, b) => a.ownerId.localeCompare(b.ownerId));
+
+  const totalAgentRounds = agentRolesPerRound.size;
+  process.stdout.write(`run: ${runDir}\n`);
+  process.stdout.write(`rows: ${rows.length}, agent-rounds: ${totalAgentRounds}\n\n`);
+
+  const cols = [
+    pad("ownerId", 22),
+    padLeft("tx", 5),
+    padLeft("ok", 5),
+    padLeft("rev", 5),
+    padLeft("rounds", 7),
+    padLeft("bid_mean_gwei", 14),
+    padLeft("bid_p50", 9),
+    padLeft("bid_p90", 9),
+    padLeft("bid_max", 9),
+    padLeft("txIdx_mean", 11),
+    padLeft("wins", 6),
+    padLeft("win_rate", 9)
+  ];
+  process.stdout.write(`${cols.join(" ")}\n`);
+
+  for (const agg of ordered) {
+    const sortedBids = [...agg.bidsGwei].sort((a, b) => a - b);
+    const bidMean = sortedBids.reduce((s, x) => s + x, 0) / Math.max(1, sortedBids.length);
+    const bidP50 = quantile(sortedBids, 0.5);
+    const bidP90 = quantile(sortedBids, 0.9);
+    const bidMax = sortedBids.length > 0 ? sortedBids[sortedBids.length - 1] : 0;
+    const txIdxMean = agg.txIndices.reduce((s, x) => s + x, 0) / Math.max(1, agg.txIndices.length);
+    const winRate = totalAgentRounds > 0 ? agg.wins / totalAgentRounds : 0;
+    const line = [
+      pad(agg.ownerId, 22),
+      padLeft(String(agg.txCount), 5),
+      padLeft(String(agg.successCount), 5),
+      padLeft(String(agg.revertCount), 5),
+      padLeft(String(agg.rounds.size), 7),
+      padLeft(bidMean.toFixed(3), 14),
+      padLeft(bidP50.toFixed(3), 9),
+      padLeft(bidP90.toFixed(3), 9),
+      padLeft(bidMax.toFixed(3), 9),
+      padLeft(txIdxMean.toFixed(2), 11),
+      padLeft(String(agg.wins), 6),
+      padLeft((winRate * 100).toFixed(1) + "%", 9)
+    ];
+    process.stdout.write(`${line.join(" ")}\n`);
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #8

## Summary

Adds `stat-arb`, a rolling-statistics arb agent that replaces the fixed-threshold pattern in `arb-bot.ts`:

- Each round computes `gap = fair / pool - 1` and feeds it to a Welford online estimator.
- Enters when `|z(gap)| > STAT_ARB_Z_ENTER`; size scales linearly from 5% to 50% of the per-round swap cap as `|z|` ramps from `Z_ENTER` to `Z_AGGRESSIVE`.
- Priority fee bid is EV-proportional: `bid ≈ alpha * EV_wei / 180_000`, clamped to the simulator's `[defaultPriorityFee, maxPriorityFee]` band.
- Burn-in: noop until `STAT_ARB_BURN_IN` samples have accumulated. The observation's `history` field is replayed on startup so late-spawned agents don't need a cold start.

## New files

| File | Purpose |
| --- | --- |
| `examples/lib/rolling-stats.ts` | Welford online mean/std/z-score class. |
| `examples/agents/stat-arb.ts` | The agent. |
| `agents.stat-arb.json` | 1 stat-arb + 5 arb-bot clones (cautious/low/mid/high/aggressive) for head-to-head. |
| `scripts/analyze-priority-bids.ts` | Per-agent bid + inclusion-order aggregator over `runs/<id>/blocks.csv`. |

## Env vars

| Var | Default | Meaning |
| --- | --- | --- |
| `STAT_ARB_WINDOW` | `64` | Burn-in window metadata. The Welford estimator is unbounded; this only labels the tuning window. |
| `STAT_ARB_Z_ENTER` | `1.5` | Minimum `\|z\|` to take a position. |
| `STAT_ARB_Z_AGGRESSIVE` | `2.5` | `\|z\|` at which sizing saturates the 50% cap. |
| `STAT_ARB_BID_ALPHA` | `0.3` | Fraction of expected EV (wei) routed to the priority-fee bid. |
| `STAT_ARB_BURN_IN` | `20` | Minimum sample count before trading. |

## Run instructions

```
# typecheck
npm run typecheck

# head-to-head sim (requires .env.local with MAINNET_RPC_URL etc.)
source .env.local
ROUNDS=64 AGENTS_CONFIG=agents.stat-arb.json npm run sim

# inspect inclusion order and bid distribution after a run
npx tsx scripts/analyze-priority-bids.ts runs/<latest>
```

## Sim result note

- `npm run typecheck` — passes.
- Integration sim — **not run in CI** for this PR: this isolated worktree has no `.env.local` (no `MAINNET_RPC_URL`). The analyze script was smoke-tested against an existing `runs/` directory and produced the expected per-agent table.

## Spawned issues

None. Everything needed for stat-arb is reachable from the existing observation / action contract; no new simulator surface area was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)