### PR TITLE
feat: LLM 戦略自己改善2層(ADR 0002)+ [strategy] issues #1/#3/#4/#6/#11

### DIFF
--- a/.claude/skills/strategy-evolve/SKILL.md
+++ b/.claude/skills/strategy-evolve/SKILL.md
@@ -48,6 +48,10 @@ SEEDS=1,2,3,4,5 ROUNDS=128 AGENTS_CONFIG=agents.evolve.json npm run evaluate --s
 前 `runs/strategy-iterations/iter-*.md` を読み、**直前イテレーションで触った agent は選ばない**。
 
 選んだ agent について、以下を計算して根本原因を 1 つ特定する。
+**PnL 帰属は共有モジュール `src/llm/attribution.ts`（`computeAttribution`）を一次の物差しにする**
+（live revise の `buildReviseMessage` と同じ指標 = 単一ソース。ADR 0002）。対象 agent の per-round
+価値系列・行動から `byAction[].netUsd`（どの行動が稼ぎ/損したか）・`turnover`・`drawdownUsd`・
+`topNoopReasons` を出し、「**負の netUsd を出している行動**」か「**機会を逃している noop 理由**」を起点にする。
 **診断は worst seed の run を開く**: `perSeedRuns` から、対象 agent の `netPnl.perSeed` が最小だった seed の `runDir` を `<worstRunDir>` とする（中央値挙動も見たいなら median seed の `runDir` も併読）。以降の成果物パスはこの `<worstRunDir>` 配下。
 **最重要の一次情報は `<worstRunDir>/agents/<target>.jsonl`（agent 自身の行動ログ）**:
 
@@ -141,6 +145,24 @@ typecheck: pass/fail · test: pass/fail · 他 agent 影響: <Σ median Δ>
 短く: 何を直したか / median before→after / 過学習チェック結果(min・win-rate) / 次候補 1-2 個。
 「次回まわす？」とは聞かない。
 
+## 9. (ADR 0002) LLM seed の昇格と A↔B 連携
+
+ロスターに `claude-llm`（`ERIS_BASE_STRATEGY=<id>`）の自己改善 agent が含まれる場合、**live(A) が run 中に
+生み出した改良版を offline(B) のゲートで選別し、勝者をベース戦略へ恒久昇格**できる（ADR 0002 の A↔B ループ）。
+
+1. **収穫**: 直近 run の `runs/<runDir>/agent-llm-<id>/strategy-v*.{md,params.json,executor.ts}` と
+   `claude-calls.jsonl`（`ok:true` の版）から、最終版や PnL 改善の大きい版を候補に集める。
+2. **ゲート**: 候補 `executorTs`/`params` を `src/llm/baseStrategies.ts` の当該 `<id>` に**一時差し替え**し、
+   `ERIS_FREEZE_STRATEGY=1`（v1 固定・LLM 呼び出し無し・決定論）で §1/§5 と同じ **マルチシード paired 評価**を回す。
+   旧ベース vs 候補で §6 の受理ルール（median 改善 + paired 非劣化 + win-rate）を適用。
+3. **恒久昇格**: 受理なら候補を `src/llm/baseStrategies.ts` の `<id>` に正式反映して commit（= A が次回 seed する v1 が良くなる）。
+   不受理なら差し戻し（`git checkout -- src/llm/baseStrategies.ts`）。
+4. **change→result メモリ**: 採用/却下を理由つきで `runs/strategy-iterations/iter-NN.md` に記録（A の `buildReviseMessage`
+   が将来このメモリを参照して同じ失敗の反復を避ける）。
+
+> 注意: live(A) は params-only 既定 + sanity ゲートで run 内の劣化を抑えるだけで、**恒久化はしない**。
+> 恒久ベース(`baseStrategies.ts`)を書き換えるのは常に B のこのゲートを通す（ADR 0002 の受け渡し点）。
+
 ---
 
 ## Notes
@@ -150,3 +172,6 @@ typecheck: pass/fail · test: pass/fail · 他 agent 影響: <Σ median Δ>
 - 全 agent が改善余地なし（全 metric グリーン）なら「進化完了」と報告して終了
 - 同じ agent で連続失敗（受理不可）3 回でアラートを上げユーザー判断を仰ぐ
 - ログ・run は git に commit しない
+- **設計の全体像は ADR 0002（LLM 戦略自己改善の2層アーキテクチャ）**。本スキル = offline(B) 層。
+  共有コア（`prompts.ts` / `strategy.ts` / `attribution.ts` / `multiSeedRun.ts` / `baseStrategies.ts` / メモリ）を
+  live(A) 層と共用する。§9 が A↔B の昇格ループ

--- a/agents.flash.json
+++ b/agents.flash.json
@@ -1,0 +1,7 @@
+{
+  "agents": [
+    { "id": "flasharb", "command": "node", "args": ["--import", "tsx", "examples/agents/flash-arb.ts"], "wallet": "AUTO", "description": "flash loan cross-venue arb" },
+    { "id": "crossvenue", "command": "node", "args": ["--import", "tsx", "examples/agents/cross-venue-arb.ts"], "wallet": "AUTO", "description": "wallet cross-venue arb" },
+    { "id": "noop", "command": "node", "args": ["--import", "tsx", "examples/agents/noop.ts"], "wallet": "AUTO", "baseline": true, "description": "noop" }
+  ]
+}

--- a/agents.liquidation.json
+++ b/agents.liquidation.json
@@ -1,0 +1,7 @@
+{
+  "agents": [
+    { "id": "liquidator", "command": "node", "args": ["--import", "tsx", "examples/agents/liquidator.ts"], "wallet": "AUTO", "description": "Aave V3 liquidation bot" },
+    { "id": "simple", "command": "node", "args": ["--import", "tsx", "examples/agents/simple-rule.ts"], "wallet": "AUTO", "description": "uniswap arb" },
+    { "id": "noop", "command": "node", "args": ["--import", "tsx", "examples/agents/noop.ts"], "wallet": "AUTO", "baseline": true, "description": "noop" }
+  ]
+}

--- a/agents.swarm-big.json
+++ b/agents.swarm-big.json
@@ -329,6 +329,132 @@
       "args": [
         "--import",
         "tsx",
+        "examples/agents/stat-arb.ts"
+      ],
+      "id": "statarb-saze1",
+      "wallet": "AUTO",
+      "env": {
+        "STAT_ARB_Z_ENTER": "1"
+      },
+      "description": "statarb (STAT_ARB_Z_ENTER=1)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/stat-arb.ts"
+      ],
+      "id": "statarb-saze1.5",
+      "wallet": "AUTO",
+      "env": {
+        "STAT_ARB_Z_ENTER": "1.5"
+      },
+      "description": "statarb (STAT_ARB_Z_ENTER=1.5)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/stat-arb.ts"
+      ],
+      "id": "statarb-saze2",
+      "wallet": "AUTO",
+      "env": {
+        "STAT_ARB_Z_ENTER": "2"
+      },
+      "description": "statarb (STAT_ARB_Z_ENTER=2)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/fair-mm.ts"
+      ],
+      "id": "fairmm-fmrtm4",
+      "wallet": "AUTO",
+      "env": {
+        "FAIR_MM_RANGE_TICK_MULTIPLIER": "4"
+      },
+      "description": "fairmm (FAIR_MM_RANGE_TICK_MULTIPLIER=4)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/fair-mm.ts"
+      ],
+      "id": "fairmm-fmrtm8",
+      "wallet": "AUTO",
+      "env": {
+        "FAIR_MM_RANGE_TICK_MULTIPLIER": "8"
+      },
+      "description": "fairmm (FAIR_MM_RANGE_TICK_MULTIPLIER=8)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/jit-lp.ts"
+      ],
+      "id": "jitlp-jvq0.8",
+      "wallet": "AUTO",
+      "env": {
+        "JIT_VOL_QUANTILE": "0.8"
+      },
+      "description": "jitlp (JIT_VOL_QUANTILE=0.8)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/jit-lp.ts"
+      ],
+      "id": "jitlp-jvq0.9",
+      "wallet": "AUTO",
+      "env": {
+        "JIT_VOL_QUANTILE": "0.9"
+      },
+      "description": "jitlp (JIT_VOL_QUANTILE=0.9)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/ladder-mm.ts"
+      ],
+      "id": "ladder-ls3",
+      "wallet": "AUTO",
+      "env": {
+        "LADDER_STEPS": "3"
+      },
+      "description": "ladder (LADDER_STEPS=3)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/ladder-mm.ts"
+      ],
+      "id": "ladder-ls5",
+      "wallet": "AUTO",
+      "env": {
+        "LADDER_STEPS": "5"
+      },
+      "description": "ladder (LADDER_STEPS=5)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
         "examples/agents/gmx-perp.ts"
       ],
       "id": "gmxperp",

--- a/agents.swarm-big.json
+++ b/agents.swarm-big.json
@@ -543,6 +543,39 @@
       "args": [
         "--import",
         "tsx",
+        "examples/agents/aave-loop.ts"
+      ],
+      "id": "aaveloop",
+      "wallet": "AUTO",
+      "description": "aaveloop (fixed)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/cross-venue-arb.ts"
+      ],
+      "id": "crossvenue",
+      "wallet": "AUTO",
+      "description": "crossvenue (fixed)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
+        "examples/agents/lp-yield.ts"
+      ],
+      "id": "lpyield",
+      "wallet": "AUTO",
+      "description": "lpyield (fixed)"
+    },
+    {
+      "command": "node",
+      "args": [
+        "--import",
+        "tsx",
         "examples/agents/noop.ts"
       ],
       "id": "noop",

--- a/contracts/FlashArb.sol
+++ b/contracts/FlashArb.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+// FlashArb (GitHub #3): Aave V3 flashLoanSimple の receiver。
+// 借りた USDC で「割安 venue で WETH 買い → 割高 venue で WETH 売り」の cross-venue 裁定を
+// 1 tx で実行し、amount+premium を返済して残り(利益)を initiator(=トリガした agent)へ送る。
+// 自己資金上限を超えるサイズで pool↔frozen-venue の乖離を取りに行く(#4 の flash 版)。
+//
+// 実行系はすべて TypeScript + viem 側。このコントラクトのみ Foundry でコンパイルする。
+
+interface IERC20 {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface IPool {
+    function flashLoanSimple(
+        address receiverAddress,
+        address asset,
+        uint256 amount,
+        bytes calldata params,
+        uint16 referralCode
+    ) external;
+}
+
+interface ISwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut);
+}
+
+interface IBalancerVault {
+    enum SwapKind {
+        GIVEN_IN,
+        GIVEN_OUT
+    }
+
+    struct SingleSwap {
+        bytes32 poolId;
+        SwapKind kind;
+        address assetIn;
+        address assetOut;
+        uint256 amount;
+        bytes userData;
+    }
+
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address recipient;
+        bool toInternalBalance;
+    }
+
+    function swap(
+        SingleSwap calldata singleSwap,
+        FundManagement calldata funds,
+        uint256 limit,
+        uint256 deadline
+    ) external payable returns (uint256);
+}
+
+contract FlashArb {
+    address public immutable pool; // Aave V3 Pool
+    address public immutable router; // Uniswap V3 SwapRouter
+    address public immutable vault; // Balancer Vault
+    bytes32 public immutable balancerPoolId;
+    address public immutable weth;
+    address public immutable usdc;
+    uint24 public immutable uniFee;
+
+    constructor(
+        address _pool,
+        address _router,
+        address _vault,
+        bytes32 _balancerPoolId,
+        address _weth,
+        address _usdc,
+        uint24 _uniFee
+    ) {
+        pool = _pool;
+        router = _router;
+        vault = _vault;
+        balancerPoolId = _balancerPoolId;
+        weth = _weth;
+        usdc = _usdc;
+        uniFee = _uniFee;
+    }
+
+    // mode 0: Uniswap で USDC->WETH 買い → Balancer で WETH->USDC 売り
+    // mode 1: Balancer で USDC->WETH 買い → Uniswap で WETH->USDC 売り
+    struct Params {
+        uint8 mode;
+        uint256 wethMinOut; // 買いレグの WETH 最小受領
+        uint256 usdcMinOut; // 売りレグの USDC 最小受領
+        address profitTo; // 利益送付先(トリガした agent)
+    }
+
+    // agent が Pool.flashLoanSimple(receiver=this, asset=USDC, amount, params) を呼ぶ。
+    function executeOperation(
+        address asset,
+        uint256 amount,
+        uint256 premium,
+        address, /* initiator */
+        bytes calldata params
+    ) external returns (bool) {
+        require(msg.sender == pool, "caller must be Pool");
+        Params memory p = abi.decode(params, (Params));
+
+        uint256 wethOut;
+        if (p.mode == 0) {
+            wethOut = _uniSwap(usdc, weth, amount, p.wethMinOut);
+            _balSwap(weth, usdc, wethOut, p.usdcMinOut);
+        } else {
+            wethOut = _balSwap(usdc, weth, amount, p.wethMinOut);
+            _uniSwap(weth, usdc, wethOut, p.usdcMinOut);
+        }
+
+        uint256 owed = amount + premium;
+        IERC20(asset).approve(pool, owed); // Pool が transferFrom で回収
+        uint256 bal = IERC20(asset).balanceOf(address(this));
+        if (bal > owed && p.profitTo != address(0)) {
+            IERC20(asset).transfer(p.profitTo, bal - owed);
+        }
+        return true;
+    }
+
+    function _uniSwap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minOut
+    ) internal returns (uint256) {
+        IERC20(tokenIn).approve(router, amountIn);
+        return
+            ISwapRouter(router).exactInputSingle(
+                ISwapRouter.ExactInputSingleParams({
+                    tokenIn: tokenIn,
+                    tokenOut: tokenOut,
+                    fee: uniFee,
+                    recipient: address(this),
+                    deadline: block.timestamp + 600,
+                    amountIn: amountIn,
+                    amountOutMinimum: minOut,
+                    sqrtPriceLimitX96: 0
+                })
+            );
+    }
+
+    function _balSwap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minOut
+    ) internal returns (uint256) {
+        IERC20(tokenIn).approve(vault, amountIn);
+        return
+            IBalancerVault(vault).swap(
+                IBalancerVault.SingleSwap({
+                    poolId: balancerPoolId,
+                    kind: IBalancerVault.SwapKind.GIVEN_IN,
+                    assetIn: tokenIn,
+                    assetOut: tokenOut,
+                    amount: amountIn,
+                    userData: ""
+                }),
+                IBalancerVault.FundManagement({
+                    sender: address(this),
+                    fromInternalBalance: false,
+                    recipient: address(this),
+                    toInternalBalance: false
+                }),
+                minOut,
+                block.timestamp + 600
+            );
+    }
+}

--- a/docs/adr/0002-llm-strategy-self-improvement-two-layer.md
+++ b/docs/adr/0002-llm-strategy-self-improvement-two-layer.md
@@ -1,0 +1,157 @@
+# ADR 0002: LLM 戦略自己改善の2層アーキテクチャ（live online × offline gated）
+
+## Status
+
+Proposed
+
+## Context
+
+本シミュレータ（ADR 0001: 多エージェント競争プラットフォーム）には、戦略を LLM が自己改善する仕組みがある。
+
+現状の構成:
+
+- **戦略表現**: `Strategy = { notes, params, executorTs }`。`executorTs` は `(obs, params, helpers) => AgentAction` の関数本体文字列で、`node:vm` サンドボックス（200ms / network・import 不可 / **ラウンド跨ぎの状態を持てない**）で毎ラウンド実行される（`src/llm/strategy.ts`）。
+- **ベース戦略ライブラリ**（`src/llm/baseStrategies.ts`）: 既存ルール戦略を executor 形式へ移植した v1 シード（現在 arb / lp / venue / aave / statarb / cvbal / dnlp / gmxperp / gmxrev / gmxtrend / fairmm / jitlp / ladder の 13 種）。`ERIS_BASE_STRATEGY=<id>` で claude-llm が v1 として決定論シードする。
+- **live revise**: sim 実行中、claude-llm エージェントが N ラウンドごと（既定 10）に `claude -p`（print mode CLI）を**背景で** spawn し、単一 JSON `{notes, params, executor_ts}` を受け取って戦略を差し替える（`src/llm/claudeCliStrategist.ts` / `src/llm/prompts.ts` の `buildReviseMessage`）。**品質ゲートは無く即適用**。
+- **offline 進化**: `/strategy-evolve` スキルが、マルチシードのペアゲート（`src/multiSeedRun.ts`）で過学習を抑えつつ 1 agent / 1 変更ずつ進化させ、勝者を恒久化する想定。
+
+実走で以下が観測・確認された:
+
+- 13 戦略すべてが live で実際に自己改善できる（`ERIS_LLM_CALL_TIMEOUT_MS` 緩和＋ revise スケジュール分散で revise 24/24 成功、各 v2〜v4）。
+- 一方で **LLM が存在しないバグを「修正」して劣化させる**ことがある（例: `venue` の revise が「`balancerSwap`/`curveSwap` は無効」と誤認。実際は `src/action.ts` が受理する有効 action）。live には品質ゲートが無いため、この劣化がそのまま適用される。
+- `claude -p` は `--disallowed-tools` に `SlashCommand` 等を含み、かつ単一 JSON・高速・背景実行が要件のため、**live revise でスキルは使えない／使うべきでない**。
+- 改善のフィードバックが「自分の直近 12 ラウンド＋集計 PnL%」のみで、**何が効いて何が損したかの帰属（attribution）が弱い**。探索も漸進 refine のみで単調。
+
+### 解決したい課題
+
+- live の自己改善で**ハルシネーションによる劣化を即適用してしまう**。
+- 改善判断の材料が弱い（**帰属・メモリ・レジーム情報が無い**）。
+- 探索が単調（**単一候補・漸進のみ**で戦略空間を広げられない）。
+- 「より自己改善を促す仕組み」を、live の高速・ツール無し制約と両立させたい。
+
+### 検討した選択肢
+
+1. **live revise のプロンプト/ロジックだけ強化**（単層・online のみ）
+2. **offline スキル（`/strategy-evolve`）だけ強化**（単層・offline のみ。live は現状維持）
+3. **live revise を Claude Code スキル化**して高機能化（スキルで帰属・ゲート・多候補を担わせる）
+4. **2層アーキテクチャ（本 ADR の採用案）**: live（online・プロンプト強化＋弱ゲート）と offline（agentic スキル・強ゲート・恒久昇格）を、共有コアで連携させる
+
+### 各選択肢の評価
+
+| 観点 | 1: live のみ | 2: offline のみ | 3: live をスキル化 | 4: 2層（採用） |
+|------|---|---|---|---|
+| 劣化（ハルシネ）抑止 | △ 文言のみ・実測不可 | ○ 強ゲート | ○ | ◎ live弱＋offline強 |
+| 改善の実測検証 | ✗ chain再実行不可 | ◎ multi-seed PnL | ◎ | ◎（offlineが担当） |
+| live での即時適応 | ◎ | ✗ 無い | △ 多ツールで遅延/ハング | ◎ |
+| 実装コスト | 低 | 中 | 高（CLI制約と衝突） | 中（段階導入可） |
+| `claude -p` 制約との整合 | ◎ | n/a | ✗ skill不可・単一JSON崩れる | ◎（liveは非skill） |
+| 探索の多様性 | △ | ○ 多候補 | ○ | ◎ |
+
+選択肢 3 は、`claude -p` がスキルを使えない／単一 JSON・高速要件と本質的に衝突するため不採用。選択肢 1・2 は片肺。**両者は別レイヤーで補完し合い、共有表現（`Strategy`）でループを閉じられる**ため、選択肢 4 を採用する。
+
+## Decision
+
+**LLM 戦略自己改善を「A: in-sim online revise（プロンプト強化＋ sanity ゲート）」と「B: offline agentic 進化スキル（強ゲート＋恒久昇格）」の2層に分け、`prompts.ts` / `Strategy` 表現 / `multiSeedRun` ゲート / `baseStrategies.ts` / change→result メモリ からなる共有コアで連携させる。スキル化は B（offline）にのみ適用し、A（live）は `claude -p` の単一 JSON・高速・ツール無し設計を維持する。**
+
+### 1. レイヤー構成と責務
+
+```
+        ┌──────────── 共有コア（単一ソース）────────────┐
+        │ prompts.ts（SYSTEM/SIM_RULES/反ハルシネ/出力契約）│
+        │ strategy.ts（Strategy型 + parse/validate + 帰属）│
+        │ baseStrategies.ts ← B が勝者を書き戻し / A が seed │
+        │ multiSeedRun.ts（ペアゲート）A=弱 / B=強 で再利用  │
+        │ memory（change→result 履歴）A も B も読む          │
+        └──────┬───────────────────────────┬─────────────┘
+   seed(ERIS_BASE_STRATEGY)│               │ 候補(live strategy-vN を収穫)
+                           ▼               ▲
+   A: in-sim online                   B: offline skill (/strategy-evolve)
+   ・Nラウンドごと claude -p revise     ・run診断→多候補→強ゲート→恒久昇格
+   ・単一JSON / 高速 / ツール無し        ・baseStrategies.ts へ commit
+   ・sanity ゲートで劣化を即適用しない    ・live版を候補に収穫
+        └──── 改良版を供給 ──► B ──── 良seed を底上げ ──► A
+```
+
+- **A（live / online）**: その run 内で戦略を適応。真の PnL ゲートは持てない（chain 再実行が必要）ため、**コンパイル＋直近観測での valid-action / 非退化チェック（sanity ゲート）**に限定。
+- **B（offline / agentic）**: run を実走して**真の multi-seed PnL でゲート**し、勝者を `baseStrategies.ts` に恒久昇格。スキルなのでフルツール（Bash で sim 実行、ログ Read、ペア replay）・多ターン・メモリ運用が可能。
+
+### 2. 共有データ構造
+
+```ts
+// 帰属（RoundRecord.inventoryUsd 差分を action.type で集計。新規プラミング不要）
+type Attribution = { byAction: Record<string,{rounds:number; netUsd:number; valid:number; failed:number}>;
+  topNoopReasons: Array<[string,number]>; drawdownUsd:number; turnover:number };
+
+// Change Contract（revise 出力 JSON を拡張。executor 改変時のみ重く）
+type StrategyOutput = { notes:string; params:object; executor_ts:string;
+  change_type:"params_only"|"executor_logic"; hypothesis:string;
+  expected:string; rollback_condition:string; why_executor_change?:string };
+
+// Memory レコード（runs/strategy-iterations/ + 共有 memory）
+// 例: "v3 (params_only): gapThreshold 0.0008→0.0012 -> fail率↓ / PnL -1.2% → 却下, 旧版維持"
+```
+
+### 3. A（live）の変更点（ファイルフック）
+
+- `src/llm/prompts.ts`: `SYSTEM_PROMPT` に**反ハルシネ規則**（観測に無いバグを仮定しない／executor 改変は直近ログの具体的失敗を引用／不明なら no-change）を追記。`buildReviseMessage` に **Attribution ブロック**と **Memory 直近数件**を追加し、**Change Contract を必須・既定 params-only** とする。
+- `src/llm/strategy.ts`（`parseStrategyFromToolInput`）: Change Contract を optional メタとして受理し、**`change_type!=="executor_logic"` のとき `executor_ts` を無視して `prev.executorTs` を流用**（無根拠な executor 改変を構造的に封じる）。
+- `src/llm/claudeAgent.ts`（revise 適用点 `state.strategy = result.strategy`）: **sanity ゲート**を挿入。State に直近 K 個の `AgentObservation` をリング保存し、新 executor がそれらで「valid な非 noop を 1 つ以上出す／全 noop 退化でない」ことを確認。満たさねば旧版維持＋却下理由を memory へ。
+- `src/llm/claudeCliStrategist.ts`: 構造変更なし（単一 JSON のまま、中身に Change Contract が乗る）。
+
+### 4. B（offline）の変更点（`/strategy-evolve` スキル）
+
+1. マルチシード baseline run（既存）
+2. **帰属診断**: `events.jsonl` の per-round inventory 系列＋ action ログから最弱 agent と出血 action を特定（既存の最弱診断を attribution ベースへ）
+3. **多候補生成**: exploit 版＋ explore 版を K 個（各 Change Contract 付き・共有 prompts を使用）
+4. **強ゲート**: `multiSeedRun.ts` で旧版 vs 候補を paired 実走 → PnL/DD/失敗率で非劣化の勝者のみ採用
+5. **恒久昇格**: 勝者を `baseStrategies.ts` の該当ベースへ書き戻し commit。過去 live run の `agent-*/strategy-vN` も候補として収穫（A→B 供給路）
+6. **メモリ**: change→result を蓄積し A の `buildReviseMessage` に注入
+
+### 5. 段階導入
+
+A-1（prompts 文言: 反ハルシネ＋ params-only 既定＋ Change Contract）→ A-2（Attribution ブロック）→ A-3（live sanity ゲート）→ B-1（帰属診断＋多候補＋強ゲート昇格）→ B-2（live 版収穫＋ memory 共有でループ閉）。各段は独立に価値を持つ。
+
+## Consequences
+
+### Positive
+
+- live の即時適応と offline の厳格検証を**両取り**できる（探索 = live、昇格 = offline）。
+- 共有表現（`Strategy`）と共有コアにより、**A↔B が相互強化**（A が改良ネタを供給、B が良 seed を底上げ）。
+- `claude -p` の制約（skill 不可・単一 JSON・高速）を壊さずに自己改善を強化できる。
+- ハルシネ劣化を、A=構造的抑止（params-only 既定・反ハルシネ）＋ sanity、B=実測ゲートの**二重**で防げる。
+
+### Negative
+
+- 仕組みが2層になり**複雑度が増す**。
+  - → 共有コアに一元化（prompts/strategy/multiSeedRun/baseStrategies/memory）し、二重実装・文言乖離を避ける。
+- B はトークン・計算コストが大きい（multi-seed × 多候補）。
+  - → `/strategy-evolve` は元々マルチシード前提。候補数 K と頻度を抑え、A で安価に探索してから B で選別。
+- live sanity ゲートは**真の PnL を見ない**ため、PnL を悪化させる「正気だが弱い」変更は通り得る。
+  - → 恒久昇格は必ず B の real PnL ゲートを通す。live の劣化は run 内に限定され、実行時 `parseAction→noop` で暴走は阻止される。
+
+### Risks
+
+- **メモリの陳腐化**: 古いレジームの「効いた変更」に引きずられる。
+  - → memory に regime タグを付け、直近・同一 regime を優先注入。
+- **ゲートが保守的すぎて探索が止まる**: 非劣化条件が厳しいと改善が採用されない。
+  - → A は探索を許容（弱ゲート）、B のみ厳格。閾値は P1/P3 データで調整（ADR 0001 の識別力ハーネスと整合）。
+- **`helpers.ADDRESSES` が mainnet 値**（`strategy.ts`）: LLM が `rawTx` 方向へ revise すると Arbitrum 上で誤アドレスになる潜在バグ。
+  - → 当面 prompts で「semantic action（swap/mintLiquidity 等）優先・rawTx は非推奨」を明示。別途アドレス修正を検討。
+
+## 決めていないこと
+
+| 項目 | 決めない理由 | いつ決めるか |
+|------|------------|------------|
+| 帰属の精緻度（手数料/スリッページ/約定後価格まで含めるか） | まず inventoryUsd 差分の安価版で十分か見極める | A-2 実装後のデータで判断 |
+| 多候補数 K と explore/exploit 比 | コストと効果のバランスを実測で決める | B-1 実装後 |
+| live sanity ゲートの合否基準（非退化の定義） | 過度に塞ぐと探索が死ぬため実走で調整 | A-3 試走後 |
+| competitor/regime 特徴量を観測へ常設するか | 過剰適合リスクがあり効果未検証 | B-1 以降に A/B テスト |
+
+## Notes
+
+### 参考資料
+
+- ADR 0001: 多エージェント競争プラットフォーム — 環境の「識別力」を主軸に（`multiSeedRun.ts` のペアゲート / 識別力ハーネスは本 ADR の B 強ゲートの土台）
+- 主要モジュール: `src/llm/prompts.ts` / `src/llm/strategy.ts` / `src/llm/baseStrategies.ts` / `src/llm/claudeAgent.ts` / `src/llm/claudeCliStrategist.ts` / `src/llm/history.ts` / `src/multiSeedRun.ts`
+- スキル: `/strategy-evolve`（offline 進化, 対象ロスター `agents.evolve.json`）/ `/sim-loop`
+- 経緯: `claude -p` はスキル不可（CLI help: `--disable-slash-commands`=「Disable all skills」/ skills は `/skill-name` で解決）。live revise は `--disallowed-tools` で `SlashCommand` 等を無効化しているため、自己改善プロンプトのスキル化は offline(B) のみが適切、という結論に至った。

--- a/docs/adr/0002-llm-strategy-self-improvement-two-layer.md
+++ b/docs/adr/0002-llm-strategy-self-improvement-two-layer.md
@@ -111,6 +111,15 @@ type StrategyOutput = { notes:string; params:object; executor_ts:string;
 
 A-1（prompts 文言: 反ハルシネ＋ params-only 既定＋ Change Contract）→ A-2（Attribution ブロック）→ A-3（live sanity ゲート）→ B-1（帰属診断＋多候補＋強ゲート昇格）→ B-2（live 版収穫＋ memory 共有でループ閉）。各段は独立に価値を持つ。
 
+### 6. レビューでの決定（2026-06-07）
+
+設計レビューで以下を確定した（実装の指針）:
+
+- **着手順**: A と B を**並行**で進める（最速で全体像を立てる。共有コア=prompts/strategy/multiSeedRun/baseStrategies/memory を先に固定し、A・B の同時改変による乖離を防ぐ）。
+- **live の executor 改変ポリシー**: **params-only を既定**とし、直近ログの具体的失敗を引用した場合のみ executor 改変を許可（条件付き）。
+- **PnL 帰属の粒度**: まず**安価版**（`RoundRecord.inventoryUsd` 差分 × `action.type` 集計）で実装。手数料/スリッページ/反事実への拡張は効果を見てから（「決めていないこと」参照）。
+- **ADR Status**: 当面 **Proposed のまま**で段階実装により検証し、効果確認後に Accepted へ。
+
 ## Consequences
 
 ### Positive

--- a/examples/agents/aave-arb.ts
+++ b/examples/agents/aave-arb.ts
@@ -4,11 +4,12 @@
  * - 価格差が小さい (< 0.15%) → 遊休 USDC を Aave に supply して利回りを稼ぐ
  * - 価格差が大きい (>= 0.15%) → Aave から withdraw して Uniswap で swap
  *
- * 外部 CLI 不要。viem + examples/lib/aave.ts のみで完結。
+ * 外部 CLI 不要。viem + examples/lib/aave.ts + src/constants.ts(Arbitrum アドレス)で完結。
  */
 import { createInterface } from "node:readline";
 import { createPublicClient, encodeFunctionData, http } from "viem";
 import { mainnet } from "viem/chains";
+import { TOKENS, UNISWAP } from "../../src/constants.js";
 import { buildAaveSupply, buildAaveWithdraw } from "../lib/aave.js";
 
 const agentAddress = process.env.ERIS_AGENT_ADDRESS ?? "";
@@ -18,56 +19,106 @@ if (!agentAddress || !rpcUrl) {
   process.exit(1);
 }
 
-const publicClient = createPublicClient({ chain: mainnet, transport: http(rpcUrl) });
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http(rpcUrl),
+});
 
-const SWAP_ROUTER = "0xE592427A0AEce92De3Edee1F18E0157C05861564";
-const WETH_ADDR = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const USDC_ADDR = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
-const QUOTER_V2 = "0x61fFE014bA17989E743c5F6cB21bF9697530B21e";
-const FEE = 500;
+// sim は Arbitrum フォーク。アドレスは src/constants.ts の Arbitrum 値を使う
+// （mainnet ハードコードだと raw tx が存在しないコントラクトに当たり機能しない）。
+const SWAP_ROUTER = UNISWAP.swapRouter;
+const WETH_ADDR = TOKENS.WETH.address;
+const USDC_ADDR = TOKENS.USDC.address;
+const QUOTER_V2 = UNISWAP.quoterV2;
+const FEE = UNISWAP.fee;
 
-const quoterAbi = [{
-  type: "function", name: "quoteExactInputSingle", stateMutability: "nonpayable",
-  inputs: [{ type: "tuple", components: [
-    { name: "tokenIn", type: "address" }, { name: "tokenOut", type: "address" },
-    { name: "amountIn", type: "uint256" }, { name: "fee", type: "uint24" },
-    { name: "sqrtPriceLimitX96", type: "uint160" }
-  ]}],
-  outputs: [
-    { name: "amountOut", type: "uint256" }, { name: "sqrtPriceX96After", type: "uint160" },
-    { name: "initializedTicksCrossed", type: "uint32" }, { name: "gasEstimate", type: "uint256" }
-  ]
-}] as const;
+const quoterAbi = [
+  {
+    type: "function",
+    name: "quoteExactInputSingle",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        type: "tuple",
+        components: [
+          { name: "tokenIn", type: "address" },
+          { name: "tokenOut", type: "address" },
+          { name: "amountIn", type: "uint256" },
+          { name: "fee", type: "uint24" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "amountOut", type: "uint256" },
+      { name: "sqrtPriceX96After", type: "uint160" },
+      { name: "initializedTicksCrossed", type: "uint32" },
+      { name: "gasEstimate", type: "uint256" },
+    ],
+  },
+] as const;
 
-const swapRouterAbi = [{
-  type: "function", name: "exactInputSingle", stateMutability: "payable",
-  inputs: [{ type: "tuple", name: "params", components: [
-    { name: "tokenIn", type: "address" }, { name: "tokenOut", type: "address" },
-    { name: "fee", type: "uint24" }, { name: "recipient", type: "address" },
-    { name: "deadline", type: "uint256" }, { name: "amountIn", type: "uint256" },
-    { name: "amountOutMinimum", type: "uint256" }, { name: "sqrtPriceLimitX96", type: "uint160" }
-  ]}],
-  outputs: [{ name: "amountOut", type: "uint256" }]
-}] as const;
+const swapRouterAbi = [
+  {
+    type: "function",
+    name: "exactInputSingle",
+    stateMutability: "payable",
+    inputs: [
+      {
+        type: "tuple",
+        name: "params",
+        components: [
+          { name: "tokenIn", type: "address" },
+          { name: "tokenOut", type: "address" },
+          { name: "fee", type: "uint24" },
+          { name: "recipient", type: "address" },
+          { name: "deadline", type: "uint256" },
+          { name: "amountIn", type: "uint256" },
+          { name: "amountOutMinimum", type: "uint256" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+        ],
+      },
+    ],
+    outputs: [{ name: "amountOut", type: "uint256" }],
+  },
+] as const;
 
 async function buildSwapRawTx(
-  tokenIn: string, tokenOut: string, amountIn: bigint
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
 ): Promise<{ to: string; data: string } | null> {
   try {
     const { result } = await publicClient.simulateContract({
-      address: QUOTER_V2 as `0x${string}`, abi: quoterAbi,
+      address: QUOTER_V2 as `0x${string}`,
+      abi: quoterAbi,
       functionName: "quoteExactInputSingle",
-      args: [{ tokenIn: tokenIn as `0x${string}`, tokenOut: tokenOut as `0x${string}`, amountIn, fee: FEE, sqrtPriceLimitX96: 0n }]
+      args: [
+        {
+          tokenIn: tokenIn as `0x${string}`,
+          tokenOut: tokenOut as `0x${string}`,
+          amountIn,
+          fee: FEE,
+          sqrtPriceLimitX96: 0n,
+        },
+      ],
     });
     const amountOutMin = (result[0] * 9950n) / 10000n;
     const data = encodeFunctionData({
-      abi: swapRouterAbi, functionName: "exactInputSingle",
-      args: [{
-        tokenIn: tokenIn as `0x${string}`, tokenOut: tokenOut as `0x${string}`,
-        fee: FEE, recipient: agentAddress as `0x${string}`,
-        deadline: BigInt(Math.floor(Date.now() / 1000) + 600),
-        amountIn, amountOutMinimum: amountOutMin, sqrtPriceLimitX96: 0n
-      }]
+      abi: swapRouterAbi,
+      functionName: "exactInputSingle",
+      args: [
+        {
+          tokenIn: tokenIn as `0x${string}`,
+          tokenOut: tokenOut as `0x${string}`,
+          fee: FEE,
+          recipient: agentAddress as `0x${string}`,
+          deadline: BigInt(Math.floor(Date.now() / 1000) + 600),
+          amountIn,
+          amountOutMinimum: amountOutMin,
+          sqrtPriceLimitX96: 0n,
+        },
+      ],
     });
     return { to: SWAP_ROUTER, data };
   } catch (error) {
@@ -85,8 +136,16 @@ const rl = createInterface({ input: process.stdin });
 rl.on("line", async (line) => {
   try {
     const obs = JSON.parse(line);
-    const poolPrice: number = obs.pool.priceUsdcPerWeth;
+    // プール価格は protocols.uniswap.pool 配下。uniswap が無効なら裁定できないので noop。
+    const poolPrice: number | undefined =
+      obs.protocols?.uniswap?.pool?.priceUsdcPerWeth;
     const fairPrice: number = obs.fairPriceUsdcPerWeth;
+    if (typeof poolPrice !== "number" || !(poolPrice > 0)) {
+      process.stdout.write(
+        `${JSON.stringify({ type: "noop", reason: "uniswap pool price unavailable" })}\n`,
+      );
+      return;
+    }
     const gap = fairPrice / poolPrice - 1;
     const absGap = Math.abs(gap);
     const usdcBalance = Number(BigInt(obs.balances.usdcUnits)) / 1e6;
@@ -95,17 +154,21 @@ rl.on("line", async (line) => {
     if (absGap < 0.0015) {
       const supplyAmount = Math.floor(usdcBalance * 0.5);
       if (supplyAmount < 10) {
-        process.stdout.write(`${JSON.stringify({ type: "noop", reason: "gap small, insufficient USDC to supply" })}\n`);
+        process.stdout.write(
+          `${JSON.stringify({ type: "noop", reason: "gap small, insufficient USDC to supply" })}\n`,
+        );
         return;
       }
 
       const txs = buildAaveSupply("USDC", supplyAmount, agentAddress);
       suppliedUsdc += supplyAmount;
-      process.stdout.write(`${JSON.stringify({
-        type: "rawBundle",
-        txs,
-        maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei
-      })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({
+          type: "rawBundle",
+          txs,
+          maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei,
+        })}\n`,
+      );
       return;
     }
 
@@ -120,45 +183,61 @@ rl.on("line", async (line) => {
     // Swap
     const tokenInAddr = gap > 0 ? USDC_ADDR : WETH_ADDR;
     const tokenOutAddr = gap > 0 ? WETH_ADDR : USDC_ADDR;
-    const maxLimit = BigInt(tokenInAddr === WETH_ADDR ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+    const maxLimit = BigInt(
+      tokenInAddr === WETH_ADDR
+        ? obs.limits.maxWethInWei
+        : obs.limits.maxUsdcInUnits,
+    );
     const sizeBps = Math.min(2500, Math.max(250, Math.floor(absGap * 200_000)));
     const amountIn = (maxLimit * BigInt(sizeBps)) / 10_000n;
 
     if (amountIn <= 0n) {
-      process.stdout.write(`${JSON.stringify({ type: "noop", reason: "computed swap amount is zero" })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({ type: "noop", reason: "computed swap amount is zero" })}\n`,
+      );
       return;
     }
 
     const swapTx = await buildSwapRawTx(tokenInAddr, tokenOutAddr, amountIn);
     if (!swapTx) {
       if (allTxs.length > 0) {
-        process.stdout.write(`${JSON.stringify({
-          type: allTxs.length === 1 ? "rawTx" : "rawBundle",
-          ...(allTxs.length === 1 ? { tx: allTxs[0] } : { txs: allTxs }),
-          maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei
-        })}\n`);
+        process.stdout.write(
+          `${JSON.stringify({
+            type: allTxs.length === 1 ? "rawTx" : "rawBundle",
+            ...(allTxs.length === 1 ? { tx: allTxs[0] } : { txs: allTxs }),
+            maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei,
+          })}\n`,
+        );
         return;
       }
-      process.stdout.write(`${JSON.stringify({ type: "noop", reason: "swap build failed" })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({ type: "noop", reason: "swap build failed" })}\n`,
+      );
       return;
     }
 
     allTxs.push(swapTx);
 
     if (allTxs.length === 1) {
-      process.stdout.write(`${JSON.stringify({
-        type: "rawTx",
-        tx: allTxs[0],
-        maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei
-      })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({
+          type: "rawTx",
+          tx: allTxs[0],
+          maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei,
+        })}\n`,
+      );
     } else {
-      process.stdout.write(`${JSON.stringify({
-        type: "rawBundle",
-        txs: allTxs,
-        maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei
-      })}\n`);
+      process.stdout.write(
+        `${JSON.stringify({
+          type: "rawBundle",
+          txs: allTxs,
+          maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei,
+        })}\n`,
+      );
     }
   } catch (error) {
-    process.stdout.write(`${JSON.stringify({ type: "noop", reason: `error: ${error}` })}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: `error: ${error}` })}\n`,
+    );
   }
 });

--- a/examples/agents/aave-loop.ts
+++ b/examples/agents/aave-loop.ts
@@ -1,0 +1,95 @@
+// aave-loop (GitHub #6): Aave V3 の supply/borrow を多段ループする leveraged WETH carry。
+// WETH supply → USDC borrow → USDC を WETH に swap → 再 supply を繰り返し targetLtv まで建てる。
+// 各ラウンド obs.protocols.aave の collateral/debt/availableBorrows から状態を再構成する素朴版
+// (aave-leverage.ts の発展)。RPC 不要・semantic action のみ。
+//
+// env:
+//   AAVE_LOOP_TARGET_LTV       目標 LTV(default 0.7)
+//   AAVE_LOOP_BORROW_FRACTION  availableBorrows の borrow 比率(default 0.8)
+//   AAVE_LOOP_SLIPPAGE_BPS     swap slippage(default 75)
+import { createInterface } from "node:readline";
+
+const TARGET_LTV = floatEnv("AAVE_LOOP_TARGET_LTV", 0.7);
+const BORROW_FRACTION = floatEnv("AAVE_LOOP_BORROW_FRACTION", 0.8);
+const SLIPPAGE_BPS = intEnv("AAVE_LOOP_SLIPPAGE_BPS", 75);
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  try {
+    const obs = JSON.parse(line);
+    const aave = obs.protocols?.aave;
+    const fee = obs.limits.defaultPriorityFeePerGasWei;
+    if (!aave) {
+      out({ type: "noop", reason: "aave disabled" });
+      return;
+    }
+    const wethWei = BigInt(obs.balances.wethWei);
+    const usdcUnits = BigInt(obs.balances.usdcUnits);
+    const maxIn = BigInt(obs.limits.maxUsdcInUnits);
+    const coll = Number(aave.totalCollateralBase) / 1e8;
+    const debt = Number(aave.totalDebtBase) / 1e8;
+    const avail = Number(aave.availableBorrowsBase) / 1e8;
+    const underTarget = coll === 0 || debt / coll < TARGET_LTV;
+
+    // 1) 手元 WETH を supply して担保を積む(初期 WETH + swap で得た WETH。carry の土台)
+    if (wethWei > 0n && underTarget) {
+      const maxSupply = BigInt(obs.limits.maxAaveSupplyWethWei);
+      const amt = wethWei < maxSupply ? wethWei : maxSupply;
+      if (amt > 0n) {
+        out({
+          type: "aaveSupply",
+          asset: "WETH",
+          amount: amt.toString(),
+          maxPriorityFeePerGasWei: fee,
+        });
+        return;
+      }
+    }
+    // 2) 目標 LTV 未満で借入余力があれば USDC borrow
+    if (underTarget && coll > 0) {
+      const borrowUsd = Math.floor(avail * BORROW_FRACTION);
+      if (borrowUsd >= 10) {
+        const maxBorrow = BigInt(obs.limits.maxAaveBorrowUsdcUnits);
+        const want = BigInt(borrowUsd) * 1_000_000n;
+        const amt = want < maxBorrow ? want : maxBorrow;
+        if (amt > 0n) {
+          out({
+            type: "aaveBorrow",
+            asset: "USDC",
+            amount: amt.toString(),
+            maxPriorityFeePerGasWei: fee,
+          });
+          return;
+        }
+      }
+    }
+    // 3) 借りた native USDC を WETH へ swap(maxUsdcInUnits で上限。native 残高超過 reject を回避)
+    if (underTarget && coll > 0 && usdcUnits > 1_000_000n) {
+      const amountIn = usdcUnits < maxIn ? usdcUnits : maxIn;
+      out({
+        type: "swap",
+        tokenIn: "USDC",
+        amountIn: amountIn.toString(),
+        slippageBps: SLIPPAGE_BPS,
+        maxPriorityFeePerGasWei: fee,
+      });
+      return;
+    }
+    out({ type: "noop", reason: "target leverage reached" });
+  } catch (error) {
+    out({ type: "noop", reason: `error: ${error}` });
+  }
+});
+
+function out(action: unknown): void {
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+}
+function floatEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+function intEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isInteger(v) && v > 0 ? v : fallback;
+}

--- a/examples/agents/cross-venue-arb.ts
+++ b/examples/agents/cross-venue-arb.ts
@@ -1,0 +1,88 @@
+// cross-venue-arb (GitHub #4): uniswap/balancer/curve のうち最安 venue で買い・最高 venue で
+// 売る 2-leg 裁定。cv-bal-arb.ts(bal↔curve 限定)を 3 venue の最大乖離ペアへ一般化したもの。
+// 注: 別 fee-tier / Uniswap v2 は観測に含まれないため対象外(uni 0.05% + balancer + curve のみ)。
+// RPC 不要・semantic action のみ。
+//
+// env:
+//   CROSS_VENUE_SPREAD_BPS  発注する最小スプレッド(bps, default 10)
+import { createInterface } from "node:readline";
+
+const SPREAD_BPS = intEnv("CROSS_VENUE_SPREAD_BPS", 10);
+const SIZE_BPS_MIN = 250;
+const SIZE_BPS_MAX = 5000;
+const SLIPPAGE_BPS = 75;
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  try {
+    const obs = JSON.parse(line);
+    const p = obs.protocols ?? {};
+    const fee = obs.limits.defaultPriorityFeePerGasWei;
+    const venues: Array<{ swapType: string; price: number }> = [];
+    if (p.uniswap?.pool?.priceUsdcPerWeth > 0)
+      venues.push({ swapType: "swap", price: p.uniswap.pool.priceUsdcPerWeth });
+    if (p.balancer?.priceUsdcPerWeth > 0)
+      venues.push({
+        swapType: "balancerSwap",
+        price: p.balancer.priceUsdcPerWeth,
+      });
+    if (p.curve?.priceUsdcPerWeth > 0)
+      venues.push({ swapType: "curveSwap", price: p.curve.priceUsdcPerWeth });
+    if (venues.length < 2) {
+      out({ type: "noop", reason: "need >=2 venues" });
+      return;
+    }
+    let lo = venues[0];
+    let hi = venues[0];
+    for (const v of venues) {
+      if (v.price < lo.price) lo = v;
+      if (v.price > hi.price) hi = v;
+    }
+    const spread = hi.price / lo.price - 1;
+    if (spread < SPREAD_BPS / 10_000 || lo.swapType === hi.swapType) {
+      out({ type: "noop", reason: "spread too small" });
+      return;
+    }
+    const sizeBps = Math.min(
+      SIZE_BPS_MAX,
+      Math.max(SIZE_BPS_MIN, Math.floor(spread * 200_000)),
+    );
+    const usdcIn =
+      (BigInt(obs.limits.maxUsdcInUnits) * BigInt(sizeBps)) / 10_000n;
+    const wethIn =
+      (BigInt(obs.limits.maxWethInWei) * BigInt(sizeBps)) / 10_000n;
+    if (usdcIn <= 0n || wethIn <= 0n) {
+      out({ type: "noop", reason: "computed size zero" });
+      return;
+    }
+    out({
+      type: "bundle",
+      actions: [
+        {
+          type: lo.swapType,
+          tokenIn: "USDC",
+          amountIn: usdcIn.toString(),
+          slippageBps: SLIPPAGE_BPS,
+        },
+        {
+          type: hi.swapType,
+          tokenIn: "WETH",
+          amountIn: wethIn.toString(),
+          slippageBps: SLIPPAGE_BPS,
+        },
+      ],
+      maxPriorityFeePerGasWei: fee,
+    });
+  } catch (error) {
+    out({ type: "noop", reason: `error: ${error}` });
+  }
+});
+
+function out(action: unknown): void {
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+}
+function intEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isInteger(v) && v > 0 ? v : fallback;
+}

--- a/examples/agents/fair-mm.ts
+++ b/examples/agents/fair-mm.ts
@@ -1,0 +1,403 @@
+import { createInterface } from "node:readline";
+import { priceToTick, tickToPrice } from "../lib/tick-math.js";
+
+// Fair-price-anchored narrow-range LP market-maker.
+//
+// Strategy:
+//  - Center an LP range on `fairPriceUsdcPerWeth`, not the live pool tick.
+//  - Range half-width = `tickSpacing * FAIR_MM_RANGE_TICK_MULTIPLIER` (N=4..8).
+//  - Hold the position across rounds; rebalance (removeLiquidity + collectFees
+//    in a single bundle, then mint on the next round) only when fair drifts
+//    past half the range from our stored midpoint, OR when the position drifts
+//    out of range and is no longer earning fees.
+//  - Otherwise emit `collectFees` if there are uncollected fees, else `noop`.
+//  - WETH:USDC inventory ratio uses fair price, not pool price, so the mint
+//    target sizing reflects what we believe is the true mid.
+
+type ObservationPosition = {
+  tokenId: string;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: string;
+  tokensOwedWethWei: string;
+  tokensOwedUsdcUnits: string;
+  amountWethWei: string;
+  amountUsdcUnits: string;
+  valueUsdc: number;
+};
+
+type Observation = {
+  round: number;
+  pool: {
+    priceUsdcPerWeth: number;
+    tick: number;
+    tickSpacing: number;
+    fee: number;
+    pair: string;
+  };
+  fairPriceUsdcPerWeth: number;
+  positions: ObservationPosition[];
+  balances: {
+    ethWei: string;
+    wethWei: string;
+    usdcUnits: string;
+  };
+  inventory: {
+    valueUsdc: number;
+    weth: number;
+    usdc: number;
+    eth: number;
+  };
+  limits: {
+    defaultPriorityFeePerGasWei: string;
+    maxPriorityFeePerGasWei: string;
+    defaultSlippageBps: number;
+    maxBundleActions: number;
+    maxLpWethWei: string;
+    maxLpUsdcUnits: string;
+    maxOpenPositions: number;
+  };
+};
+
+const RANGE_TICK_MULTIPLIER = clampInt(
+  parseIntEnv("FAIR_MM_RANGE_TICK_MULTIPLIER", 4),
+  1,
+  64,
+);
+const MINT_BUDGET_BPS = clampInt(
+  parseIntEnv("FAIR_MM_MINT_BUDGET_BPS", 3500),
+  1,
+  10_000,
+);
+const REMINT_THRESHOLD_BPS = clampInt(
+  parseIntEnv("FAIR_MM_REMINT_THRESHOLD_BPS", 150),
+  1,
+  10_000,
+);
+
+const MIN_WETH_MINT_WEI = 5_000_000_000_000_000n; // 0.005 WETH
+const MIN_USDC_MINT_UNITS = 10_000_000n; // 10 USDC
+const LOG_BASE = Math.log(1.0001);
+
+// State held across rounds (process is long-lived per the harness contract).
+type ManagedRange = {
+  tokenId: string;
+  tickLower: number;
+  tickUpper: number;
+  midTick: number;
+  fairAtMint: number;
+};
+let managed: ManagedRange | null = null;
+
+// 観測はネスト形 (protocols.uniswap.{pool,positions})。本戦略はトップレベル
+// pool/positions を前提にしたフラット形を使うため、パース後に正規化する。
+type RawObservation = Observation & {
+  protocols?: {
+    uniswap?: { pool?: Observation["pool"]; positions?: ObservationPosition[] };
+  };
+};
+
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let raw: RawObservation;
+  try {
+    raw = JSON.parse(line) as RawObservation;
+  } catch (err) {
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: `parse error: ${(err as Error).message}` })}\n`,
+    );
+    return;
+  }
+  const uni = raw.protocols?.uniswap;
+  if (!uni?.pool) {
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: "uniswap unavailable" })}\n`,
+    );
+    return;
+  }
+  const observation: Observation = {
+    ...raw,
+    pool: uni.pool,
+    positions: uni.positions ?? [],
+  };
+  const action = decide(observation);
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+});
+
+function decide(observation: Observation) {
+  const priorityFee = observation.limits.defaultPriorityFeePerGasWei;
+  const spacing = observation.pool.tickSpacing;
+  const halfWidthTicks = spacing * RANGE_TICK_MULTIPLIER;
+  const poolTick = observation.pool.tick;
+
+  // Refresh managed state from on-chain positions: if the tokenId we remember
+  // no longer exists or has zero liquidity, drop it. Otherwise prefer the
+  // matching on-chain position so we never act on a stale id.
+  const livePosition = pickLivePosition(observation, managed);
+  if (!livePosition) {
+    managed = null;
+  }
+
+  // Compute the fair tick using a pool-tick-anchored ratio so the orientation
+  // convention (token0/token1) cancels out: fairTick = poolTick + delta where
+  // delta = log(fairPrice/poolPrice) / log(1.0001).
+  const fairTickRaw = computeFairTickFromPool(observation);
+  // Fall back to absolute conversion if the pool price is degenerate.
+  const fairTickAligned =
+    fairTickRaw !== null
+      ? alignTick(fairTickRaw, spacing)
+      : alignTick(
+          priceToTick(observation.fairPriceUsdcPerWeth, spacing),
+          spacing,
+        );
+
+  // The mint center is the fair tick, but clamped so the resulting band still
+  // contains the current pool tick. If fair has wandered far from pool, this
+  // prevents minting a dead (out-of-range) position that earns no fees.
+  const centerTick = clampCenterToBracketPoolTick(
+    fairTickAligned,
+    poolTick,
+    halfWidthTicks,
+    spacing,
+  );
+
+  // No live position → consider minting.
+  if (!livePosition) {
+    return tryMint(observation, centerTick, halfWidthTicks, priorityFee);
+  }
+
+  // Live position exists. Decide between (a) rebalance, (b) collect fees, (c) noop.
+  const remembered = managed;
+  const driftFromCenter =
+    remembered === null
+      ? Math.abs(centerTick - midTick(livePosition))
+      : Math.abs(centerTick - remembered.midTick);
+
+  // Rebalance thresholds:
+  //  - drift in ticks >= full half-width (fair-derived target moved past the
+  //    band's edge) AND drift in price >= REMINT_THRESHOLD_BPS (guards against
+  //    gas-burning churn on low-volatility seeds where tick math wobbles)
+  //  - OR position is fully out of range AND moving the band would actually
+  //    bracket the pool tick again (so we don't churn while pool is far away)
+  const driftBps = computeDriftBpsSinceMint(observation, remembered);
+  const driftExceeds =
+    driftFromCenter >= Math.max(1, halfWidthTicks) &&
+    driftBps >= REMINT_THRESHOLD_BPS;
+  const outOfRange =
+    poolTick < livePosition.tickLower || poolTick > livePosition.tickUpper;
+  const newBandLower = centerTick - halfWidthTicks;
+  const newBandUpper = centerTick + halfWidthTicks;
+  const newBandWouldHelp =
+    poolTick >= newBandLower &&
+    poolTick <= newBandUpper &&
+    (centerTick !== midTick(livePosition) || !outOfRange);
+
+  if ((driftExceeds && newBandWouldHelp) || (outOfRange && newBandWouldHelp)) {
+    // Bundle remove + collect; the next round will mint anew.
+    const actions: Array<Record<string, unknown>> = [
+      {
+        type: "removeLiquidity",
+        tokenId: livePosition.tokenId,
+        liquidity: livePosition.liquidity,
+      },
+    ];
+    if (hasCollectableFees(livePosition)) {
+      actions.push({ type: "collectFees", tokenId: livePosition.tokenId });
+    }
+    // Clear local state; positions[] will reflect removal next round.
+    managed = null;
+    return {
+      type: "bundle",
+      maxPriorityFeePerGasWei: priorityFee,
+      actions,
+    };
+  }
+
+  if (hasCollectableFees(livePosition)) {
+    return {
+      type: "collectFees",
+      tokenId: livePosition.tokenId,
+      maxPriorityFeePerGasWei: priorityFee,
+    };
+  }
+
+  return { type: "noop", reason: "fair-MM range still centered" };
+}
+
+// Clamp the band center so `[center - halfWidth, center + halfWidth]` includes
+// poolTick. The center is always aligned to the spacing grid (so the mint
+// transaction passes validation).
+function clampCenterToBracketPoolTick(
+  fairCenter: number,
+  poolTick: number,
+  halfWidthTicks: number,
+  spacing: number,
+): number {
+  const minCenter = poolTick - halfWidthTicks;
+  const maxCenter = poolTick + halfWidthTicks;
+  const clamped = Math.max(minCenter, Math.min(maxCenter, fairCenter));
+  return alignTick(clamped, spacing);
+}
+
+function tryMint(
+  observation: Observation,
+  centerTick: number,
+  halfWidthTicks: number,
+  priorityFee: string,
+) {
+  if (observation.positions.length >= observation.limits.maxOpenPositions) {
+    return { type: "noop", reason: "max open LP positions reached" };
+  }
+
+  const tickLower = centerTick - halfWidthTicks;
+  const tickUpper = centerTick + halfWidthTicks;
+  if (tickLower >= tickUpper) {
+    return { type: "noop", reason: "computed tick range invalid" };
+  }
+
+  // Compute desired amounts using fair price for the WETH/USDC split.
+  // Target ratio: half value in WETH, half in USDC, where value uses fairPrice.
+  const wethBudget = capBudget(
+    BigInt(observation.balances.wethWei),
+    BigInt(observation.limits.maxLpWethWei),
+  );
+  const usdcBudget = capBudget(
+    BigInt(observation.balances.usdcUnits),
+    BigInt(observation.limits.maxLpUsdcUnits),
+  );
+
+  if (wethBudget < MIN_WETH_MINT_WEI || usdcBudget < MIN_USDC_MINT_UNITS) {
+    return { type: "noop", reason: "insufficient LP budget" };
+  }
+
+  // The pool itself will pick the actual ratio at mint time based on current
+  // tick vs [tickLower, tickUpper]. We just need to provide both sides large
+  // enough. Use full budget on both sides — the unused side is returned.
+  const amountWethDesired = wethBudget;
+  const amountUsdcDesired = usdcBudget;
+
+  managed = {
+    tokenId: "pending",
+    tickLower,
+    tickUpper,
+    midTick: centerTick,
+    fairAtMint: observation.fairPriceUsdcPerWeth,
+  };
+
+  return {
+    type: "mintLiquidity",
+    tickLower,
+    tickUpper,
+    amountWethDesired: amountWethDesired.toString(),
+    amountUsdcDesired: amountUsdcDesired.toString(),
+    maxPriorityFeePerGasWei: priorityFee,
+    slippageBps: Math.max(50, observation.limits.defaultSlippageBps),
+  };
+}
+
+function pickLivePosition(
+  observation: Observation,
+  remembered: ManagedRange | null,
+): ObservationPosition | null {
+  const live = observation.positions.filter((p) => BigInt(p.liquidity) > 0n);
+  if (live.length === 0) {
+    // We may still hold a zero-liquidity position object with uncollected fees.
+    if (remembered) {
+      const stale = observation.positions.find(
+        (p) => p.tokenId === remembered.tokenId,
+      );
+      if (stale && hasCollectableFees(stale)) return stale;
+    }
+    return null;
+  }
+  if (remembered) {
+    const match = live.find((p) => p.tokenId === remembered.tokenId);
+    if (match) {
+      // Sync managed state in case we restarted: backfill midTick.
+      managed = {
+        tokenId: match.tokenId,
+        tickLower: match.tickLower,
+        tickUpper: match.tickUpper,
+        midTick: midTick(match),
+        fairAtMint: remembered.fairAtMint,
+      };
+      return match;
+    }
+  }
+  // Adopt the most-recent live position (largest tokenId numerically).
+  const adopted = live.reduce((best, p) =>
+    BigInt(p.tokenId) > BigInt(best.tokenId) ? p : best,
+  );
+  managed = {
+    tokenId: adopted.tokenId,
+    tickLower: adopted.tickLower,
+    tickUpper: adopted.tickUpper,
+    midTick: midTick(adopted),
+    fairAtMint: observation.fairPriceUsdcPerWeth,
+  };
+  return adopted;
+}
+
+function computeFairTickFromPool(observation: Observation): number | null {
+  const pool = observation.pool.priceUsdcPerWeth;
+  const fair = observation.fairPriceUsdcPerWeth;
+  if (
+    !Number.isFinite(pool) ||
+    pool <= 0 ||
+    !Number.isFinite(fair) ||
+    fair <= 0
+  )
+    return null;
+  const delta = Math.log(fair / pool) / LOG_BASE;
+  return observation.pool.tick + delta;
+}
+
+function computeDriftBpsSinceMint(
+  observation: Observation,
+  remembered: ManagedRange | null,
+): number {
+  if (
+    !remembered ||
+    !Number.isFinite(remembered.fairAtMint) ||
+    remembered.fairAtMint <= 0
+  )
+    return 0;
+  const ratio = observation.fairPriceUsdcPerWeth / remembered.fairAtMint;
+  const driftBps = Math.abs(ratio - 1) * 10_000;
+  return driftBps;
+}
+
+function hasCollectableFees(
+  p: Pick<ObservationPosition, "tokensOwedWethWei" | "tokensOwedUsdcUnits">,
+): boolean {
+  return BigInt(p.tokensOwedWethWei) > 0n || BigInt(p.tokensOwedUsdcUnits) > 0n;
+}
+
+function midTick(p: ObservationPosition): number {
+  return Math.floor((p.tickLower + p.tickUpper) / 2);
+}
+
+function alignTick(tick: number, spacing: number): number {
+  return Math.floor(tick / spacing) * spacing;
+}
+
+function capBudget(balance: bigint, limit: bigint): bigint {
+  const capped = balance < limit ? balance : limit;
+  return (capped * BigInt(MINT_BUDGET_BPS)) / 10_000n;
+}
+
+function parseIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+// `tickToPrice` is re-exported indirectly via the helper module; we import it
+// to ensure the helper compiles into the dependency graph and stays callable
+// from tests / future agents.
+void tickToPrice;

--- a/examples/agents/flash-arb.ts
+++ b/examples/agents/flash-arb.ts
@@ -1,0 +1,81 @@
+// flash-arb (GitHub #3): フラッシュローンで自己資金上限を超えるサイズの cross-venue 裁定を行う。
+// uniswap(動的)と balancer(凍結参照価格)の乖離を見て、割安 venue で WETH 買い・割高 venue で
+// 売る 2-leg を FlashArb コントラクト内で 1 tx 実行する。agent は方向とサイズを決め、Aave
+// flashLoanSimple を rawTx で起動するだけ(FlashArb のアドレスは決定論的に計算)。
+//
+// 注: フラッシュローン受取コントラクト + rawTx 依存のため sandbox executor 化(LLM 自己改善)不可。
+// 利益が出ない場合は返済段で revert(アトミックなので資金損失はなく、gas のみ)。
+import { createInterface } from "node:readline";
+import { encodeAbiParameters } from "viem";
+import { TOKENS } from "../../src/constants.js";
+import { FLASH_ARB_ADDRESS } from "../../src/flashArbDemo.js";
+import { buildFlashLoanSimple } from "../lib/flash.js";
+
+const agentAddress = process.env.ERIS_AGENT_ADDRESS ?? "";
+const SPREAD_THRESHOLD = floatEnv("FLASH_ARB_SPREAD", 0.003); // 30 bps
+const FLASH_USDC = intEnv("FLASH_ARB_USDC", 15000); // フラッシュ借入 USDC(自己資金上限超)
+
+const paramsType = [
+  {
+    type: "tuple",
+    components: [
+      { name: "mode", type: "uint8" },
+      { name: "wethMinOut", type: "uint256" },
+      { name: "usdcMinOut", type: "uint256" },
+      { name: "profitTo", type: "address" },
+    ],
+  },
+] as const;
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  try {
+    const obs = JSON.parse(line);
+    const fee = obs.limits.defaultPriorityFeePerGasWei;
+    const uni = obs.protocols?.uniswap?.pool?.priceUsdcPerWeth;
+    const bal = obs.protocols?.balancer?.priceUsdcPerWeth;
+    if (!(uni > 0) || !(bal > 0)) {
+      out({ type: "noop", reason: "need uniswap+balancer prices" });
+      return;
+    }
+    const spread = Math.abs(uni / bal - 1);
+    if (spread < SPREAD_THRESHOLD) {
+      out({ type: "noop", reason: "spread too small" });
+      return;
+    }
+    // WETH が割安な venue で買う。uni < bal → uniswap 買い(mode 0)。else balancer 買い(mode 1)。
+    const mode = uni < bal ? 0 : 1;
+    const amount = BigInt(FLASH_USDC) * 1_000_000n;
+    // min-out は 0(返済段で利益不足なら atomic revert。sim 内に同 tx の敵対者はいない)。
+    const params = encodeAbiParameters(paramsType, [
+      {
+        mode,
+        wethMinOut: 0n,
+        usdcMinOut: 0n,
+        profitTo: agentAddress as `0x${string}`,
+      },
+    ]);
+    const tx = buildFlashLoanSimple(
+      FLASH_ARB_ADDRESS,
+      TOKENS.USDC.address,
+      amount,
+      params,
+    );
+    out({ type: "rawTx", tx, maxPriorityFeePerGasWei: fee });
+  } catch (error) {
+    out({ type: "noop", reason: `error: ${error}` });
+  }
+});
+
+function out(action: unknown): void {
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+}
+function floatEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+function intEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isInteger(v) && v > 0 ? v : fallback;
+}

--- a/examples/agents/jit-lp.ts
+++ b/examples/agents/jit-lp.ts
@@ -1,0 +1,292 @@
+// JIT-style LP at round boundary (Issue #5).
+//
+// Pseudo-JIT without mempool visibility: predict per-round volatility from the
+// pool-price history embedded in each observation. When the most-recent realized
+// vol exceeds a high quantile of the recent vol distribution, mint a very narrow
+// concentrated-liquidity range centered on the current tick. Next round, remove
+// + collect that position and re-evaluate.
+//
+// Env (all optional):
+//   JIT_VOL_WINDOW       (default 16)   history points per vol estimate
+//   JIT_VOL_QUANTILE     (default 0.7)  fire only if current vol > this quantile
+//   JIT_RANGE_TICKS      (default 2)    half-width in tick-spacing units
+//   JIT_MINT_BUDGET_BPS  (default 4500) fraction of LP budget (bps of 10000)
+//   JIT_MIN_HISTORY      (default JIT_VOL_WINDOW * 2) burn-in before any mint
+//
+// Cross-round state:
+//   * lastMintedTokenId: the tokenId we minted on the previous round, used to
+//     drive a remove+collect bundle at the top of the current round.
+//   * pendingMintRange: the (tickLower, tickUpper) we just submitted; on the
+//     following observation we reconcile that against `positions` to learn the
+//     runtime-assigned tokenId.
+
+import { createInterface } from "node:readline";
+import {
+  realizedVariance,
+  quantile,
+  type HistoryPoint,
+} from "../lib/flow-stats.js";
+
+type PositionObs = {
+  tokenId: string;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: string;
+  tokensOwedWethWei: string;
+  tokensOwedUsdcUnits: string;
+};
+
+type Observation = {
+  round: number;
+  pool: {
+    priceUsdcPerWeth: number;
+    tick: number;
+    tickSpacing: number;
+  };
+  fairPriceUsdcPerWeth: number;
+  positions: PositionObs[];
+  balances: { wethWei: string; usdcUnits: string };
+  history: HistoryPoint[];
+  limits: {
+    defaultPriorityFeePerGasWei: string;
+    maxLpWethWei: string;
+    maxLpUsdcUnits: string;
+    maxOpenPositions: number;
+    maxBundleActions: number;
+  };
+};
+
+// NOTE: the coordinator caps observation `history` at 20 points (see
+// src/coordinator.ts). Defaults below assume that cap: VOL_WINDOW=6 lets us
+// collect ~7 historical vol samples via the rolling step in
+// collectHistoricalVols, while MIN_HISTORY=12 ensures we have enough burn-in
+// to build a stable quantile threshold before firing.
+//
+// The runtime exposes maxOpenPositions=10 AND does not expose a burn action,
+// so every fired JIT round leaves a stale NFT counted against the cap. A very
+// high quantile (0.9) makes us conserve our 10 mint budget across the run and
+// only fire on the strongest vol signal, which is also what the no-firing-in-
+// low-vol-rounds completion criterion requires. Wider tick range (4 spacings)
+// earns fees in a wider band so a single mint is meaningful when we do fire.
+const VOL_WINDOW = positiveInt(process.env.JIT_VOL_WINDOW, 6);
+const VOL_QUANTILE = clampUnit(
+  parseFloatEnv(process.env.JIT_VOL_QUANTILE, 0.9),
+);
+const RANGE_TICKS = positiveInt(process.env.JIT_RANGE_TICKS, 4);
+const MINT_BUDGET_BPS = positiveInt(process.env.JIT_MINT_BUDGET_BPS, 4500);
+const MIN_HISTORY = positiveInt(process.env.JIT_MIN_HISTORY, 12);
+
+const MIN_WETH_MINT_WEI = 1_000_000_000_000_000n; // 0.001 WETH floor (narrow range = small)
+const MIN_USDC_MINT_UNITS = 2_500_000n; // 2.5 USDC floor
+
+let lastMintedTokenId: string | null = null;
+let pendingMintRange: { tickLower: number; tickUpper: number } | null = null;
+
+// 観測はネスト形 (protocols.uniswap.{pool,positions})。本戦略はトップレベル
+// pool/positions を前提にしたフラット形を使うため、パース後に正規化する。
+type RawObservation = Observation & {
+  protocols?: {
+    uniswap?: { pool?: Observation["pool"]; positions?: PositionObs[] };
+  };
+};
+
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  let raw: RawObservation;
+  try {
+    raw = JSON.parse(line) as RawObservation;
+  } catch (err) {
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: `parse-error: ${(err as Error).message}` })}\n`,
+    );
+    return;
+  }
+  const uni = raw.protocols?.uniswap;
+  if (!uni?.pool) {
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: "uniswap unavailable" })}\n`,
+    );
+    return;
+  }
+  const observation: Observation = {
+    ...raw,
+    pool: uni.pool,
+    positions: uni.positions ?? [],
+  };
+  reconcilePendingMint(observation);
+  const action = decideAction(observation);
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+});
+
+function reconcilePendingMint(observation: Observation): void {
+  if (!pendingMintRange || lastMintedTokenId !== null) return;
+  // Reuse the same tick range across mints means previously closed positions
+  // (liquidity=0) can still match the range. Pick the live one (liquidity > 0),
+  // and among ties prefer the highest tokenId (most recently minted).
+  const candidates = observation.positions
+    .filter(
+      (p) =>
+        p.tickLower === pendingMintRange!.tickLower &&
+        p.tickUpper === pendingMintRange!.tickUpper &&
+        BigInt(p.liquidity) > 0n,
+    )
+    .sort((a, b) => {
+      const da = BigInt(a.tokenId);
+      const db = BigInt(b.tokenId);
+      if (da === db) return 0;
+      return da < db ? 1 : -1;
+    });
+  if (candidates.length > 0) {
+    lastMintedTokenId = candidates[0].tokenId;
+    pendingMintRange = null;
+  }
+}
+
+function decideAction(observation: Observation) {
+  const priorityFee = observation.limits.defaultPriorityFeePerGasWei;
+
+  // 1. Close out previous JIT mint if it is still open.
+  const stalePosition = lastMintedTokenId
+    ? observation.positions.find((p) => p.tokenId === lastMintedTokenId)
+    : undefined;
+  if (lastMintedTokenId && !stalePosition) {
+    // Position no longer exists — runtime / external action cleared it.
+    lastMintedTokenId = null;
+  }
+  if (stalePosition) {
+    const closingTokenId = lastMintedTokenId as string;
+    // Clear state optimistically; if the bundle reverts the next observation
+    // will still surface the open position and we will retry the close.
+    lastMintedTokenId = null;
+    const actions: Array<Record<string, unknown>> = [];
+    if (BigInt(stalePosition.liquidity) > 0n) {
+      actions.push({
+        type: "removeLiquidity",
+        tokenId: closingTokenId,
+        liquidity: stalePosition.liquidity,
+      });
+    }
+    actions.push({ type: "collectFees", tokenId: closingTokenId });
+    if (actions.length === 1)
+      return { ...actions[0], maxPriorityFeePerGasWei: priorityFee };
+    if (actions.length > observation.limits.maxBundleActions) {
+      return { type: "noop", reason: "close bundle exceeds maxBundleActions" };
+    }
+    return { type: "bundle", maxPriorityFeePerGasWei: priorityFee, actions };
+  }
+
+  // 2. Burn-in: need enough history for both the current-window variance and
+  //    the historical distribution of vols we compare it to.
+  const history = observation.history ?? [];
+  if (history.length < MIN_HISTORY) {
+    return { type: "noop", reason: "burn-in" };
+  }
+
+  // 3. Evaluate current vs historical vol.
+  const currentVol = realizedVariance(history, VOL_WINDOW);
+  const historicalVols = collectHistoricalVols(history, VOL_WINDOW);
+  if (historicalVols.length < 4) {
+    return { type: "noop", reason: "insufficient vol samples" };
+  }
+  const threshold = quantile(historicalVols, VOL_QUANTILE);
+  if (!(currentVol > threshold) || currentVol <= 0) {
+    return { type: "noop", reason: "low-vol round" };
+  }
+
+  // 4. Respect open position cap. The runtime counts ALL positions including
+  //    liquidity=0 NFTs that Uniswap V3 leaves behind after removeLiquidity
+  //    (no burn action is exposed). Stop firing once we get within one of the
+  //    cap so we don't end up with stranded liquidity we can't unwind.
+  if (observation.positions.length >= observation.limits.maxOpenPositions) {
+    return { type: "noop", reason: "max open positions" };
+  }
+
+  // 5. Size proportional to vol relative to the max historical vol observed.
+  //    Floor at 25% of budget so a triggered mint is meaningful.
+  const maxVol = Math.max(...historicalVols, currentVol);
+  const ratio = maxVol > 0 ? Math.min(1, currentVol / maxVol) : 1;
+  const sizeFraction = Math.max(0.25, ratio);
+  const budgetBps = BigInt(Math.round(MINT_BUDGET_BPS * sizeFraction));
+
+  const balanceWeth = BigInt(observation.balances.wethWei);
+  const balanceUsdc = BigInt(observation.balances.usdcUnits);
+  const limitWeth = BigInt(observation.limits.maxLpWethWei);
+  const limitUsdc = BigInt(observation.limits.maxLpUsdcUnits);
+  const amountWethDesired = budgetAmount(balanceWeth, limitWeth, budgetBps);
+  const amountUsdcDesired = budgetAmount(balanceUsdc, limitUsdc, budgetBps);
+  if (
+    amountWethDesired < MIN_WETH_MINT_WEI ||
+    amountUsdcDesired < MIN_USDC_MINT_UNITS
+  ) {
+    return { type: "noop", reason: "insufficient LP budget" };
+  }
+
+  const spacing = observation.pool.tickSpacing;
+  const center = alignTick(observation.pool.tick, spacing);
+  const halfWidth = spacing * RANGE_TICKS;
+  const tickLower = center - halfWidth;
+  const tickUpper = center + halfWidth;
+  if (tickLower >= tickUpper) {
+    return { type: "noop", reason: "degenerate tick range" };
+  }
+
+  // Remember the range so we can identify the tokenId on the next observation.
+  pendingMintRange = { tickLower, tickUpper };
+
+  return {
+    type: "mintLiquidity",
+    tickLower,
+    tickUpper,
+    amountWethDesired: amountWethDesired.toString(),
+    amountUsdcDesired: amountUsdcDesired.toString(),
+    maxPriorityFeePerGasWei: priorityFee,
+    slippageBps: 100,
+  };
+}
+
+function collectHistoricalVols(
+  history: HistoryPoint[],
+  window: number,
+): number[] {
+  // Roll a window of size `window` across the history excluding the most recent
+  // window (the "current" estimate). Step by max(1, window/2) so samples are
+  // roughly independent.
+  const out: number[] = [];
+  if (history.length < window + 1) return out;
+  const step = Math.max(1, Math.floor(window / 2));
+  for (let end = history.length - 1 - step; end >= window; end -= step) {
+    const sub = history.slice(end - window, end);
+    const v = realizedVariance(sub, window);
+    if (v > 0) out.push(v);
+  }
+  return out;
+}
+
+function budgetAmount(balance: bigint, limit: bigint, bps: bigint): bigint {
+  const capped = balance < limit ? balance : limit;
+  return (capped * bps) / 10_000n;
+}
+
+function alignTick(tick: number, spacing: number): number {
+  return Math.floor(tick / spacing) * spacing;
+}
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.floor(n);
+}
+
+function parseFloatEnv(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return n;
+}
+
+function clampUnit(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/examples/agents/ladder-mm.ts
+++ b/examples/agents/ladder-mm.ts
@@ -1,0 +1,495 @@
+import { createInterface } from "node:readline";
+
+type PositionObservation = {
+  tokenId: string;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: string;
+  tokensOwedWethWei: string;
+  tokensOwedUsdcUnits: string;
+  amountWethWei: string;
+  amountUsdcUnits: string;
+  valueUsdc: number;
+};
+
+type Observation = {
+  pool: {
+    priceUsdcPerWeth: number;
+    tick: number;
+    tickSpacing: number;
+    fee: number;
+    pair: string;
+  };
+  fairPriceUsdcPerWeth: number;
+  positions: PositionObservation[];
+  balances: {
+    wethWei: string;
+    usdcUnits: string;
+  };
+  inventory: {
+    valueUsdc: number;
+    weth: number;
+    usdc: number;
+    eth: number;
+  };
+  limits: {
+    defaultPriorityFeePerGasWei: string;
+    maxPriorityFeePerGasWei: string;
+    maxBundleActions: number;
+    maxLpWethWei: string;
+    maxLpUsdcUnits: string;
+    maxOpenPositions: number;
+  };
+};
+
+type BundleAction =
+  | {
+      type: "mintLiquidity";
+      tickLower: number;
+      tickUpper: number;
+      amountWethDesired: string;
+      amountUsdcDesired: string;
+      slippageBps?: number;
+    }
+  | { type: "removeLiquidity"; tokenId: string; liquidity: string }
+  | { type: "collectFees"; tokenId: string };
+
+type AgentAction =
+  | { type: "noop"; reason?: string }
+  | (BundleAction & { maxPriorityFeePerGasWei?: string })
+  | {
+      type: "bundle";
+      actions: BundleAction[];
+      maxPriorityFeePerGasWei?: string;
+    };
+
+type ManagedPosition = { tickLower: number; tickUpper: number; weight: number };
+
+const LADDER_STEPS = clampInt(intEnv("LADDER_STEPS", 3), 1, 9);
+// Weight allocation: concentrate the inner step heavily so the at-price
+// capital approaches the single-range LP baseline; outer steps are thin
+// inventory-management reserves that capture flow during larger drift.
+const LADDER_INNER_WEIGHT = floatEnv("LADDER_INNER_WEIGHT", 0.8);
+const LADDER_OUTER_WEIGHT = floatEnv("LADDER_OUTER_WEIGHT", 0.2);
+// Step width: each step covers ±(width/2) ticks. tickSpacing=10 for the 5-bps
+// WETH/USDC pool, so multiplier=120 → each step spans 1200 ticks (~±6%), the
+// same width as the single-range LP baseline (`lp-provider`'s
+// RANGE_WIDTH_MULTIPLIER=60 = half-width 600 ticks = total width 1200 ticks).
+// Matching the baseline width neutralises the concentration-IL premium so the
+// ladder's inventory-skew advantage can show up in PnL.
+//
+// Previously 20 (~±1% per step) drained ladder slots within <128 rounds, since
+// drained NFTs permanently consume a `maxOpenPositions` slot (no burn action).
+const LADDER_STEP_WIDTH_MULTIPLIER = intEnv(
+  "LADDER_STEP_WIDTH_MULTIPLIER",
+  120,
+);
+const LADDER_REBALANCE_GAP_BPS = intEnv("LADDER_REBALANCE_GAP_BPS", 80);
+const LADDER_REBALANCE_SKEW = floatEnv("LADDER_REBALANCE_SKEW", 0.3);
+// Total fraction of available balance to deploy across the ladder. The single-
+// range LP baseline uses 3500 (35%); we use 5000 (50%) because ladder splits
+// across multiple positions, so each position individually receives less. With
+// inner=0.8 and budget=0.5 the inner position holds ~40% of capped balance,
+// slightly above the single-range baseline.
+const LADDER_MINT_BUDGET_BPS = intEnv("LADDER_MINT_BUDGET_BPS", 5000);
+const LADDER_SKEW_TILT = floatEnv("LADDER_SKEW_TILT", 0.5);
+const MIN_WETH_MINT_WEI = 5_000_000_000_000_000n; // 0.005 WETH
+const MIN_USDC_MINT_UNITS = 10_000_000n; // 10 USDC
+
+const managed = new Map<string, ManagedPosition>();
+
+// 観測はネスト形 (protocols.uniswap.{pool,positions})。本戦略はトップレベル
+// pool/positions を前提にしたフラット形を使うため、パース後に正規化する。
+type RawObservation = Observation & {
+  protocols?: {
+    uniswap?: { pool?: Observation["pool"]; positions?: PositionObservation[] };
+  };
+};
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  try {
+    const raw = JSON.parse(line) as RawObservation;
+    const uni = raw.protocols?.uniswap;
+    if (!uni?.pool) {
+      process.stdout.write(
+        `${JSON.stringify({ type: "noop", reason: "uniswap unavailable" })}\n`,
+      );
+      return;
+    }
+    const observation: Observation = {
+      ...raw,
+      pool: uni.pool,
+      positions: uni.positions ?? [],
+    };
+    const action = decide(observation);
+    process.stdout.write(`${JSON.stringify(action)}\n`);
+  } catch (err) {
+    process.stderr.write(`[ladder-mm] error: ${(err as Error).message}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: "parse error" })}\n`,
+    );
+  }
+});
+
+function decide(obs: Observation): AgentAction {
+  syncManaged(obs);
+
+  const priorityFee = obs.limits.defaultPriorityFeePerGasWei;
+  const maxBundle = obs.limits.maxBundleActions;
+  const maxOpen = obs.limits.maxOpenPositions;
+
+  const fairTick = fairTickFromPool(
+    obs.pool.tick,
+    obs.pool.priceUsdcPerWeth,
+    obs.fairPriceUsdcPerWeth,
+    obs.pool.tickSpacing,
+  );
+  const gapBps =
+    Math.abs(obs.fairPriceUsdcPerWeth / obs.pool.priceUsdcPerWeth - 1) * 10_000;
+  const skew = inventorySkew(obs);
+
+  const targets = buildTargetLadder(fairTick, skew, obs.pool.tickSpacing);
+
+  // Determine which existing positions are stale. We allow generous tolerance
+  // when matching positions to target ranges: a position that overlaps a target
+  // by >=70% of the target's tick span counts as a match. This stops trivial
+  // fair-price wobble from churning the entire ladder.
+  const ownedPositions = obs.positions.filter((p) => BigInt(p.liquidity) > 0n);
+  const matchTolerance = 0.7;
+
+  const stale: PositionObservation[] = [];
+  const matchedTargetIdx = new Set<number>();
+  for (const pos of ownedPositions) {
+    let matched = false;
+    for (let i = 0; i < targets.length; i++) {
+      if (matchedTargetIdx.has(i)) continue;
+      const t = targets[i];
+      const overlap = Math.max(
+        0,
+        Math.min(pos.tickUpper, t.tickUpper) -
+          Math.max(pos.tickLower, t.tickLower),
+      );
+      const span = t.tickUpper - t.tickLower;
+      if (span > 0 && overlap / span >= matchTolerance) {
+        matchedTargetIdx.add(i);
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) stale.push(pos);
+  }
+
+  // Compute drift between the existing ladder centroid and the new fair tick.
+  // Rebalance only when the centroid is well outside the inner step — otherwise
+  // we'd churn every round and burn through `maxOpenPositions` (drained NFTs
+  // are never burned in this sim, they just accumulate).
+  const stepWidthTicks = obs.pool.tickSpacing * LADDER_STEP_WIDTH_MULTIPLIER;
+  const ladderCenter = ownedPositions.length
+    ? Math.round(
+        ownedPositions.reduce(
+          (s, p) => s + (p.tickLower + p.tickUpper) / 2,
+          0,
+        ) / ownedPositions.length,
+      )
+    : fairTick;
+  const driftTicks = Math.abs(fairTick - ladderCenter);
+  const driftTriggered =
+    ownedPositions.length > 0 && driftTicks > stepWidthTicks * 1.5;
+
+  const gapTriggered = gapBps > LADDER_REBALANCE_GAP_BPS;
+  const skewTriggered = Math.abs(skew) > LADDER_REBALANCE_SKEW;
+
+  // Soft brake: if we're within `steps + 2` NFT slots of maxOpenPositions,
+  // stop initiating new tear-downs (since every rebalance burns through `steps`
+  // more NFTs). This guarantees we never hit the hard validator limit.
+  const nftBudget = maxOpen - obs.positions.length;
+  const rebalanceAllowed = nftBudget >= LADDER_STEPS;
+
+  const rebalanceTriggered =
+    rebalanceAllowed &&
+    ownedPositions.length > 0 &&
+    (driftTriggered ||
+      (gapTriggered && stale.length > 0) ||
+      (skewTriggered && stale.length > 0));
+
+  // When a rebalance fires we tear down the whole ladder so the next mint cycle
+  // can construct a fresh, properly weighted one. Otherwise we only purge
+  // positions that are strictly stale (don't match any current target).
+  const positionsToRemove = rebalanceTriggered ? ownedPositions.slice() : stale;
+
+  // 1. Tear down stale positions first (free up position slots).
+  if (positionsToRemove.length > 0) {
+    const actions: BundleAction[] = [];
+    for (const pos of positionsToRemove) {
+      // remove + collect = 2 slots. Stop before exceeding maxBundle.
+      if (actions.length + 2 > maxBundle) break;
+      actions.push({
+        type: "removeLiquidity",
+        tokenId: pos.tokenId,
+        liquidity: pos.liquidity,
+      });
+      actions.push({ type: "collectFees", tokenId: pos.tokenId });
+      managed.delete(pos.tokenId);
+    }
+    if (actions.length === 1) {
+      const only = actions[0];
+      return { ...only, maxPriorityFeePerGasWei: priorityFee };
+    }
+    if (actions.length >= 2) {
+      return { type: "bundle", actions, maxPriorityFeePerGasWei: priorityFee };
+    }
+    // If we couldn't fit any remove+collect pair (maxBundle < 2), fall through to other behaviour.
+  }
+
+  // 2. Collect fees on still-managed in-range positions before potentially minting more.
+  const collectable = ownedPositions.find(
+    (p) => !positionsToRemove.includes(p) && hasCollectableFees(p),
+  );
+  // Targets that don't already have a sufficiently-overlapping live position.
+  // Use the same tolerance as the staleness check so we don't double-mint when
+  // an existing position drifted slightly out of exact tick alignment.
+  const remainingTargets = targets.filter(
+    (t) =>
+      !ownedPositions.some((p) => {
+        if (positionsToRemove.includes(p)) return false;
+        const overlap = Math.max(
+          0,
+          Math.min(p.tickUpper, t.tickUpper) -
+            Math.max(p.tickLower, t.tickLower),
+        );
+        const span = t.tickUpper - t.tickLower;
+        return span > 0 && overlap / span >= matchTolerance;
+      }),
+  );
+
+  // 3. Mint missing target steps.
+  // CAREFUL: obs.positions includes drained NFTs (liquidity=0). Burning isn't
+  // exposed as an action, so every rebalance burns through real NFT slots. We
+  // count drained NFTs against `maxOpenPositions` because the validator does.
+  const slotsLeft = maxOpen - obs.positions.length;
+  const mintsToEmit = remainingTargets.slice(
+    0,
+    Math.max(0, Math.min(slotsLeft, maxBundle)),
+  );
+
+  if (mintsToEmit.length > 0) {
+    const totalWeightToMint = mintsToEmit.reduce((sum, t) => sum + t.weight, 0);
+    if (totalWeightToMint <= 0) {
+      return collectable
+        ? collectAction(collectable.tokenId, priorityFee)
+        : { type: "noop", reason: "no positive ladder weight" };
+    }
+
+    const wethBudget = budgetAmount(
+      BigInt(obs.balances.wethWei),
+      BigInt(obs.limits.maxLpWethWei),
+    );
+    const usdcBudget = budgetAmount(
+      BigInt(obs.balances.usdcUnits),
+      BigInt(obs.limits.maxLpUsdcUnits),
+    );
+
+    // If total budget is too tiny across the ladder, skip minting.
+    if (wethBudget < MIN_WETH_MINT_WEI && usdcBudget < MIN_USDC_MINT_UNITS) {
+      return collectable
+        ? collectAction(collectable.tokenId, priorityFee)
+        : { type: "noop", reason: "insufficient LP budget for ladder" };
+    }
+
+    const actions: BundleAction[] = [];
+    for (const t of mintsToEmit) {
+      const share = t.weight / totalWeightToMint;
+      const wethShare =
+        (wethBudget * BigInt(Math.floor(share * 10_000))) / 10_000n;
+      const usdcShare =
+        (usdcBudget * BigInt(Math.floor(share * 10_000))) / 10_000n;
+      // Skip ranges that would mint trivially small amounts.
+      if (wethShare < MIN_WETH_MINT_WEI && usdcShare < MIN_USDC_MINT_UNITS)
+        continue;
+      actions.push({
+        type: "mintLiquidity",
+        tickLower: t.tickLower,
+        tickUpper: t.tickUpper,
+        amountWethDesired: wethShare.toString(),
+        amountUsdcDesired: usdcShare.toString(),
+        slippageBps: 100,
+      });
+      managed.set(`pending:${t.tickLower}:${t.tickUpper}`, {
+        tickLower: t.tickLower,
+        tickUpper: t.tickUpper,
+        weight: t.weight,
+      });
+    }
+    if (actions.length === 1) {
+      return { ...actions[0], maxPriorityFeePerGasWei: priorityFee };
+    }
+    if (actions.length >= 2) {
+      return { type: "bundle", actions, maxPriorityFeePerGasWei: priorityFee };
+    }
+  }
+
+  if (collectable) {
+    return collectAction(collectable.tokenId, priorityFee);
+  }
+
+  return { type: "noop", reason: "ladder in place" };
+}
+
+function syncManaged(obs: Observation): void {
+  const onChainIds = new Set(obs.positions.map((p) => p.tokenId));
+  // Drop entries we tracked for tokenIds that no longer exist.
+  for (const key of Array.from(managed.keys())) {
+    if (key.startsWith("pending:")) {
+      managed.delete(key);
+      continue;
+    }
+    if (!onChainIds.has(key)) managed.delete(key);
+  }
+  // Pick up tokenIds that appeared this round (likely minted last round).
+  for (const pos of obs.positions) {
+    if (BigInt(pos.liquidity) === 0n) continue;
+    if (!managed.has(pos.tokenId)) {
+      managed.set(pos.tokenId, {
+        tickLower: pos.tickLower,
+        tickUpper: pos.tickUpper,
+        weight: 1,
+      });
+    }
+  }
+}
+
+function buildTargetLadder(
+  fairTick: number,
+  skew: number,
+  tickSpacing: number,
+): Array<{ tickLower: number; tickUpper: number; weight: number }> {
+  // Ensure stepWidth is a multiple of tickSpacing and even so half-widths align.
+  let stepWidth = tickSpacing * LADDER_STEP_WIDTH_MULTIPLIER;
+  if (stepWidth % (tickSpacing * 2) !== 0) {
+    stepWidth = tickSpacing * (LADDER_STEP_WIDTH_MULTIPLIER + 1);
+  }
+  const halfWidth = stepWidth / 2; // multiple of tickSpacing by construction.
+
+  const steps = LADDER_STEPS;
+  // Index range: for STEPS=3 we use [-1, 0, 1]; for STEPS=5 use [-2..2]; for
+  // STEPS=4 use [-2, -1, 1, 2] (skip 0).
+  const half = Math.floor(steps / 2);
+  const indices: number[] = [];
+  for (let i = -half; i <= half; i++) {
+    if (steps % 2 === 0 && i === 0) continue;
+    indices.push(i);
+  }
+
+  const innerCount = steps % 2 === 1 ? 1 : 2;
+  const outerCount = steps - innerCount;
+  const innerWeightEach =
+    outerCount === 0 ? 1 : LADDER_INNER_WEIGHT / innerCount;
+  const outerWeightEach =
+    outerCount === 0 ? 0 : LADDER_OUTER_WEIGHT / outerCount;
+
+  const out: Array<{ tickLower: number; tickUpper: number; weight: number }> =
+    [];
+  for (const i of indices) {
+    const isInner = steps % 2 === 1 ? i === 0 : Math.abs(i) === 1;
+    let weight = isInner ? innerWeightEach : outerWeightEach;
+
+    // Skew adjustment: positive skew (WETH-heavy) => bias OUTER steps to the
+    // ask side (i > 0) so flow sweeps WETH out and brings USDC in. Keep inner
+    // symmetric to preserve a tight spot quote.
+    if (!isInner && Math.abs(skew) > 0) {
+      const direction = Math.sign(i); // +1 above fair, -1 below fair
+      const tilt = clamp(skew * LADDER_SKEW_TILT, -0.9, 0.9);
+      weight = Math.max(0, weight * (1 + direction * tilt));
+    }
+
+    const stepCenter = alignTick(fairTick + i * stepWidth, tickSpacing);
+    const lo = stepCenter - halfWidth;
+    const up = stepCenter + halfWidth;
+    if (up <= lo) continue;
+    out.push({ tickLower: lo, tickUpper: up, weight });
+  }
+  // Normalize weights to sum to 1 (skew tilt may have changed the total).
+  const total = out.reduce((s, t) => s + t.weight, 0);
+  if (total > 0) for (const t of out) t.weight = t.weight / total;
+  return out;
+}
+
+function inventorySkew(obs: Observation): number {
+  const wethValue = obs.inventory.weth * obs.fairPriceUsdcPerWeth;
+  const usdc = obs.inventory.usdc;
+  const sum = wethValue + usdc;
+  if (sum <= 0) return 0;
+  return (wethValue - usdc) / sum;
+}
+
+function collectAction(tokenId: string, priorityFee: string): AgentAction {
+  return { type: "collectFees", tokenId, maxPriorityFeePerGasWei: priorityFee };
+}
+
+function hasCollectableFees(p: PositionObservation): boolean {
+  return BigInt(p.tokensOwedWethWei) > 0n || BigInt(p.tokensOwedUsdcUnits) > 0n;
+}
+
+function budgetAmount(balance: bigint, limit: bigint): bigint {
+  const capped = balance < limit ? balance : limit;
+  return (capped * BigInt(LADDER_MINT_BUDGET_BPS)) / 10_000n;
+}
+
+// Derive the fair tick by anchoring on the pool's reported tick and shifting by
+// the log-price ratio. We use `pool.tick` as the calibration anchor so we don't
+// need to hard-code a tick-zero offset.
+//
+// For the WETH/USDC 0.05% pool token0=USDC, token1=WETH. v3 ticks encode
+// token1/token0, so higher tick == higher WETH/USDC == lower USDC/WETH (the
+// human price the observation reports). Hence:
+//   fairTick - poolTick = log(poolPrice / fairPrice) / log(1.0001)
+// where prices are USDC/WETH (human units).
+//
+// After PR-A (#10) merges, swap this for `priceToTick` in `examples/lib/tick-math.ts`
+// (see follow-up issue).
+function fairTickFromPool(
+  poolTick: number,
+  poolPrice: number,
+  fairPrice: number,
+  tickSpacing: number,
+): number {
+  if (
+    !Number.isFinite(fairPrice) ||
+    fairPrice <= 0 ||
+    !Number.isFinite(poolPrice) ||
+    poolPrice <= 0
+  ) {
+    return alignTick(poolTick, tickSpacing);
+  }
+  const offset = Math.log(poolPrice / fairPrice) / Math.log(1.0001);
+  const rawFairTick = poolTick + Math.round(offset);
+  return alignTick(rawFairTick, tickSpacing);
+}
+
+function alignTick(tick: number, spacing: number): number {
+  return Math.floor(tick / spacing) * spacing;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function floatEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/examples/agents/liquidator.ts
+++ b/examples/agents/liquidator.ts
@@ -1,0 +1,89 @@
+// liquidator (GitHub #1): Aave V3 の liquidationCall で清算する bot。
+// 観測には victim は含まれない原則なので、env(ERIS_LIQUIDATION_VICTIMS, カンマ区切り)で
+// 監視対象アドレスを受け取り、RPC で getUserAccountData を直読みする。HF<1 の victim を見つけたら
+// liquidationCall を rawTx で送る(USDC で債務を返済し WETH 担保+ボーナスを受領)。
+// 受領した WETH は次ラウンドに semantic swap で USDC へ戻して PnL を確定する。
+//
+// 注: sandbox executor ではなく標準の標準入出力 agent。RPC を使うため LLM 自己改善対象外。
+import { createInterface } from "node:readline";
+import { createPublicClient, http, maxUint256, parseAbi } from "viem";
+import { mainnet } from "viem/chains";
+import { AAVE, TOKENS } from "../../src/constants.js";
+import { VICTIM_ADDRESS } from "../../src/liquidationDemo.js";
+import { buildLiquidationCall } from "../lib/aave-liquidation.js";
+
+const rpcUrl = process.env.ERIS_RPC_URL ?? "";
+if (!rpcUrl) {
+  process.stderr.write("ERIS_RPC_URL is required\n");
+  process.exit(1);
+}
+const victims = (process.env.ERIS_LIQUIDATION_VICTIMS ?? VICTIM_ADDRESS)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const pc = createPublicClient({ chain: mainnet, transport: http(rpcUrl) });
+const poolAbi = parseAbi([
+  "function getUserAccountData(address) view returns (uint256,uint256,uint256,uint256,uint256,uint256)",
+]);
+
+const HF_ONE = 10n ** 18n;
+// 清算で受領した WETH を判別するための下限(初期残高に紛れない程度)。初期 10 WETH より十分大きく
+// した上で「増えた分」を売るのは難しいため、ここでは閾値超の WETH を一定サイズで USDC 化する。
+const WETH_REALIZE_THRESHOLD_WEI = 10_500_000_000_000_000_000n; // 10.5 WETH
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", async (line) => {
+  try {
+    const obs = JSON.parse(line);
+    const fee = obs.limits.defaultPriorityFeePerGasWei;
+
+    // 1) HF<1 の victim があれば清算(USDC で返済 → WETH 担保受領)
+    for (const victim of victims) {
+      const acc = (await pc.readContract({
+        address: AAVE.Pool,
+        abi: poolAbi,
+        functionName: "getUserAccountData",
+        args: [victim as `0x${string}`],
+      })) as readonly bigint[];
+      const totalDebt = acc[1];
+      const hf = acc[5];
+      if (totalDebt > 0n && hf < HF_ONE) {
+        const tx = buildLiquidationCall(
+          TOKENS.WETH.address,
+          TOKENS.USDC.address,
+          victim,
+          maxUint256, // close factor で上限クランプ
+          false,
+        );
+        process.stdout.write(
+          `${JSON.stringify({ type: "rawTx", tx, maxPriorityFeePerGasWei: fee })}\n`,
+        );
+        return;
+      }
+    }
+
+    // 2) 清算で増えた WETH を USDC に戻して確定(初期 WETH を超えた分の目安で売る)
+    const wethWei = BigInt(obs.balances.wethWei);
+    if (wethWei > WETH_REALIZE_THRESHOLD_WEI) {
+      const maxIn = BigInt(obs.limits.maxWethInWei);
+      const excess = wethWei - 10_000_000_000_000_000_000n; // 初期 10 WETH 超過分
+      const amountIn = excess < maxIn ? excess : maxIn;
+      if (amountIn > 0n) {
+        process.stdout.write(
+          `${JSON.stringify({ type: "swap", tokenIn: "WETH", amountIn: amountIn.toString(), slippageBps: 100, maxPriorityFeePerGasWei: fee })}\n`,
+        );
+        return;
+      }
+    }
+
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: "no liquidatable victim" })}\n`,
+    );
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({ type: "noop", reason: `error: ${error}` })}\n`,
+    );
+  }
+});

--- a/examples/agents/lp-yield.ts
+++ b/examples/agents/lp-yield.ts
@@ -1,0 +1,98 @@
+// lp-yield (GitHub #11): fair 含意 tick 中心に LP を mint し、残った遊休 USDC を Aave V3 に supply
+// して「手数料 + 利回り」の二段収益を狙う無レバレッジ複合(fair-MM × Aave park)。
+// LP コンポーネントは fair-mm を簡約移植、park は aave-arb 流。RPC 不要・semantic action のみ。
+//
+// env:
+//   LP_YIELD_RANGE_SPACINGS  レンジ半幅(tickSpacing 単位, default 4)
+//   LP_YIELD_DEPOSIT_FRAC    LP 預入率(default 0.5)
+//   LP_YIELD_MIN_IDLE_USDC   Aave に回さず手元に残す USDC 下限(default 10)
+import { createInterface } from "node:readline";
+
+const RANGE_SPACINGS = intEnv("LP_YIELD_RANGE_SPACINGS", 4);
+const DEPOSIT_FRAC = floatEnv("LP_YIELD_DEPOSIT_FRAC", 0.5);
+const MIN_IDLE_USDC = intEnv("LP_YIELD_MIN_IDLE_USDC", 10);
+const SLIPPAGE_BPS = 75;
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on("line", (line) => {
+  try {
+    const obs = JSON.parse(line);
+    const uni = obs.protocols?.uniswap;
+    const aave = obs.protocols?.aave;
+    const fee = obs.limits.defaultPriorityFeePerGasWei;
+    if (!uni?.pool) {
+      out({ type: "noop", reason: "uniswap disabled" });
+      return;
+    }
+    const positions = uni.positions ?? [];
+    const live = positions.filter(
+      (p: { liquidity: string }) => BigInt(p.liquidity) > 0n,
+    ).length;
+
+    // 1) LP 未保有 → fair 含意 tick 中心に mint
+    if (live === 0) {
+      const pool = uni.pool.priceUsdcPerWeth;
+      const fair = obs.fairPriceUsdcPerWeth;
+      if (pool > 0 && fair > 0) {
+        const spacing = uni.pool.tickSpacing;
+        const offset = Math.round(Math.log(fair / pool) / Math.log(1.0001));
+        const center = Math.round((uni.pool.tick + offset) / spacing) * spacing;
+        const w = Math.max(1, RANGE_SPACINGS) * spacing;
+        const frac = BigInt(Math.floor(DEPOSIT_FRAC * 10_000));
+        const wethWei = BigInt(obs.balances.wethWei);
+        const usdcUnits = BigInt(obs.balances.usdcUnits);
+        const maxW = BigInt(obs.limits.maxLpWethWei);
+        const maxU = BigInt(obs.limits.maxLpUsdcUnits);
+        const wd = ((wethWei < maxW ? wethWei : maxW) * frac) / 10_000n;
+        const ud = ((usdcUnits < maxU ? usdcUnits : maxU) * frac) / 10_000n;
+        if (wd > 0n || ud > 0n) {
+          out({
+            type: "mintLiquidity",
+            tickLower: center - w,
+            tickUpper: center + w,
+            amountWethDesired: wd.toString(),
+            amountUsdcDesired: ud.toString(),
+            maxPriorityFeePerGasWei: fee,
+            slippageBps: SLIPPAGE_BPS,
+          });
+          return;
+        }
+      }
+    }
+
+    // 2) LP 配分後の遊休 USDC を Aave に park(余剰だけ)。1 回の supply は maxUsdcInUnits で
+    //    上限を切り、集約残高(USDC.e/USDT 込み)で native USDC 残高を超えて reject されるのを避ける。
+    if (aave) {
+      const usdcUnits = BigInt(obs.balances.usdcUnits);
+      const maxIn = BigInt(obs.limits.maxUsdcInUnits);
+      const minIdle = BigInt(MIN_IDLE_USDC) * 1_000_000n;
+      if (usdcUnits > minIdle) {
+        const excess = usdcUnits - minIdle;
+        const amt = excess < maxIn ? excess : maxIn;
+        out({
+          type: "aaveSupply",
+          asset: "USDC",
+          amount: amt.toString(),
+          maxPriorityFeePerGasWei: fee,
+        });
+        return;
+      }
+    }
+    out({ type: "noop", reason: "LP + idle parked" });
+  } catch (error) {
+    out({ type: "noop", reason: `error: ${error}` });
+  }
+});
+
+function out(action: unknown): void {
+  process.stdout.write(`${JSON.stringify(action)}\n`);
+}
+function floatEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+function intEnv(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isInteger(v) && v >= 0 ? v : fallback;
+}

--- a/examples/agents/stat-arb.ts
+++ b/examples/agents/stat-arb.ts
@@ -1,0 +1,216 @@
+/**
+ * stat-arb: rolling-stats driven arb agent with z-score sizing and dynamic
+ *           priority fee bidding.
+ *
+ * Compared to arb-bot (fixed gap threshold, fixed sizing schedule):
+ *   - Threshold is data-driven: enter when |z(gap)| > STAT_ARB_Z_ENTER.
+ *   - Size scales with |z| (capped at 50% of per-round swap limit).
+ *   - Priority fee is EV-proportional: bid ≈ alpha * EV_wei / gasEstimate,
+ *     clamped to the simulator's [defaultPriorityFee, maxPriorityFee] band.
+ *   - During burn-in (rolling stats not yet meaningful) emit noop. The
+ *     observation's `history` field is replayed on startup so late-spawned
+ *     agents don't need a fresh N rounds of cold start.
+ *
+ * Env vars:
+ *   STAT_ARB_WINDOW         (default 64)  burn-in stats window metadata; the
+ *                                          Welford estimator is unbounded, so
+ *                                          this only labels the tuning window.
+ *   STAT_ARB_Z_ENTER        (default 1.5) minimum |z| to take a position.
+ *   STAT_ARB_Z_AGGRESSIVE   (default 2.5) |z| at which sizing saturates the
+ *                                          50% cap; below this, size scales
+ *                                          linearly from Z_ENTER → cap.
+ *   STAT_ARB_BID_ALPHA      (default 0.3) fraction of expected EV (wei) routed
+ *                                          to priority fee bidding.
+ *   STAT_ARB_BURN_IN        (default 20)  minimum sample count before trading.
+ */
+import { createInterface } from "node:readline";
+import { RollingStats } from "../lib/rolling-stats.js";
+
+type HistoryPoint = {
+  round: number;
+  poolPriceUsdcPerWeth: number;
+  fairPriceUsdcPerWeth: number;
+};
+
+type Observation = {
+  round: number;
+  pool: { priceUsdcPerWeth: number };
+  fairPriceUsdcPerWeth: number;
+  history?: HistoryPoint[];
+  limits: {
+    maxWethInWei: string;
+    maxUsdcInUnits: string;
+    defaultPriorityFeePerGasWei: string;
+    maxPriorityFeePerGasWei: string;
+  };
+};
+
+const WINDOW = Math.max(
+  2,
+  Math.floor(Number(process.env.STAT_ARB_WINDOW ?? "64")),
+);
+const Z_ENTER = Number(process.env.STAT_ARB_Z_ENTER ?? "1.5");
+const Z_AGGRESSIVE = Number(process.env.STAT_ARB_Z_AGGRESSIVE ?? "2.5");
+const BID_ALPHA = Number(process.env.STAT_ARB_BID_ALPHA ?? "0.3");
+const BURN_IN = Math.max(
+  2,
+  Math.floor(Number(process.env.STAT_ARB_BURN_IN ?? "20")),
+);
+
+const GAS_UNITS_ESTIMATE = 180_000n;
+const SIZE_CAP_BPS = 5000; // 50% of per-round swap limit
+const SIZE_FLOOR_BPS = 500; // 5% — when |z| barely clears Z_ENTER
+
+if (!Number.isFinite(Z_ENTER) || Z_ENTER <= 0) {
+  process.stderr.write(
+    `invalid STAT_ARB_Z_ENTER: ${process.env.STAT_ARB_Z_ENTER}\n`,
+  );
+  process.exit(1);
+}
+if (!Number.isFinite(Z_AGGRESSIVE) || Z_AGGRESSIVE <= Z_ENTER) {
+  process.stderr.write(
+    `invalid STAT_ARB_Z_AGGRESSIVE (must be > Z_ENTER): ${process.env.STAT_ARB_Z_AGGRESSIVE}\n`,
+  );
+  process.exit(1);
+}
+if (!Number.isFinite(BID_ALPHA) || BID_ALPHA < 0) {
+  process.stderr.write(
+    `invalid STAT_ARB_BID_ALPHA: ${process.env.STAT_ARB_BID_ALPHA}\n`,
+  );
+  process.exit(1);
+}
+
+const stats = new RollingStats(WINDOW);
+const seenRounds = new Set<number>();
+
+function computeGap(pool: number, fair: number): number | null {
+  if (!Number.isFinite(pool) || pool <= 0) return null;
+  if (!Number.isFinite(fair) || fair <= 0) return null;
+  return fair / pool - 1;
+}
+
+function seedFromHistory(history: HistoryPoint[] | undefined): void {
+  if (!history || history.length === 0) return;
+  for (const point of history) {
+    if (seenRounds.has(point.round)) continue;
+    const gap = computeGap(
+      point.poolPriceUsdcPerWeth,
+      point.fairPriceUsdcPerWeth,
+    );
+    if (gap === null) continue;
+    stats.update(gap);
+    seenRounds.add(point.round);
+  }
+}
+
+function noop(reason: string): string {
+  return `${JSON.stringify({ type: "noop", reason })}\n`;
+}
+
+const rl = createInterface({ input: process.stdin });
+
+// 観測はネスト形 (protocols.uniswap.pool)。本戦略はトップレベル pool を前提にした
+// フラット形を使うため、パース後に正規化する。uniswap 無効時は裁定できず noop。
+type RawObservation = Observation & {
+  protocols?: { uniswap?: { pool?: { priceUsdcPerWeth: number } } };
+};
+
+rl.on("line", (line) => {
+  let raw: RawObservation;
+  try {
+    raw = JSON.parse(line) as RawObservation;
+  } catch (err) {
+    process.stdout.write(noop(`parse error: ${(err as Error).message}`));
+    return;
+  }
+  const uniPool = raw.protocols?.uniswap?.pool;
+  if (!uniPool) {
+    process.stdout.write(noop("uniswap pool unavailable"));
+    return;
+  }
+  const obs: Observation = { ...raw, pool: uniPool };
+
+  seedFromHistory(obs.history);
+
+  const pool = obs.pool.priceUsdcPerWeth;
+  const fair = obs.fairPriceUsdcPerWeth;
+  const gap = computeGap(pool, fair);
+  if (gap === null) {
+    process.stdout.write(noop("invalid prices"));
+    return;
+  }
+
+  // Score against the current model BEFORE incorporating the new sample —
+  // otherwise the latest point pulls the mean toward itself and damps the
+  // signal. Then fold it in for next round.
+  const z = stats.zscore(gap);
+  stats.update(gap);
+  seenRounds.add(obs.round);
+
+  if (stats.count() < BURN_IN) {
+    process.stdout.write(noop(`burn-in (${stats.count()}/${BURN_IN})`));
+    return;
+  }
+
+  const absZ = Math.abs(z);
+  if (absZ < Z_ENTER) {
+    process.stdout.write(noop(`|z|=${absZ.toFixed(2)} < ${Z_ENTER}`));
+    return;
+  }
+
+  const tokenIn: "WETH" | "USDC" = gap > 0 ? "USDC" : "WETH";
+  const max = BigInt(
+    tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits,
+  );
+
+  // Linear ramp: SIZE_FLOOR_BPS at |z| = Z_ENTER, SIZE_CAP_BPS at |z| >= Z_AGGRESSIVE.
+  const span = Math.max(0.0001, Z_AGGRESSIVE - Z_ENTER);
+  const t = Math.max(0, Math.min(1, (absZ - Z_ENTER) / span));
+  const sizeBps = Math.max(
+    SIZE_FLOOR_BPS,
+    Math.min(
+      SIZE_CAP_BPS,
+      Math.floor(SIZE_FLOOR_BPS + (SIZE_CAP_BPS - SIZE_FLOOR_BPS) * t),
+    ),
+  );
+  const amountIn = (max * BigInt(sizeBps)) / 10_000n;
+
+  if (amountIn <= 0n) {
+    process.stdout.write(noop("size rounds to zero"));
+    return;
+  }
+
+  // EV in USDC ≈ size_usdc * |gap|. Convert to wei via fair price.
+  const sizeUsdc =
+    tokenIn === "USDC"
+      ? Number(amountIn) / 1e6
+      : (Number(amountIn) / 1e18) * fair;
+  const evUsdc = sizeUsdc * Math.abs(gap);
+  const evGwei = Math.max(0, Math.floor((evUsdc / fair) * 1e9));
+  const evWei = BigInt(evGwei) * 1_000_000_000n;
+
+  const alphaScale = 10_000n;
+  const alphaNum = BigInt(
+    Math.max(0, Math.floor(BID_ALPHA * Number(alphaScale))),
+  );
+  const bidPerGasWei = (evWei * alphaNum) / alphaScale / GAS_UNITS_ESTIMATE;
+
+  const minBid = BigInt(obs.limits.defaultPriorityFeePerGasWei);
+  const maxBid = BigInt(obs.limits.maxPriorityFeePerGasWei);
+  const bid =
+    bidPerGasWei < minBid
+      ? minBid
+      : bidPerGasWei > maxBid
+        ? maxBid
+        : bidPerGasWei;
+
+  process.stdout.write(
+    `${JSON.stringify({
+      type: "swap",
+      tokenIn,
+      amountIn: amountIn.toString(),
+      maxPriorityFeePerGasWei: bid.toString(),
+      slippageBps: 75,
+    })}\n`,
+  );
+});

--- a/examples/lib/aave-liquidation.ts
+++ b/examples/lib/aave-liquidation.ts
@@ -1,0 +1,50 @@
+// Aave V3 liquidationCall の raw tx builder(GitHub #1)。
+// Pool/トークンは src/constants.ts(Arbitrum)を参照。
+import { encodeFunctionData } from "viem";
+import { AAVE } from "../../src/constants.js";
+
+export type RawTx = { to: string; data: string };
+
+const liquidationAbi = [
+  {
+    type: "function",
+    name: "liquidationCall",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "collateralAsset", type: "address" },
+      { name: "debtAsset", type: "address" },
+      { name: "user", type: "address" },
+      { name: "debtToCover", type: "uint256" },
+      { name: "receiveAToken", type: "bool" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/**
+ * liquidationCall を 1 tx 分組み立てる。
+ * debtToCover に uint256.max を渡すと Aave 側が close factor(最大 50% など)で上限クランプする。
+ * receiveAToken=false で原資産(WETH)を受け取り、別途 swap で USDC 化できる。
+ */
+export function buildLiquidationCall(
+  collateralAsset: string,
+  debtAsset: string,
+  user: string,
+  debtToCover: bigint,
+  receiveAToken = false,
+): RawTx {
+  return {
+    to: AAVE.Pool,
+    data: encodeFunctionData({
+      abi: liquidationAbi,
+      functionName: "liquidationCall",
+      args: [
+        collateralAsset as `0x${string}`,
+        debtAsset as `0x${string}`,
+        user as `0x${string}`,
+        debtToCover,
+        receiveAToken,
+      ],
+    }),
+  };
+}

--- a/examples/lib/aave.ts
+++ b/examples/lib/aave.ts
@@ -2,51 +2,76 @@
  * Aave V3 raw transaction builders.
  *
  * Builds unsigned tx objects ({ to, data }) for supply, withdraw,
- * and ERC-20 approval. No external CLI or dependencies beyond viem.
+ * and ERC-20 approval. Pool/トークンアドレスは src/constants.ts(Arbitrum)を参照。
  */
 import { encodeFunctionData } from "viem";
+import { AAVE, TOKENS as ARB_TOKENS } from "../../src/constants.js";
 
-const AAVE_V3_POOL = "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2";
+// sim は Arbitrum フォーク。Pool/トークンは src/constants.ts の Arbitrum 値を使う
+// （mainnet ハードコードだとフォーク上の存在しないコントラクトに当たり機能しない）。
+const AAVE_V3_POOL: `0x${string}` = AAVE.Pool;
 
 const TOKENS: Record<string, { address: `0x${string}`; decimals: number }> = {
-  USDC: { address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6 },
-  WETH: { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", decimals: 18 },
-  DAI:  { address: "0x6B175474E89094C44Da98b954EedeAC495271d0F", decimals: 18 },
-  WBTC: { address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", decimals: 8 },
+  USDC: {
+    address: ARB_TOKENS.USDC.address,
+    decimals: ARB_TOKENS.USDC.decimals,
+  },
+  WETH: {
+    address: ARB_TOKENS.WETH.address,
+    decimals: ARB_TOKENS.WETH.decimals,
+  },
 };
 
 export type RawTx = { to: string; data: string; value?: string };
 
-const erc20ApproveAbi = [{
-  type: "function", name: "approve", stateMutability: "nonpayable",
-  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
-  outputs: [{ name: "", type: "bool" }],
-}] as const;
+const erc20ApproveAbi = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
 
-const poolSupplyAbi = [{
-  type: "function", name: "supply", stateMutability: "nonpayable",
-  inputs: [
-    { name: "asset", type: "address" },
-    { name: "amount", type: "uint256" },
-    { name: "onBehalfOf", type: "address" },
-    { name: "referralCode", type: "uint16" },
-  ],
-  outputs: [],
-}] as const;
+const poolSupplyAbi = [
+  {
+    type: "function",
+    name: "supply",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "asset", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "onBehalfOf", type: "address" },
+      { name: "referralCode", type: "uint16" },
+    ],
+    outputs: [],
+  },
+] as const;
 
-const poolWithdrawAbi = [{
-  type: "function", name: "withdraw", stateMutability: "nonpayable",
-  inputs: [
-    { name: "asset", type: "address" },
-    { name: "amount", type: "uint256" },
-    { name: "to", type: "address" },
-  ],
-  outputs: [{ name: "", type: "uint256" }],
-}] as const;
+const poolWithdrawAbi = [
+  {
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "asset", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "to", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
 
 function resolveToken(symbol: string) {
   const token = TOKENS[symbol.toUpperCase()];
-  if (!token) throw new Error(`Unsupported token: ${symbol}. Supported: ${Object.keys(TOKENS).join(", ")}`);
+  if (!token)
+    throw new Error(
+      `Unsupported token: ${symbol}. Supported: ${Object.keys(TOKENS).join(", ")}`,
+    );
   return token;
 }
 
@@ -97,9 +122,10 @@ export function buildAaveWithdraw(
   to: string,
 ): RawTx {
   const token = resolveToken(asset);
-  const amountBase = amount < 0
-    ? 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn
-    : toBaseUnits(amount, token.decimals);
+  const amountBase =
+    amount < 0
+      ? 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn
+      : toBaseUnits(amount, token.decimals);
 
   return {
     to: AAVE_V3_POOL,

--- a/examples/lib/flash.ts
+++ b/examples/lib/flash.ts
@@ -1,0 +1,45 @@
+// フラッシュローン helper(GitHub #2)。Aave V3 Pool.flashLoanSimple の raw tx builder。
+// receiver(FlashArb)が executeOperation で arb を実行し amount+premium を返済する。
+import { encodeFunctionData } from "viem";
+import { AAVE } from "../../src/constants.js";
+
+export type RawTx = { to: string; data: string };
+
+const flashAbi = [
+  {
+    type: "function",
+    name: "flashLoanSimple",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "receiverAddress", type: "address" },
+      { name: "asset", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "params", type: "bytes" },
+      { name: "referralCode", type: "uint16" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+export function buildFlashLoanSimple(
+  receiver: string,
+  asset: string,
+  amount: bigint,
+  params: `0x${string}` = "0x",
+  referralCode = 0,
+): RawTx {
+  return {
+    to: AAVE.Pool,
+    data: encodeFunctionData({
+      abi: flashAbi,
+      functionName: "flashLoanSimple",
+      args: [
+        receiver as `0x${string}`,
+        asset as `0x${string}`,
+        amount,
+        params,
+        referralCode,
+      ],
+    }),
+  };
+}

--- a/examples/lib/flow-stats.ts
+++ b/examples/lib/flow-stats.ts
@@ -1,0 +1,81 @@
+// Flow / volatility statistics helpers for prediction-style strategies.
+// Pure functions; no shared state. Numbers (float) inputs since price observations
+// are returned as JS numbers in the observation schema.
+
+export type HistoryPoint = {
+  round: number;
+  poolPriceUsdcPerWeth: number;
+  fairPriceUsdcPerWeth: number;
+};
+
+/**
+ * Realized variance of `poolPriceUsdcPerWeth` log-returns over the last `window`
+ * history points. Uses log-returns so it is scale-invariant and consistent with
+ * standard realized-vol estimators.
+ *
+ * Returns 0 if fewer than 2 valid points are available in the window. The
+ * variance is computed with N-1 (sample) denominator; for window=2 this is the
+ * single squared log-return.
+ */
+export function realizedVariance(history: HistoryPoint[], window: number): number {
+  if (!Array.isArray(history) || history.length < 2 || window < 2) return 0;
+  const slice = history.slice(-window);
+  const returns: number[] = [];
+  for (let i = 1; i < slice.length; i++) {
+    const prev = slice[i - 1].poolPriceUsdcPerWeth;
+    const curr = slice[i].poolPriceUsdcPerWeth;
+    if (!Number.isFinite(prev) || !Number.isFinite(curr) || prev <= 0 || curr <= 0) continue;
+    returns.push(Math.log(curr / prev));
+  }
+  if (returns.length < 1) return 0;
+  if (returns.length === 1) return returns[0] * returns[0];
+  let mean = 0;
+  for (const r of returns) mean += r;
+  mean /= returns.length;
+  let sumSq = 0;
+  for (const r of returns) {
+    const d = r - mean;
+    sumSq += d * d;
+  }
+  return sumSq / (returns.length - 1);
+}
+
+/**
+ * Root-mean-square deviation of `poolPrice` from `fairPrice` (relative) over
+ * the last `window` history points. 0 if no points.
+ */
+export function fairDeviationRms(history: HistoryPoint[], window: number): number {
+  if (!Array.isArray(history) || history.length === 0 || window < 1) return 0;
+  const slice = history.slice(-window);
+  let sumSq = 0;
+  let n = 0;
+  for (const point of slice) {
+    const pool = point.poolPriceUsdcPerWeth;
+    const fair = point.fairPriceUsdcPerWeth;
+    if (!Number.isFinite(pool) || !Number.isFinite(fair) || fair <= 0) continue;
+    const rel = pool / fair - 1;
+    sumSq += rel * rel;
+    n++;
+  }
+  if (n === 0) return 0;
+  return Math.sqrt(sumSq / n);
+}
+
+/**
+ * Linear-interpolated quantile (q in [0,1]) of `values`. Returns 0 if empty.
+ * Does NOT mutate `values`.
+ */
+export function quantile(values: number[], q: number): number {
+  if (!Array.isArray(values) || values.length === 0) return 0;
+  const cleaned = values.filter((v) => Number.isFinite(v));
+  if (cleaned.length === 0) return 0;
+  if (cleaned.length === 1) return cleaned[0];
+  const sorted = cleaned.slice().sort((a, b) => a - b);
+  const clamped = Math.max(0, Math.min(1, q));
+  const pos = clamped * (sorted.length - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  const frac = pos - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}

--- a/examples/lib/rolling-stats.ts
+++ b/examples/lib/rolling-stats.ts
@@ -1,0 +1,64 @@
+/**
+ * RollingStats: Welford's online algorithm for streaming mean / variance.
+ *
+ * Numerically stable, unbounded sample count (no fixed window — see note).
+ * Used by stat-arb to feed pool/fair gap series and pull a z-score per round.
+ *
+ * Note: this implementation is unbounded; older samples are not evicted. The
+ * `windowHint` constructor argument is metadata only (callers can read it via
+ * `.windowHint`) so a single env var can express both "how long is the
+ * burn-in" and "what window were you tuned against".
+ *
+ * Usage:
+ *   const rs = new RollingStats();
+ *   rs.update(0.001);
+ *   rs.update(-0.0005);
+ *   rs.zscore(0.0008); // (0.0008 - mean) / std
+ */
+export class RollingStats {
+  private n = 0;
+  private mu = 0;
+  private m2 = 0;
+  readonly windowHint: number;
+
+  constructor(windowHint = 0) {
+    this.windowHint = windowHint;
+  }
+
+  update(x: number): void {
+    if (!Number.isFinite(x)) return;
+    this.n += 1;
+    const delta = x - this.mu;
+    this.mu += delta / this.n;
+    const delta2 = x - this.mu;
+    this.m2 += delta * delta2;
+  }
+
+  count(): number {
+    return this.n;
+  }
+
+  mean(): number {
+    return this.n > 0 ? this.mu : 0;
+  }
+
+  /**
+   * Sample standard deviation (n-1 denominator). Returns 0 if fewer than 2
+   * samples have been recorded.
+   */
+  std(): number {
+    if (this.n < 2) return 0;
+    const variance = this.m2 / (this.n - 1);
+    return variance > 0 ? Math.sqrt(variance) : 0;
+  }
+
+  /**
+   * Z-score of `x` against the running mean/std. Returns 0 if std is 0 (no
+   * spread observed yet) so callers can treat "uninformative" as "do nothing".
+   */
+  zscore(x: number): number {
+    const s = this.std();
+    if (s === 0) return 0;
+    return (x - this.mu) / s;
+  }
+}

--- a/examples/lib/tick-math.ts
+++ b/examples/lib/tick-math.ts
@@ -1,0 +1,26 @@
+// Tick math helpers for Uniswap v3-style concentrated liquidity ranges.
+// Uses the standard formula: tick = log(price) / log(1.0001), aligned to tickSpacing
+// via Math.floor (so the returned tick is the largest multiple of tickSpacing
+// that is <= the raw tick, which mirrors the spacing convention used by the pool).
+//
+// `price` here is the pool price in token1-per-token0 terms. For our pool that
+// is USDC-per-WETH, after normalizing the 12-decimal gap between WETH (18) and
+// USDC (6). Observations already expose `pool.priceUsdcPerWeth` in that
+// human-readable form, so callers can pass it directly.
+
+const LOG_BASE = Math.log(1.0001);
+
+export function priceToTick(price: number, tickSpacing: number): number {
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new Error("priceToTick: price must be a positive finite number");
+  }
+  if (!Number.isInteger(tickSpacing) || tickSpacing <= 0) {
+    throw new Error("priceToTick: tickSpacing must be a positive integer");
+  }
+  const rawTick = Math.log(price) / LOG_BASE;
+  return Math.floor(rawTick / tickSpacing) * tickSpacing;
+}
+
+export function tickToPrice(tick: number): number {
+  return Math.pow(1.0001, tick);
+}

--- a/scripts/genRoster.ts
+++ b/scripts/genRoster.ts
@@ -52,6 +52,28 @@ const PARAMETRIC: StratDef[] = [
     script: "examples/agents/gmx-trend.ts",
     sweep: { TREND_BPS: [30, 60], TREND_LOOKBACK: [8, 16] },
   },
+  // main から取り込んだ新戦略(observation 正規化を入れて実動作させた)。
+  {
+    base: "statarb",
+    script: "examples/agents/stat-arb.ts",
+    // Z_AGGRESSIVE 既定 2.5 を超えない範囲で entry 閾値を sweep。
+    sweep: { STAT_ARB_Z_ENTER: [1.0, 1.5, 2.0] },
+  },
+  {
+    base: "fairmm",
+    script: "examples/agents/fair-mm.ts",
+    sweep: { FAIR_MM_RANGE_TICK_MULTIPLIER: [4, 8] },
+  },
+  {
+    base: "jitlp",
+    script: "examples/agents/jit-lp.ts",
+    sweep: { JIT_VOL_QUANTILE: [0.8, 0.9] },
+  },
+  {
+    base: "ladder",
+    script: "examples/agents/ladder-mm.ts",
+    sweep: { LADDER_STEPS: [3, 5] },
+  },
 ];
 
 // 固定挙動(env パラメータ無し)。1 インスタンスずつ。

--- a/scripts/genRoster.ts
+++ b/scripts/genRoster.ts
@@ -11,6 +11,7 @@
 //   ENABLED_PROTOCOLS=uniswap,balancer,curve,gmx ROUNDS=128 \
 //     AGENTS_CONFIG=agents.swarm-big.json npm run leaderboard
 import { writeFileSync } from "node:fs";
+import { BASE_STRATEGY_IDS } from "../src/llm/baseStrategies.js";
 import type { AgentSpec } from "../src/types.js";
 
 type Sweep = Record<string, Array<string | number>>;
@@ -147,9 +148,12 @@ function build(): AgentSpec[] {
     });
   }
 
-  // 任意: 自己改善する LLM agent(ベース戦略から進化)。INCLUDE_LLM=1 で混ぜる。
+  // 任意: 自己改善する LLM agent。INCLUDE_LLM=1 で**全ベース戦略**(src/llm/baseStrategies.ts)を
+  // それぞれ LLM seed して混ぜる。ベース戦略を増やすほど自動で対象が増える。
+  // 注意: 各 agent が背景で `claude -p`(1回 ~1-3分)を revise ごとに呼ぶため、数が増えると
+  // run 時間とサブスク/API コストが大きくなる。小さく試すなら ERIS_LLM_REVIEW_EVERY を大きく。
   if (process.env.INCLUDE_LLM === "1") {
-    for (const base of ["arb", "lp"]) {
+    for (const base of BASE_STRATEGY_IDS) {
       agents.push({
         ...agentScript("examples/agents/claude-llm.ts"),
         id: `llm-${base}`,

--- a/scripts/genRoster.ts
+++ b/scripts/genRoster.ts
@@ -87,6 +87,10 @@ const FIXED: StratDef[] = [
   { base: "venue", script: "examples/agents/venue-arb.ts" },
   { base: "simple", script: "examples/agents/simple-rule.ts" },
   { base: "rawswap", script: "examples/agents/raw-swap.ts" },
+  // GitHub [strategy] issues #6 / #4 / #11
+  { base: "aaveloop", script: "examples/agents/aave-loop.ts" },
+  { base: "crossvenue", script: "examples/agents/cross-venue-arb.ts" },
+  { base: "lpyield", script: "examples/agents/lp-yield.ts" },
 ];
 
 // env パラメータの直積。{A:[1,2],B:[9]} → [{A:1,B:9},{A:2,B:9}]

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -165,11 +165,50 @@ export async function mine(
   } as AnvilRequest);
 }
 
-export async function resetFork(publicClient: PublicClient): Promise<void> {
+export type ResetForkOptions = {
+  // 上流フォーク RPC（ARB_RPC_URL）。指定時は forking 付き anvil_reset でフォークを
+  // 丸ごと作り直し、前 run/seed のローカル変更（Aave ポジション・reserve タイムスタンプ等）を
+  // 完全に破棄する。未指定なら anvil_reset [] にフォールバック（状態が残留する点に注意）。
+  forkUrl?: string;
+  // 再フォーク先ブロック（FORK_BLOCK_NUMBER）。固定すると再実行が完全再現可能。
+  forkBlockNumber?: number;
+};
+
+// 同一プロセス内で一度捕捉した再フォーク先ブロック。multiSeedRun は 1 プロセスで全 SEED を
+// 回すため、ここで固定して全 seed が同一フォークブロック（=同一の DeFi 流動性基準）を共有する。
+let capturedForkBlock: number | undefined;
+
+export async function resetFork(
+  publicClient: PublicClient,
+  options: ResetForkOptions = {},
+): Promise<void> {
+  const { forkUrl, forkBlockNumber } = options;
+  if (!forkUrl) {
+    // 上流 RPC 不明 → soft reset。状態が完全にはクリアされないため、複数 run/seed を
+    // 同一 anvil で回す場合は anvil を都度再起動するか forkUrl を設定すること。
+    await publicClient.request({
+      method: "anvil_reset",
+      params: [],
+    } as AnvilRequest);
+    return;
+  }
+  // 再現性のためブロックを固定。優先順: 明示指定 > プロセス内で捕捉済み > これから捕捉。
+  const blockNumber = forkBlockNumber ?? capturedForkBlock;
   await publicClient.request({
     method: "anvil_reset",
-    params: [],
+    params: [
+      {
+        forking:
+          blockNumber !== undefined
+            ? { jsonRpcUrl: forkUrl, blockNumber }
+            : { jsonRpcUrl: forkUrl },
+      },
+    ],
   } as AnvilRequest);
+  if (blockNumber === undefined) {
+    // latest を捕捉し、以降の resetFork で再利用（同プロセス内の決定論を確保）。
+    capturedForkBlock = Number((await publicClient.getBlock()).number);
+  }
 }
 
 async function setStorageAt(

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,13 @@ export type SimConfig = {
   // 再フォーク先ブロック（FORK_BLOCK_NUMBER）。固定すると再実行が完全再現可能になる。
   // 未設定なら最初の resetFork で latest を捕捉し、以降のリセットで再利用する。
   forkBlockNumber?: number;
+  // 清算デモ(GitHub #1)。ERIS_LIQUIDATION_DEMO=1 のとき、coordinator が victim ウォレットに
+  // 過剰レバレッジの Aave ポジションを開かせ、shockRound 以降に Aave WETH オラクルを引き下げて
+  // HF<1 にし、liquidator agent が清算できる状況を作る。既定 off(既存 run/テストは不変)。
+  liquidationDemo: boolean;
+  liquidationShockBps: number; // WETH オラクル引き下げ幅(bps, 既定 1500=15%)
+  liquidationShockRound: number; // 引き下げを始めるラウンド(既定 3)
+  liquidationVictimSupplyWethWei: bigint; // victim が supply する WETH(既定 5)
   rounds: number;
   roundTimeSeconds: number;
   seed: number;
@@ -97,6 +104,13 @@ export function loadConfig(env = process.env): SimConfig {
       env.FORK_BLOCK_NUMBER && env.FORK_BLOCK_NUMBER.trim() !== ""
         ? intEnv(env.FORK_BLOCK_NUMBER, 0)
         : undefined,
+    liquidationDemo: env.ERIS_LIQUIDATION_DEMO === "1",
+    liquidationShockBps: intEnv(env.ERIS_LIQUIDATION_SHOCK_BPS, 1500),
+    liquidationShockRound: intEnv(env.ERIS_LIQUIDATION_SHOCK_ROUND, 3),
+    liquidationVictimSupplyWethWei: bigintEnv(
+      env.ERIS_LIQUIDATION_VICTIM_WETH_WEI,
+      5_000_000_000_000_000_000n,
+    ),
     rounds: intEnv(env.ROUNDS, 50),
     // 1 ラウンドあたりに進める EVM 時間（秒）。Aave 変動金利の累積や GMX funding
     // を現実的なスケールで発生させるためにラウンドループで evm_increaseTime に渡す。

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,14 @@ const SUPPORTED_AGENT_WALLETS = [...NAMED_AGENT_WALLETS, "AUTO"] as const;
 export type SimConfig = {
   rpcUrl: string;
   chainId: number;
+  // フォーク元の上流 RPC（ARB_RPC_URL）。設定時は resetFork が anvil_reset を
+  // forking 設定付きで呼び、フォーク状態を毎回クリーンに再構築する（run/seed 間で
+  // Aave 等のポジションが残留する anvil_reset [] の問題を回避）。未設定なら従来の
+  // anvil_reset [] にフォールバック。
+  forkUrl?: string;
+  // 再フォーク先ブロック（FORK_BLOCK_NUMBER）。固定すると再実行が完全再現可能になる。
+  // 未設定なら最初の resetFork で latest を捕捉し、以降のリセットで再利用する。
+  forkBlockNumber?: number;
   rounds: number;
   roundTimeSeconds: number;
   seed: number;
@@ -81,6 +89,14 @@ export function loadConfig(env = process.env): SimConfig {
   return {
     rpcUrl: env.ANVIL_RPC_URL ?? `http://127.0.0.1:${anvilPort}`,
     chainId: intEnv(env.CHAIN_ID, CHAIN_ID),
+    forkUrl:
+      env.ARB_RPC_URL && env.ARB_RPC_URL.trim() !== ""
+        ? env.ARB_RPC_URL.trim()
+        : undefined,
+    forkBlockNumber:
+      env.FORK_BLOCK_NUMBER && env.FORK_BLOCK_NUMBER.trim() !== ""
+        ? intEnv(env.FORK_BLOCK_NUMBER, 0)
+        : undefined,
     rounds: intEnv(env.ROUNDS, 50),
     // 1 ラウンドあたりに進める EVM 時間（秒）。Aave 変動金利の累積や GMX funding
     // を現実的なスケールで発生させるためにラウンドループで evm_increaseTime に渡す。

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,9 @@ export type SimConfig = {
   liquidationShockBps: number; // WETH オラクル引き下げ幅(bps, 既定 1500=15%)
   liquidationShockRound: number; // 引き下げを始めるラウンド(既定 3)
   liquidationVictimSupplyWethWei: bigint; // victim が supply する WETH(既定 5)
+  // フラッシュ arb デモ(GitHub #3)。ERIS_FLASH_ARB=1 で coordinator が FlashArb コントラクトを
+  // デプロイし、flash-arb agent が利用できるようにする。uniswap+balancer+aave 有効が前提。既定 off。
+  flashArbDemo: boolean;
   rounds: number;
   roundTimeSeconds: number;
   seed: number;
@@ -111,6 +114,7 @@ export function loadConfig(env = process.env): SimConfig {
       env.ERIS_LIQUIDATION_VICTIM_WETH_WEI,
       5_000_000_000_000_000_000n,
     ),
+    flashArbDemo: env.ERIS_FLASH_ARB === "1",
     rounds: intEnv(env.ROUNDS, 50),
     // 1 ラウンドあたりに進める EVM 時間（秒）。Aave 変動金利の累積や GMX funding
     // を現実的なスケールで発生させるためにラウンドループで evm_increaseTime に渡す。

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -107,8 +107,19 @@ export async function runSimulation(): Promise<void> {
     config.rpcUrl,
     config.chainId,
   );
-  await resetFork(publicClient);
-  logger.event({ type: "fork_reset" });
+  await resetFork(publicClient, {
+    forkUrl: config.forkUrl,
+    forkBlockNumber: config.forkBlockNumber,
+  });
+  if (!config.forkUrl) {
+    // 上流 RPC 未設定だと soft reset になり、run/seed 間で Aave 等の状態が残留する。
+    console.warn(
+      "[coordinator] ARB_RPC_URL 未設定: anvil_reset [] フォールバック。複数 run/seed を" +
+        "同一 anvil で回すと Aave ポジションが残留し PnL が汚染されます。ARB_RPC_URL を設定するか" +
+        " anvil を都度再起動してください。",
+    );
+  }
+  logger.event({ type: "fork_reset", forked: Boolean(config.forkUrl) });
 
   const agentSpecs = loadAgents(config.agentsConfigPath);
   const agentRuntimes: AgentRuntime[] = agentSpecs.map((spec) => {

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -48,6 +48,13 @@ import { GMX_MARKETS } from "./constants.js";
 import { FlowProcess } from "./flowProcess.js";
 import type { FlowContextWire } from "./flow/logic.js";
 import { readAaveFlowReserves } from "./protocols/aave.js";
+import {
+  applyOracleShock,
+  openVictimPosition,
+  setupVictim,
+  VICTIM_ADDRESS,
+  victimHealthFactor,
+} from "./liquidationDemo.js";
 
 type AgentRuntime = {
   id: string;
@@ -261,6 +268,17 @@ export async function runSimulation(): Promise<void> {
       });
     }
 
+    // ---- 清算デモ(GitHub #1, env gate): victim を資金調達+approve ----
+    const liquidationDemo =
+      config.liquidationDemo && enabledIds.includes("aave");
+    if (liquidationDemo) {
+      await setupVictim(ctx);
+      logger.event({
+        type: "liquidation_victim_setup",
+        address: VICTIM_ADDRESS,
+      });
+    }
+
     let fairPrice = await initialFairPrice(ctx, enabledIds);
     const history: AgentObservation["history"] = [];
     for (const agent of agentRuntimes) {
@@ -283,6 +301,20 @@ export async function runSimulation(): Promise<void> {
       // ---- 1) Oracle ブロック（GMX/Aave の mock 価格を fairPrice に追従）----
       // updateOracles は内部で sendAndMine するため追加 mine は不要。
       await updateOracles(ctx, fairPrice);
+
+      // ---- 1b) 清算デモ(env gate): round 1 で victim を開き、shockRound 以降は
+      //         WETH オラクルを引き下げて victim を HF<1 にする ----
+      if (liquidationDemo) {
+        if (round === 1) await openVictimPosition(ctx);
+        if (round >= config.liquidationShockRound) {
+          await applyOracleShock(ctx, fairPrice);
+          logger.event({
+            type: "liquidation_victim_hf",
+            round,
+            healthFactor: (await victimHealthFactor(ctx)).toString(),
+          });
+        }
+      }
 
       // ---- 2) 競争ブロック ----
       const stateById = new Map<ProtocolId, unknown>();

--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -55,6 +55,7 @@ import {
   VICTIM_ADDRESS,
   victimHealthFactor,
 } from "./liquidationDemo.js";
+import { deployFlashArb, FLASH_ARB_ADDRESS } from "./flashArbDemo.js";
 
 type AgentRuntime = {
   id: string;
@@ -277,6 +278,17 @@ export async function runSimulation(): Promise<void> {
         type: "liquidation_victim_setup",
         address: VICTIM_ADDRESS,
       });
+    }
+
+    // ---- フラッシュ arb デモ(GitHub #3, env gate): FlashArb をデプロイ ----
+    if (
+      config.flashArbDemo &&
+      enabledIds.includes("aave") &&
+      enabledIds.includes("uniswap") &&
+      enabledIds.includes("balancer")
+    ) {
+      await deployFlashArb(ctx);
+      logger.event({ type: "flash_arb_deployed", address: FLASH_ARB_ADDRESS });
     }
 
     let fairPrice = await initialFairPrice(ctx, enabledIds);

--- a/src/flashArbDemo.ts
+++ b/src/flashArbDemo.ts
@@ -1,0 +1,89 @@
+// フラッシュ arb デモ(GitHub #3)。ERIS_FLASH_ARB=1 のときだけ coordinator から使う。
+// 固定 deployer の nonce-0 デプロイで FlashArb のアドレスを決定論化し、agent 側でも
+// getContractAddress で同じ値を計算できる(env 注入不要)。既定 off。
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  getContractAddress,
+  keccak256,
+  toBytes,
+  type Abi,
+  type Address,
+  type Hex,
+} from "viem";
+import { accountAddress, mine, setEthBalance } from "./chain.js";
+import { AAVE, BALANCER, TOKENS, UNISWAP } from "./constants.js";
+import type { SimContext } from "./protocols/types.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// デモ用の固定 deployer 鍵。FlashArb をこの鍵の最初の tx(nonce 0)としてデプロイするため、
+// CREATE アドレスが決定論的になる。
+export const FLASH_DEPLOYER_KEY: Hex = keccak256(
+  toBytes("eris-flash-arb-deployer-v1"),
+);
+export const FLASH_DEPLOYER_ADDRESS: Address =
+  accountAddress(FLASH_DEPLOYER_KEY);
+
+// nonce 0 デプロイの決定論アドレス。agent も coordinator もこの値を使う。
+export const FLASH_ARB_ADDRESS: Address = getContractAddress({
+  from: FLASH_DEPLOYER_ADDRESS,
+  nonce: 0n,
+});
+
+function artifact(name: string): { abi: Abi; bytecode: Hex } {
+  const p = resolve(here, `../out/${name}.sol/${name}.json`);
+  if (!existsSync(p)) {
+    throw new Error(
+      `forge artifact missing: ${p}. Run \`npm run build:contracts\`.`,
+    );
+  }
+  const a = JSON.parse(readFileSync(p, "utf8"));
+  return {
+    abi: a.abi as Abi,
+    bytecode: (a.bytecode?.object ?? a.bytecode) as Hex,
+  };
+}
+
+// FlashArb を固定 deployer から(nonce 0 で)デプロイ。setup フェーズで 1 回。
+export async function deployFlashArb(ctx: SimContext): Promise<Address> {
+  const account = privateKeyToAccount(FLASH_DEPLOYER_KEY);
+  await setEthBalance(
+    ctx.publicClient,
+    FLASH_DEPLOYER_ADDRESS,
+    1_000_000_000_000_000_000n,
+  );
+  const { abi, bytecode } = artifact("FlashArb");
+  const block = await ctx.publicClient.getBlock();
+  const baseFee = block.baseFeePerGas ?? 0n;
+  const hash = await ctx.walletClient.deployContract({
+    abi,
+    bytecode,
+    args: [
+      AAVE.Pool,
+      UNISWAP.swapRouter,
+      BALANCER.vault,
+      BALANCER.poolId,
+      TOKENS.WETH.address,
+      TOKENS.USDC.address,
+      UNISWAP.fee,
+    ] as never,
+    account,
+    chain: ctx.chain,
+    maxFeePerGas: baseFee + 1_000_000_000n,
+    maxPriorityFeePerGas: 1_000_000_000n,
+  });
+  await mine(ctx.publicClient);
+  const receipt = await ctx.publicClient.waitForTransactionReceipt({ hash });
+  if (!receipt.contractAddress) throw new Error("FlashArb deploy failed");
+  if (
+    receipt.contractAddress.toLowerCase() !== FLASH_ARB_ADDRESS.toLowerCase()
+  ) {
+    throw new Error(
+      `FlashArb address mismatch: ${receipt.contractAddress} != ${FLASH_ARB_ADDRESS}`,
+    );
+  }
+  return receipt.contractAddress;
+}

--- a/src/liquidationDemo.ts
+++ b/src/liquidationDemo.ts
@@ -1,0 +1,126 @@
+// 清算デモ(GitHub #1)。ERIS_LIQUIDATION_DEMO=1 のときだけ coordinator から使う。
+// victim ウォレットに過剰レバレッジの Aave ポジションを開かせ、shockRound 以降に Aave WETH
+// オラクルを引き下げて HF<1 にし、liquidator agent が liquidationCall で清算できる状況を作る。
+// 既定 off なので通常の run/テストには一切影響しない。
+import {
+  encodeFunctionData,
+  keccak256,
+  toBytes,
+  type Address,
+  type Hex,
+} from "viem";
+import { accountAddress, fundWallet, mine, sendAndMine } from "./chain.js";
+import { AAVE, TOKENS } from "./constants.js";
+import {
+  aavePoolAbi,
+  mockAggregatorAbi,
+  toAavePrice,
+} from "./protocols/aave.js";
+import { approveTx } from "./protocols/uniswap.js";
+import type { SimContext } from "./protocols/types.js";
+
+const AAVE_STABLE = TOKENS.USDC.address;
+const VARIABLE_RATE = 2n;
+
+// デモ用の固定鍵。アドレスが既知なので liquidator の env(ERIS_LIQUIDATION_VICTIMS)に
+// ハードコード(既定値)できる。seed 非依存でよい(デモ専用・env gate 済み)。
+export const VICTIM_PRIVATE_KEY: Hex = keccak256(
+  toBytes("eris-liquidation-victim-v1"),
+);
+export const VICTIM_ADDRESS: Address = accountAddress(VICTIM_PRIVATE_KEY);
+
+// victim に資金を入れ Aave Pool へ approve(setup フェーズで 1 回)。
+export async function setupVictim(ctx: SimContext): Promise<void> {
+  const { publicClient, walletClient, chain, config } = ctx;
+  await fundWallet(
+    publicClient,
+    walletClient,
+    chain,
+    VICTIM_PRIVATE_KEY,
+    1_000_000_000_000_000_000n, // 1 ETH (gas)
+    config.liquidationVictimSupplyWethWei + 1_000_000_000_000_000_000n, // supply + buffer
+    1_000_000n, // 1 USDC(端数)
+  );
+  for (const tx of [
+    approveTx(TOKENS.WETH.address, AAVE.Pool),
+    approveTx(AAVE_STABLE, AAVE.Pool),
+  ]) {
+    await sendAndMine(publicClient, walletClient, chain, VICTIM_PRIVATE_KEY, {
+      to: tx.to,
+      data: tx.data,
+    });
+  }
+}
+
+// victim が WETH を supply → 借入余力ほぼ満額の USDC を borrow(HF を 1 付近に置く)。
+export async function openVictimPosition(ctx: SimContext): Promise<void> {
+  const { publicClient, walletClient, chain, config } = ctx;
+  await sendAndMine(publicClient, walletClient, chain, VICTIM_PRIVATE_KEY, {
+    to: AAVE.Pool,
+    data: encodeFunctionData({
+      abi: aavePoolAbi,
+      functionName: "supply",
+      args: [
+        TOKENS.WETH.address,
+        config.liquidationVictimSupplyWethWei,
+        VICTIM_ADDRESS,
+        0,
+      ],
+    }),
+  });
+  const acc = (await publicClient.readContract({
+    address: AAVE.Pool,
+    abi: aavePoolAbi,
+    functionName: "getUserAccountData",
+    args: [VICTIM_ADDRESS],
+  })) as readonly bigint[];
+  // availableBorrowsBase は USD 8 桁。USDC(6 桁)へ: /1e2。安全側に 99%。
+  const borrowUsdc = (acc[2] * 99n) / 10_000n;
+  if (borrowUsdc > 0n) {
+    await sendAndMine(publicClient, walletClient, chain, VICTIM_PRIVATE_KEY, {
+      to: AAVE.Pool,
+      data: encodeFunctionData({
+        abi: aavePoolAbi,
+        functionName: "borrow",
+        args: [AAVE_STABLE, borrowUsdc, VARIABLE_RATE, 0, VICTIM_ADDRESS],
+      }),
+    });
+  }
+}
+
+// Aave WETH オラクルを fairPrice から shockBps 分だけ引き下げて victim を HF<1 にする。
+// updateOracles が毎ラウンド fairPrice に戻すため、その直後に上書きする。
+export async function applyOracleShock(
+  ctx: SimContext,
+  fairPrice: number,
+): Promise<void> {
+  const agg = ctx.oracle.aaveAggregators[TOKENS.WETH.address.toLowerCase()];
+  if (!agg) return;
+  const shocked = fairPrice * (1 - ctx.config.liquidationShockBps / 10_000);
+  await sendAndMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: agg,
+      data: encodeFunctionData({
+        abi: mockAggregatorAbi,
+        functionName: "setAnswer",
+        args: [toAavePrice(shocked)],
+      }),
+    },
+  );
+  await mine(ctx.publicClient);
+}
+
+// victim の現在 HF(1e18 = 1.0)。可視化用。
+export async function victimHealthFactor(ctx: SimContext): Promise<bigint> {
+  const acc = (await ctx.publicClient.readContract({
+    address: AAVE.Pool,
+    abi: aavePoolAbi,
+    functionName: "getUserAccountData",
+    args: [VICTIM_ADDRESS],
+  })) as readonly bigint[];
+  return acc[5];
+}

--- a/src/llm/attribution.ts
+++ b/src/llm/attribution.ts
@@ -1,0 +1,86 @@
+// PnL 帰属(attribution)— ADR 0002 の「安価版」。
+// RoundRecord.inventoryUsd の差分を action.type 別に集計し、「どの行動が効いて/損したか」を
+// revise プロンプトに渡せる小さな要約へ落とす。新規プラミング不要(History が既に持つ情報のみ)。
+import type { RoundRecord } from "./history.js";
+
+export type ActionAttribution = {
+  rounds: number; // その action.type を取ったラウンド数
+  netUsd: number; // 次ラウンドにかけての inventoryUsd 変化の合計(概算 PnL)
+  valid: number; // executorOk だった回数
+  failed: number; // executor エラー/不正だった回数
+};
+
+export type Attribution = {
+  byAction: Record<string, ActionAttribution>;
+  topNoopReasons: Array<[string, number]>;
+  drawdownUsd: number; // 期間中の最大 peak-to-trough(USD, 0 以上)
+  turnover: number; // 非 noop の行動回数
+  samples: number; // 集計に使ったラウンド数
+};
+
+// 連続する RoundRecord の inventoryUsd 差分を「直前の行動」に帰属させる(行動 → 次の評価額)。
+export function computeAttribution(records: RoundRecord[]): Attribution {
+  const byAction: Record<string, ActionAttribution> = {};
+  const noopReasons = new Map<string, number>();
+  let turnover = 0;
+  let peak = records.length > 0 ? records[0].inventoryUsd : 0;
+  let drawdownUsd = 0;
+
+  const bucket = (type: string): ActionAttribution =>
+    (byAction[type] ??= { rounds: 0, netUsd: 0, valid: 0, failed: 0 });
+
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i];
+    const b = bucket(r.action.type);
+    b.rounds++;
+    if (r.executorOk) b.valid++;
+    else b.failed++;
+    if (r.action.type !== "noop") turnover++;
+    // noop / 失敗の理由を数える(executorOk=false の理由も含む)
+    if (r.action.type === "noop" || !r.executorOk) {
+      const key = r.executorReason ?? r.action.type;
+      noopReasons.set(key, (noopReasons.get(key) ?? 0) + 1);
+    }
+    // 行動 i の損益は i→i+1 の評価額変化で概算
+    if (i + 1 < records.length) {
+      b.netUsd += records[i + 1].inventoryUsd - r.inventoryUsd;
+    }
+    // ドローダウン
+    if (r.inventoryUsd > peak) peak = r.inventoryUsd;
+    const dd = peak - r.inventoryUsd;
+    if (dd > drawdownUsd) drawdownUsd = dd;
+  }
+
+  const topNoopReasons = [...noopReasons.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4);
+
+  return {
+    byAction,
+    topNoopReasons,
+    drawdownUsd,
+    turnover,
+    samples: records.length,
+  };
+}
+
+// revise プロンプト用のコンパクトな文字列(トークン節約)。
+export function formatAttribution(a: Attribution): string {
+  if (a.samples === 0) return "(no rounds yet)";
+  const lines = Object.entries(a.byAction)
+    .sort((x, y) => y[1].netUsd - x[1].netUsd)
+    .map(
+      ([type, s]) =>
+        `  ${type}: rounds=${s.rounds} netUsd=${s.netUsd.toFixed(2)} ok=${s.valid} fail=${s.failed}`,
+    );
+  const noop =
+    a.topNoopReasons.length > 0
+      ? a.topNoopReasons.map(([r, n]) => `${r}×${n}`).join(", ")
+      : "none";
+  return [
+    `samples=${a.samples} turnover=${a.turnover} maxDrawdownUsd=${a.drawdownUsd.toFixed(2)}`,
+    "per-action PnL attribution (netUsd = inventory change attributed to that action):",
+    ...lines,
+    `top noop/failed reasons: ${noop}`,
+  ].join("\n");
+}

--- a/src/llm/baseStrategies.ts
+++ b/src/llm/baseStrategies.ts
@@ -60,6 +60,93 @@ helpers.log("mint range [" + tickLower + "," + tickUpper + "]");
 return { type: "mintLiquidity", tickLower: tickLower, tickUpper: tickUpper, amountWethDesired: wethDesired.toString(), amountUsdcDesired: usdcDesired.toString(), slippageBps: params.slippageBps };
 `.trim();
 
+// venue: 有効な AMM venue (uniswap/balancer/curve) のうち fair から最も乖離した
+// プールで価格を fair に寄せる cross-venue 裁定。状態を持たず obs だけで判断。
+// (examples/agents/venue-arb.ts の移植)
+const VENUE_EXECUTOR = `
+const p = obs.protocols || {};
+const fair = obs.fairPriceUsdcPerWeth;
+if (!(fair > 0)) return { type: "noop", reason: "invalid fair" };
+const venues = [];
+if (p.uniswap && p.uniswap.pool) venues.push({ swapType: "swap", price: p.uniswap.pool.priceUsdcPerWeth });
+if (p.balancer) venues.push({ swapType: "balancerSwap", price: p.balancer.priceUsdcPerWeth });
+if (p.curve) venues.push({ swapType: "curveSwap", price: p.curve.priceUsdcPerWeth });
+let best = null; let bestGap = 0;
+for (const v of venues) {
+  if (!(v.price > 0)) continue;
+  const gap = Math.abs(fair / v.price - 1);
+  if (gap > bestGap) { bestGap = gap; best = v; }
+}
+if (!best || bestGap < params.gapThreshold) return { type: "noop", reason: "no venue gap" };
+const tokenIn = best.price < fair ? "USDC" : "WETH";
+const max = BigInt(tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+const sizeBps = Math.min(params.maxSizeBps, Math.max(params.minSizeBps, Math.floor(bestGap * params.sizeGain)));
+const amountIn = (max * BigInt(sizeBps)) / 10000n;
+if (amountIn <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("venue=" + best.swapType + " gap=" + (bestGap * 10000).toFixed(1) + "bps size=" + sizeBps);
+return { type: best.swapType, tokenIn: tokenIn, amountIn: amountIn.toString(), maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei, slippageBps: params.slippageBps };
+`.trim();
+
+// aave: WETH を担保供給 → USDC を借入する段階的レバレッジ。状態は obs.protocols.aave
+// (supplied/borrowed)から毎ラウンド判定するので持たない。(examples/agents/aave-leverage.ts の移植)
+const AAVE_EXECUTOR = `
+const aave = obs.protocols && obs.protocols.aave;
+if (!aave) return { type: "noop", reason: "aave disabled" };
+const suppliedWeth = BigInt((aave.supplied && aave.supplied.WETH) || "0");
+const borrowedUsdc = BigInt((aave.borrowed && aave.borrowed.USDC) || "0");
+const wethWei = BigInt(obs.balances.wethWei);
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (suppliedWeth === 0n && wethWei > 0n) {
+  const maxSupply = BigInt(obs.limits.maxAaveSupplyWethWei);
+  const half = wethWei / 2n;
+  const base = half < maxSupply ? half : maxSupply;
+  const frac = BigInt(Math.max(0, Math.min(10000, Math.floor(params.supplyFraction * 10000))));
+  const amount = (base * frac) / 10000n;
+  if (amount > 0n) return { type: "aaveSupply", asset: "WETH", amount: amount.toString(), maxPriorityFeePerGasWei: fee };
+}
+if (suppliedWeth > 0n && borrowedUsdc === 0n) {
+  const maxBorrow = BigInt(obs.limits.maxAaveBorrowUsdcUnits);
+  const want = BigInt(Math.max(0, Math.floor(params.borrowUsdc))) * 1000000n;
+  const amount = want < maxBorrow ? want : maxBorrow;
+  if (amount > 0n) return { type: "aaveBorrow", asset: "USDC", amount: amount.toString(), maxPriorityFeePerGasWei: fee };
+}
+return { type: "noop", reason: "position established" };
+`.trim();
+
+// statarb: gap の z-score(obs.history の直近窓から平均/分散を再計算 → 状態を持たない近似)で
+// 閾値超のとき過小評価側へ z 比例サイズで swap。(examples/agents/stat-arb.ts の窓版移植)
+const STATARB_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const pool = uni.pool.priceUsdcPerWeth;
+const fair = obs.fairPriceUsdcPerWeth;
+if (!(pool > 0) || !(fair > 0)) return { type: "noop", reason: "invalid prices" };
+const hist = obs.history || [];
+const gaps = [];
+for (let i = 0; i < hist.length; i++) {
+  const h = hist[i];
+  if (h && h.poolPriceUsdcPerWeth > 0 && h.fairPriceUsdcPerWeth > 0) gaps.push(h.fairPriceUsdcPerWeth / h.poolPriceUsdcPerWeth - 1);
+}
+if (gaps.length < params.minSamples) return { type: "noop", reason: "burn-in (" + gaps.length + ")" };
+let mean = 0; for (let i = 0; i < gaps.length; i++) mean += gaps[i]; mean /= gaps.length;
+let vs = 0; for (let i = 0; i < gaps.length; i++) { const d = gaps[i] - mean; vs += d * d; }
+const std = Math.sqrt(vs / Math.max(1, gaps.length - 1));
+if (!(std > 0)) return { type: "noop", reason: "no variance" };
+const gap = fair / pool - 1;
+const z = (gap - mean) / std;
+const absZ = Math.abs(z);
+if (absZ < params.zEnter) return { type: "noop", reason: "|z|=" + absZ.toFixed(2) + " < enter" };
+const tokenIn = gap > 0 ? "USDC" : "WETH";
+const max = BigInt(tokenIn === "WETH" ? obs.limits.maxWethInWei : obs.limits.maxUsdcInUnits);
+const span = Math.max(0.0001, params.zAggressive - params.zEnter);
+const t = Math.max(0, Math.min(1, (absZ - params.zEnter) / span));
+const sizeBps = Math.floor(params.minSizeBps + (params.maxSizeBps - params.minSizeBps) * t);
+const amountIn = (max * BigInt(sizeBps)) / 10000n;
+if (amountIn <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("z=" + z.toFixed(2) + " size=" + sizeBps);
+return { type: "swap", tokenIn: tokenIn, amountIn: amountIn.toString(), maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei, slippageBps: params.slippageBps };
+`.trim();
+
 // id → ベース戦略(version を除いた雛形)。
 const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
   arb: {
@@ -84,6 +171,40 @@ const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
       slippageBps: 100,
     },
     executorTs: LP_EXECUTOR,
+  },
+  venue: {
+    notes:
+      "Base strategy **venue**: uniswap/balancer/curve のうち fair から最も乖離した venue で価格を fair に寄せる cross-venue 裁定。revise で gapThreshold / sizeGain を磨く。",
+    params: {
+      gapThreshold: 0.001,
+      minSizeBps: 250,
+      maxSizeBps: 2500,
+      sizeGain: 200000,
+      slippageBps: 75,
+    },
+    executorTs: VENUE_EXECUTOR,
+  },
+  aave: {
+    notes:
+      "Base strategy **aave**: WETH を担保供給 → USDC を借入する段階的レバレッジ。revise で supplyFraction / borrowUsdc やヘッジ運用を磨く。aave protocol 有効時のみ機能。",
+    params: {
+      supplyFraction: 1.0,
+      borrowUsdc: 1000,
+    },
+    executorTs: AAVE_EXECUTOR,
+  },
+  statarb: {
+    notes:
+      "Base strategy **statarb**: gap の z-score(obs.history 窓から再計算)が zEnter 超で過小評価側へ z 比例サイズで swap。revise で zEnter / zAggressive / サイズを磨く。",
+    params: {
+      minSamples: 12,
+      zEnter: 1.5,
+      zAggressive: 2.5,
+      minSizeBps: 500,
+      maxSizeBps: 5000,
+      slippageBps: 75,
+    },
+    executorTs: STATARB_EXECUTOR,
   },
 };
 

--- a/src/llm/baseStrategies.ts
+++ b/src/llm/baseStrategies.ts
@@ -147,6 +147,236 @@ helpers.log("z=" + z.toFixed(2) + " size=" + sizeBps);
 return { type: "swap", tokenIn: tokenIn, amountIn: amountIn.toString(), maxPriorityFeePerGasWei: obs.limits.defaultPriorityFeePerGasWei, slippageBps: params.slippageBps };
 `.trim();
 
+// cvbal: Balancer↔Curve の WETH 価格差(スプレッド)を取りに行くペア裁定。割安 venue で買い・
+// 割高 venue で売りの両建てを 1 bundle で。状態を持たず obs の 2 価格だけで判断。
+// (examples/agents/cv-bal-arb.ts の移植)
+const CVBAL_EXECUTOR = `
+const p = obs.protocols || {};
+const bal = p.balancer && p.balancer.priceUsdcPerWeth;
+const curve = p.curve && p.curve.priceUsdcPerWeth;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (!(bal > 0) || !(curve > 0)) return { type: "noop", reason: "balancer/curve unavailable" };
+const spread = Math.abs(bal / curve - 1);
+if (spread < params.spreadBps / 10000) return { type: "noop", reason: "spread too small" };
+const balCheaper = bal < curve;
+const buyVenue = balCheaper ? "balancerSwap" : "curveSwap";
+const sellVenue = balCheaper ? "curveSwap" : "balancerSwap";
+const sizeBps = Math.min(params.maxSizeBps, Math.max(params.minSizeBps, Math.floor(spread * params.sizeGain)));
+const usdcIn = (BigInt(obs.limits.maxUsdcInUnits) * BigInt(sizeBps)) / 10000n;
+const wethIn = (BigInt(obs.limits.maxWethInWei) * BigInt(sizeBps)) / 10000n;
+if (usdcIn <= 0n || wethIn <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("spread=" + (spread * 10000).toFixed(1) + "bps buy=" + buyVenue);
+return { type: "bundle", actions: [ { type: buyVenue, tokenIn: "USDC", amountIn: usdcIn.toString(), slippageBps: params.slippageBps }, { type: sellVenue, tokenIn: "WETH", amountIn: wethIn.toString(), slippageBps: params.slippageBps } ], maxPriorityFeePerGasWei: fee };
+`.trim();
+
+// dnlp: Uniswap V3 LP を mint し、その WETH エクスポージャを GMX short でヘッジするデルタニュートラル。
+// ラウンドをまたぐ状態は obs.protocols.uniswap.positions / obs.protocols.gmx.position から毎ラウンド
+// 判定する(A:LP無→mint, B:LP有/short無→hedge, C:両方→hold)。(examples/agents/dn-lp.ts の移植)
+const DNLP_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+const gmx = obs.protocols && obs.protocols.gmx;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const positions = uni.positions || [];
+if (positions.length === 0) {
+  const spacing = uni.pool.tickSpacing;
+  const center = Math.floor(uni.pool.tick / spacing) * spacing;
+  const w = Math.max(1, Math.floor(params.rangeSpacings)) * spacing;
+  return { type: "mintLiquidity", tickLower: center - w, tickUpper: center + w, amountWethDesired: (BigInt(obs.limits.maxLpWethWei) / 2n).toString(), amountUsdcDesired: (BigInt(obs.limits.maxLpUsdcUnits) / 2n).toString(), maxPriorityFeePerGasWei: fee, slippageBps: 100 };
+}
+if (!gmx) return { type: "noop", reason: "lp held (gmx disabled, no hedge)" };
+if (!gmx.position) {
+  let totalWethWei = 0n;
+  for (let i = 0; i < positions.length; i++) totalWethWei += BigInt(positions[i].amountWethWei || "0");
+  const wethEth = Number(totalWethWei) / 1e18;
+  const mkt = gmx.marketPriceUsd;
+  if (!(wethEth > 0) || !(mkt > 0)) return { type: "noop", reason: "no exposure to hedge" };
+  const notionalUsd = wethEth * mkt * params.hedgeFraction;
+  const sizeRaw = BigInt(Math.max(0, Math.round(notionalUsd))) * (10n ** 30n);
+  const maxSize = BigInt(obs.limits.maxGmxSizeUsd);
+  const sizeUsd = sizeRaw < maxSize ? sizeRaw : maxSize;
+  const collRaw = BigInt(Math.max(0, Math.round((notionalUsd / 2) * 1e6)));
+  const maxColl = BigInt(obs.limits.maxUsdcInUnits);
+  const collateral = collRaw < maxColl ? collRaw : maxColl;
+  if (sizeUsd <= 0n) return { type: "noop", reason: "hedge size zero" };
+  helpers.log("hedge short notional=" + Math.round(notionalUsd) + "usd");
+  return { type: "gmxIncrease", isLong: false, collateral: "USDC", collateralAmount: collateral.toString(), sizeDeltaUsd: sizeUsd.toString(), maxPriorityFeePerGasWei: fee };
+}
+return { type: "noop", reason: "delta-neutral established" };
+`.trim();
+
+// gmxperp: ポジションが無ければ ETH long を open、あれば hold。(examples/agents/gmx-perp.ts の移植)
+const GMXPERP_EXECUTOR = `
+const gmx = obs.protocols && obs.protocols.gmx;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (!gmx) return { type: "noop", reason: "gmx disabled" };
+if (gmx.position) return { type: "noop", reason: "position open" };
+const collWei = BigInt(Math.max(0, Math.round(params.collateralWeth * 1000))) * (10n ** 15n);
+const sizeRaw = BigInt(Math.max(0, Math.round(params.sizeUsd))) * (10n ** 30n);
+const maxSize = BigInt(obs.limits.maxGmxSizeUsd);
+const sizeUsd = sizeRaw < maxSize ? sizeRaw : maxSize;
+if (collWei <= 0n || sizeUsd <= 0n) return { type: "noop", reason: "computed size zero" };
+return { type: "gmxIncrease", isLong: params.isLong !== false, collateral: "WETH", collateralAmount: collWei.toString(), sizeDeltaUsd: sizeUsd.toString(), maxPriorityFeePerGasWei: fee };
+`.trim();
+
+// gmxrev: history の MA からの乖離で逆張り。割高→short / 割安→long を open、MA 近傍復帰 or
+// 含み損 stop でクローズ。(examples/agents/gmx-reversion.ts の移植)
+const GMXREV_EXECUTOR = `
+const gmx = obs.protocols && obs.protocols.gmx;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (!gmx) return { type: "noop", reason: "gmx disabled" };
+const h = obs.history || [];
+const hist = [];
+for (let i = 0; i < h.length; i++) { const p = h[i] && h[i].fairPriceUsdcPerWeth; if (p > 0) hist.push(p); }
+const look = Math.max(2, Math.floor(params.maLookback));
+if (hist.length < look) return { type: "noop", reason: "warming up" };
+const win = hist.slice(-look);
+let ma = 0; for (let i = 0; i < win.length; i++) ma += win[i]; ma /= win.length;
+const price = obs.fairPriceUsdcPerWeth;
+if (!(price > 0) || !(ma > 0)) return { type: "noop", reason: "invalid prices" };
+const dev = price / ma - 1;
+const pos = gmx.position;
+if (pos) {
+  const pnl = Number(pos.pnlUsd || 0);
+  const reverted = Math.abs(dev) < params.exitBps / 10000;
+  const stopped = pnl < -params.stopUsd;
+  if (reverted || stopped) return { type: "gmxDecrease", isLong: pos.isLong, collateral: pos.collateral, collateralDeltaAmount: pos.collateralAmount, sizeDeltaUsd: pos.sizeUsd, maxPriorityFeePerGasWei: fee };
+  return { type: "noop", reason: "hold (awaiting reversion)" };
+}
+if (Math.abs(dev) < params.entryBps / 10000) return { type: "noop", reason: "near MA" };
+const mkt = gmx.marketPriceUsd;
+if (!(mkt > 0)) return { type: "noop", reason: "invalid gmx price" };
+const sizeRaw = BigInt(Math.max(0, Math.round(mkt * params.leverage))) * (10n ** 30n);
+const maxSize = BigInt(obs.limits.maxGmxSizeUsd);
+const sizeUsd = sizeRaw < maxSize ? sizeRaw : maxSize;
+const collWei = BigInt(Math.max(0, Math.round(params.collateralWeth * 1000))) * (10n ** 15n);
+if (sizeUsd <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("dev=" + (dev * 10000).toFixed(1) + "bps long=" + (dev < 0));
+return { type: "gmxIncrease", isLong: dev < 0, collateral: "WETH", collateralAmount: collWei.toString(), sizeDeltaUsd: sizeUsd.toString(), maxPriorityFeePerGasWei: fee };
+`.trim();
+
+// gmxtrend: history の傾き(前半/後半平均の変化率)で順張り。トレンド方向に open、反転で close。
+// (examples/agents/gmx-trend.ts の移植)
+const GMXTREND_EXECUTOR = `
+const gmx = obs.protocols && obs.protocols.gmx;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+if (!gmx) return { type: "noop", reason: "gmx disabled" };
+const h = obs.history || [];
+const hist = [];
+for (let i = 0; i < h.length; i++) { const p = h[i] && h[i].fairPriceUsdcPerWeth; if (p > 0) hist.push(p); }
+const look = Math.max(4, Math.floor(params.lookback));
+if (hist.length < look) return { type: "noop", reason: "warming up" };
+const win = hist.slice(-look);
+const half = Math.floor(look / 2);
+let oa = 0; for (let i = 0; i < half; i++) oa += win[i]; oa /= Math.max(1, half);
+let ra = 0; for (let i = half; i < win.length; i++) ra += win[i]; ra /= Math.max(1, win.length - half);
+if (!(oa > 0)) return { type: "noop", reason: "invalid window" };
+const trend = ra / oa - 1;
+const upTrend = trend > 0;
+const pos = gmx.position;
+if (pos) {
+  const reversed = pos.isLong !== upTrend;
+  if (reversed && Math.abs(trend) > params.trendBps / 10000) return { type: "gmxDecrease", isLong: pos.isLong, collateral: pos.collateral, collateralDeltaAmount: pos.collateralAmount, sizeDeltaUsd: pos.sizeUsd, maxPriorityFeePerGasWei: fee };
+  return { type: "noop", reason: "hold (trend intact)" };
+}
+if (Math.abs(trend) < params.trendBps / 10000) return { type: "noop", reason: "no trend" };
+const mkt = gmx.marketPriceUsd;
+if (!(mkt > 0)) return { type: "noop", reason: "invalid gmx price" };
+const sizeRaw = BigInt(Math.max(0, Math.round(mkt * params.leverage))) * (10n ** 30n);
+const maxSize = BigInt(obs.limits.maxGmxSizeUsd);
+const sizeUsd = sizeRaw < maxSize ? sizeRaw : maxSize;
+const collWei = BigInt(Math.max(0, Math.round(params.collateralWeth * 1000))) * (10n ** 15n);
+if (sizeUsd <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("trend=" + (trend * 10000).toFixed(1) + "bps up=" + upTrend);
+return { type: "gmxIncrease", isLong: upTrend, collateral: "WETH", collateralAmount: collWei.toString(), sizeDeltaUsd: sizeUsd.toString(), maxPriorityFeePerGasWei: fee };
+`.trim();
+
+// fairmm: pool tick ではなく fairPrice の含意 tick を中心に集中流動性を供給する MM。
+// 状態は obs.positions(liquidity>0 があれば hold)から判定。offset は ln(fair/pool)/ln(1.0001)。
+// (examples/agents/fair-mm.ts の簡約シード。レンジ再調整等の高度化は revise に委ねる)
+const FAIRMM_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const positions = uni.positions || [];
+let live = 0; for (let i = 0; i < positions.length; i++) if (BigInt(positions[i].liquidity) > 0n) live++;
+if (live > 0) return { type: "noop", reason: "holding fair-anchored LP" };
+const pool = uni.pool.priceUsdcPerWeth;
+const fair = obs.fairPriceUsdcPerWeth;
+if (!(pool > 0) || !(fair > 0)) return { type: "noop", reason: "invalid prices" };
+const spacing = uni.pool.tickSpacing;
+const offset = Math.round(Math.log(fair / pool) / Math.log(1.0001));
+const center = Math.round((uni.pool.tick + offset) / spacing) * spacing;
+const w = Math.max(1, Math.floor(params.rangeSpacings)) * spacing;
+const frac = BigInt(Math.max(0, Math.min(10000, Math.floor(params.depositFraction * 10000))));
+const wethWei = BigInt(obs.balances.wethWei); const usdcUnits = BigInt(obs.balances.usdcUnits);
+const maxW = BigInt(obs.limits.maxLpWethWei); const maxU = BigInt(obs.limits.maxLpUsdcUnits);
+const wethDesired = ((wethWei < maxW ? wethWei : maxW) * frac) / 10000n;
+const usdcDesired = ((usdcUnits < maxU ? usdcUnits : maxU) * frac) / 10000n;
+if (wethDesired <= 0n && usdcDesired <= 0n) return { type: "noop", reason: "no inventory to LP" };
+helpers.log("fair-anchored mint center=" + center + " offset=" + offset);
+return { type: "mintLiquidity", tickLower: center - w, tickUpper: center + w, amountWethDesired: wethDesired.toString(), amountUsdcDesired: usdcDesired.toString(), maxPriorityFeePerGasWei: fee, slippageBps: params.slippageBps };
+`.trim();
+
+// jitlp: history の直近リターンの実現ボラが閾値超のときだけ集中レンジを mint する Just-In-Time LP。
+// (examples/agents/jit-lp.ts の簡約シード。窓ボラ stddev で発火判定。分位ベースの高度化は revise)
+const JITLP_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const positions = uni.positions || [];
+let live = 0; for (let i = 0; i < positions.length; i++) if (BigInt(positions[i].liquidity) > 0n) live++;
+if (live > 0) return { type: "noop", reason: "holding JIT LP" };
+const h = obs.history || [];
+const rets = [];
+for (let i = 1; i < h.length; i++) { const a = h[i-1] && h[i-1].fairPriceUsdcPerWeth; const b = h[i] && h[i].fairPriceUsdcPerWeth; if (a > 0 && b > 0) rets.push(b / a - 1); }
+if (rets.length < params.minHistory) return { type: "noop", reason: "insufficient vol samples" };
+let m = 0; for (let i = 0; i < rets.length; i++) m += rets[i]; m /= rets.length;
+let v = 0; for (let i = 0; i < rets.length; i++) { const d = rets[i] - m; v += d * d; }
+const vol = Math.sqrt(v / Math.max(1, rets.length - 1));
+if (vol < params.volThreshold) return { type: "noop", reason: "low-vol round" };
+const spacing = uni.pool.tickSpacing;
+const center = Math.round(uni.pool.tick / spacing) * spacing;
+const w = Math.max(1, Math.floor(params.rangeTicks)) * spacing;
+const frac = BigInt(Math.max(0, Math.min(10000, Math.floor(params.mintBudgetBps))));
+const wethWei = BigInt(obs.balances.wethWei); const usdcUnits = BigInt(obs.balances.usdcUnits);
+const maxW = BigInt(obs.limits.maxLpWethWei); const maxU = BigInt(obs.limits.maxLpUsdcUnits);
+const wethDesired = ((wethWei < maxW ? wethWei : maxW) * frac) / 10000n;
+const usdcDesired = ((usdcUnits < maxU ? usdcUnits : maxU) * frac) / 10000n;
+if (wethDesired <= 0n && usdcDesired <= 0n) return { type: "noop", reason: "no inventory to LP" };
+helpers.log("JIT mint vol=" + (vol * 10000).toFixed(1) + "bps");
+return { type: "mintLiquidity", tickLower: center - w, tickUpper: center + w, amountWethDesired: wethDesired.toString(), amountUsdcDesired: usdcDesired.toString(), maxPriorityFeePerGasWei: fee, slippageBps: params.slippageBps };
+`.trim();
+
+// ladder: 現在 tick の周りに steps 段の集中レンジを外側へ広げて張るラダー型 MM。1 ラウンド 1 段ずつ
+// 構築(owned 数で次段を決定)。(examples/agents/ladder-mm.ts の簡約シード。在庫スキュー等は revise)
+const LADDER_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const positions = uni.positions || [];
+let owned = 0; for (let i = 0; i < positions.length; i++) if (BigInt(positions[i].liquidity) > 0n) owned++;
+const steps = Math.max(1, Math.floor(params.steps));
+if (owned >= steps) return { type: "noop", reason: "ladder full" };
+const maxOpen = obs.limits.maxOpenPositions;
+if (positions.length >= maxOpen) return { type: "noop", reason: "no position slots" };
+const spacing = uni.pool.tickSpacing;
+const center = Math.round(uni.pool.tick / spacing) * spacing;
+const halfWidth = Math.max(1, Math.floor(params.stepWidthSpacings)) * spacing;
+const step = owned;
+const dir = step % 2 === 0 ? 1 : -1;
+const segCenter = center + dir * Math.ceil(step / 2) * halfWidth * 2;
+const totalFrac = Math.max(0, Math.min(10000, Math.floor(params.mintBudgetBps)));
+const perStep = BigInt(Math.floor(totalFrac / steps));
+const wethWei = BigInt(obs.balances.wethWei); const usdcUnits = BigInt(obs.balances.usdcUnits);
+const maxW = BigInt(obs.limits.maxLpWethWei); const maxU = BigInt(obs.limits.maxLpUsdcUnits);
+const wethDesired = ((wethWei < maxW ? wethWei : maxW) * perStep) / 10000n;
+const usdcDesired = ((usdcUnits < maxU ? usdcUnits : maxU) * perStep) / 10000n;
+if (wethDesired <= 0n && usdcDesired <= 0n) return { type: "noop", reason: "no inventory to LP" };
+helpers.log("ladder step " + (step + 1) + "/" + steps + " center=" + segCenter);
+return { type: "mintLiquidity", tickLower: segCenter - halfWidth, tickUpper: segCenter + halfWidth, amountWethDesired: wethDesired.toString(), amountUsdcDesired: usdcDesired.toString(), maxPriorityFeePerGasWei: fee, slippageBps: params.slippageBps };
+`.trim();
+
 // id → ベース戦略(version を除いた雛形)。
 const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
   arb: {
@@ -205,6 +435,94 @@ const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
       slippageBps: 75,
     },
     executorTs: STATARB_EXECUTOR,
+  },
+  cvbal: {
+    notes:
+      "Base strategy **cvbal**: Balancer↔Curve のスプレッドが閾値超なら割安 venue 買い+割高 venue 売りの両建て bundle。revise で spreadBps / サイズを磨く。balancer+curve 有効時のみ。",
+    params: {
+      spreadBps: 15,
+      minSizeBps: 250,
+      maxSizeBps: 5000,
+      sizeGain: 200000,
+      slippageBps: 75,
+    },
+    executorTs: CVBAL_EXECUTOR,
+  },
+  dnlp: {
+    notes:
+      "Base strategy **dnlp**: Uniswap LP を mint し WETH エクスポージャを GMX short でヘッジするデルタニュートラル(LP→hedge→hold の状態機械)。revise で hedgeFraction / レンジ幅を磨く。uniswap+gmx 有効時のみ。",
+    params: {
+      hedgeFraction: 1.0,
+      rangeSpacings: 20,
+    },
+    executorTs: DNLP_EXECUTOR,
+  },
+  gmxperp: {
+    notes:
+      "Base strategy **gmxperp**: GMX でポジション無しなら ETH long を open、あれば hold。revise で size / leverage / 方向を磨く。gmx 有効時のみ。",
+    params: {
+      collateralWeth: 1,
+      sizeUsd: 4000,
+      isLong: true,
+    },
+    executorTs: GMXPERP_EXECUTOR,
+  },
+  gmxrev: {
+    notes:
+      "Base strategy **gmxrev**: history MA からの乖離で逆張り(割高 short / 割安 long)。MA 近傍復帰 or 含み損 stop でクローズ。revise で entry/exit/stop/lookback を磨く。gmx 有効時のみ。",
+    params: {
+      maLookback: 12,
+      entryBps: 40,
+      exitBps: 10,
+      stopUsd: 150,
+      leverage: 2,
+      collateralWeth: 1,
+    },
+    executorTs: GMXREV_EXECUTOR,
+  },
+  gmxtrend: {
+    notes:
+      "Base strategy **gmxtrend**: history の傾きで順張り。トレンド方向に open、反転で close。revise で lookback / trendBps / leverage を磨く。gmx 有効時のみ。",
+    params: {
+      lookback: 8,
+      trendBps: 30,
+      leverage: 2,
+      collateralWeth: 1,
+    },
+    executorTs: GMXTREND_EXECUTOR,
+  },
+  fairmm: {
+    notes:
+      "Base strategy **fairmm**: fairPrice の含意 tick を中心に集中流動性を供給(pool tick ではなく fair 基準)。revise でレンジ幅 / 預入率 / 再調整条件を磨く。",
+    params: {
+      rangeSpacings: 4,
+      depositFraction: 0.35,
+      slippageBps: 75,
+    },
+    executorTs: FAIRMM_EXECUTOR,
+  },
+  jitlp: {
+    notes:
+      "Base strategy **jitlp**: history 窓の実現ボラが閾値超のときだけ集中レンジを mint する JIT LP。revise で volThreshold / レンジ幅 / 予算を磨く。",
+    params: {
+      minHistory: 12,
+      volThreshold: 0.003,
+      rangeTicks: 4,
+      mintBudgetBps: 4500,
+      slippageBps: 75,
+    },
+    executorTs: JITLP_EXECUTOR,
+  },
+  ladder: {
+    notes:
+      "Base strategy **ladder**: 現在 tick の周りに steps 段の集中レンジを外側へ広げて 1 ラウンド 1 段ずつ張るラダー型 MM。revise で段数 / 段幅 / 在庫スキューを磨く。",
+    params: {
+      steps: 3,
+      stepWidthSpacings: 60,
+      mintBudgetBps: 5000,
+      slippageBps: 75,
+    },
+    executorTs: LADDER_EXECUTOR,
   },
 };
 

--- a/src/llm/baseStrategies.ts
+++ b/src/llm/baseStrategies.ts
@@ -377,6 +377,111 @@ helpers.log("ladder step " + (step + 1) + "/" + steps + " center=" + segCenter);
 return { type: "mintLiquidity", tickLower: segCenter - halfWidth, tickUpper: segCenter + halfWidth, amountWethDesired: wethDesired.toString(), amountUsdcDesired: usdcDesired.toString(), maxPriorityFeePerGasWei: fee, slippageBps: params.slippageBps };
 `.trim();
 
+// aaveloop: WETH supply → USDC borrow → USDC を WETH に swap → 再 supply を多段ループする
+// leveraged WETH carry(GitHub #6)。状態は obs.protocols.aave の collateral/debt/availableBorrows
+// から毎ラウンド再構成し、targetLtv に達するまで 1 段ずつ進める素朴版。(aave-leverage の発展)
+const AAVELOOP_EXECUTOR = `
+const aave = obs.protocols && obs.protocols.aave;
+if (!aave) return { type: "noop", reason: "aave disabled" };
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const wethWei = BigInt(obs.balances.wethWei);
+const usdcUnits = BigInt(obs.balances.usdcUnits);
+const maxIn = BigInt(obs.limits.maxUsdcInUnits);
+const coll = Number(aave.totalCollateralBase) / 1e8;
+const debt = Number(aave.totalDebtBase) / 1e8;
+const avail = Number(aave.availableBorrowsBase) / 1e8;
+const underTarget = coll === 0 || debt / coll < params.targetLtv;
+// 1) 手元 WETH を supply して担保を積む(初期 WETH + swap で得た WETH。carry の土台)
+if (wethWei > 0n && underTarget) {
+  const maxSupply = BigInt(obs.limits.maxAaveSupplyWethWei);
+  const capped = wethWei < maxSupply ? wethWei : maxSupply;
+  const frac = BigInt(Math.max(0, Math.min(10000, Math.floor(params.supplyFraction * 10000))));
+  const amt = (capped * frac) / 10000n;
+  if (amt > 0n) return { type: "aaveSupply", asset: "WETH", amount: amt.toString(), maxPriorityFeePerGasWei: fee };
+}
+// 2) 目標 LTV 未満で借入余力があれば USDC borrow
+if (underTarget && coll > 0) {
+  const borrowUsd = Math.floor(avail * params.borrowFraction);
+  if (borrowUsd >= 10) {
+    const maxBorrow = BigInt(obs.limits.maxAaveBorrowUsdcUnits);
+    const want = BigInt(borrowUsd) * 1000000n;
+    const amt = want < maxBorrow ? want : maxBorrow;
+    if (amt > 0n) return { type: "aaveBorrow", asset: "USDC", amount: amt.toString(), maxPriorityFeePerGasWei: fee };
+  }
+}
+// 3) 借りた native USDC を WETH へ swap(次段 supply の原資)。maxUsdcInUnits で上限を切り、
+//    集約残高(USDC.e/USDT 込み)で native 残高を超えて reject されるのを避ける。
+if (underTarget && coll > 0 && usdcUnits > 1000000n) {
+  const amountIn = usdcUnits < maxIn ? usdcUnits : maxIn;
+  return { type: "swap", tokenIn: "USDC", amountIn: amountIn.toString(), slippageBps: params.slippageBps, maxPriorityFeePerGasWei: fee };
+}
+return { type: "noop", reason: "target leverage reached" };
+`.trim();
+
+// crossvenue: uniswap/balancer/curve のうち最安 venue で買い・最高 venue で売る 2-leg 裁定
+// (GitHub #4 の cross-venue 部分)。cvbal(bal↔curve 限定)を 3 venue の最大乖離ペアへ一般化。
+// 注: 別 fee-tier / v2 は観測に無いため対象外(uni 0.05% + balancer + curve のみ)。
+const CROSSVENUE_EXECUTOR = `
+const p = obs.protocols || {};
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const venues = [];
+if (p.uniswap && p.uniswap.pool && p.uniswap.pool.priceUsdcPerWeth > 0) venues.push({ swapType: "swap", price: p.uniswap.pool.priceUsdcPerWeth });
+if (p.balancer && p.balancer.priceUsdcPerWeth > 0) venues.push({ swapType: "balancerSwap", price: p.balancer.priceUsdcPerWeth });
+if (p.curve && p.curve.priceUsdcPerWeth > 0) venues.push({ swapType: "curveSwap", price: p.curve.priceUsdcPerWeth });
+if (venues.length < 2) return { type: "noop", reason: "need >=2 venues" };
+let lo = venues[0]; let hi = venues[0];
+for (let i = 0; i < venues.length; i++) { if (venues[i].price < lo.price) lo = venues[i]; if (venues[i].price > hi.price) hi = venues[i]; }
+const spread = hi.price / lo.price - 1;
+if (spread < params.spreadThreshold || lo.swapType === hi.swapType) return { type: "noop", reason: "spread too small" };
+const sizeBps = Math.min(params.maxSizeBps, Math.max(params.minSizeBps, Math.floor(spread * params.sizeGain)));
+const usdcIn = (BigInt(obs.limits.maxUsdcInUnits) * BigInt(sizeBps)) / 10000n;
+const wethIn = (BigInt(obs.limits.maxWethInWei) * BigInt(sizeBps)) / 10000n;
+if (usdcIn <= 0n || wethIn <= 0n) return { type: "noop", reason: "computed size zero" };
+helpers.log("crossvenue spread=" + (spread * 10000).toFixed(1) + "bps buy=" + lo.swapType + " sell=" + hi.swapType);
+return { type: "bundle", actions: [
+  { type: lo.swapType, tokenIn: "USDC", amountIn: usdcIn.toString(), slippageBps: params.slippageBps },
+  { type: hi.swapType, tokenIn: "WETH", amountIn: wethIn.toString(), slippageBps: params.slippageBps },
+], maxPriorityFeePerGasWei: fee };
+`.trim();
+
+// lpyield: fair 含意 tick 中心に LP を mint し、残った遊休 USDC を Aave に supply して手数料+利回りの
+// 二段収益を狙う無レバレッジ複合(GitHub #11)。fairmm(LP)+ aave(park)の合成。
+const LPYIELD_EXECUTOR = `
+const uni = obs.protocols && obs.protocols.uniswap;
+if (!uni || !uni.pool) return { type: "noop", reason: "uniswap disabled" };
+const aave = obs.protocols && obs.protocols.aave;
+const fee = obs.limits.defaultPriorityFeePerGasWei;
+const positions = uni.positions || [];
+let live = 0; for (let i = 0; i < positions.length; i++) if (BigInt(positions[i].liquidity) > 0n) live++;
+if (live === 0) {
+  const pool = uni.pool.priceUsdcPerWeth; const fair = obs.fairPriceUsdcPerWeth;
+  if (!(pool > 0) || !(fair > 0)) return { type: "noop", reason: "invalid prices" };
+  const spacing = uni.pool.tickSpacing;
+  const offset = Math.round(Math.log(fair / pool) / Math.log(1.0001));
+  const center = Math.round((uni.pool.tick + offset) / spacing) * spacing;
+  const w = Math.max(1, Math.floor(params.rangeSpacings)) * spacing;
+  const frac = BigInt(Math.max(0, Math.min(10000, Math.floor(params.depositFraction * 10000))));
+  const wethWei = BigInt(obs.balances.wethWei); const usdcUnits = BigInt(obs.balances.usdcUnits);
+  const maxW = BigInt(obs.limits.maxLpWethWei); const maxU = BigInt(obs.limits.maxLpUsdcUnits);
+  const wd = ((wethWei < maxW ? wethWei : maxW) * frac) / 10000n;
+  const ud = ((usdcUnits < maxU ? usdcUnits : maxU) * frac) / 10000n;
+  if (wd > 0n || ud > 0n) return { type: "mintLiquidity", tickLower: center - w, tickUpper: center + w, amountWethDesired: wd.toString(), amountUsdcDesired: ud.toString(), maxPriorityFeePerGasWei: fee, slippageBps: params.slippageBps };
+}
+// LP 配分後の遊休 USDC を Aave に park(余剰だけ)。1 回の supply は maxUsdcInUnits で上限を切り、
+// 集約残高(USDC.e/USDT 込み)で native USDC 残高を超えて reject されるのを避ける。
+if (aave) {
+  const usdcUnits = BigInt(obs.balances.usdcUnits);
+  const maxIn = BigInt(obs.limits.maxUsdcInUnits);
+  const minIdle = BigInt(Math.max(0, Math.floor(params.minIdleUsdc))) * 1000000n;
+  if (usdcUnits > minIdle) {
+    const excess = usdcUnits - minIdle;
+    const amt = excess < maxIn ? excess : maxIn;
+    return { type: "aaveSupply", asset: "USDC", amount: amt.toString(), maxPriorityFeePerGasWei: fee };
+  }
+}
+return { type: "noop", reason: "LP + idle parked" };
+`.trim();
+
 // id → ベース戦略(version を除いた雛形)。
 const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
   arb: {
@@ -523,6 +628,40 @@ const BASE_STRATEGIES: Record<string, Omit<Strategy, "version">> = {
       slippageBps: 75,
     },
     executorTs: LADDER_EXECUTOR,
+  },
+  aaveloop: {
+    notes:
+      "Base strategy **aaveloop** (GitHub #6): WETH supply → USDC borrow → swap → 再 supply の多段レバレッジ carry。targetLtv まで 1 段ずつ。revise で targetLtv / borrowFraction を磨く。aave+uniswap 有効時のみ。",
+    params: {
+      targetLtv: 0.7,
+      borrowFraction: 0.8,
+      supplyFraction: 1.0,
+      slippageBps: 75,
+    },
+    executorTs: AAVELOOP_EXECUTOR,
+  },
+  crossvenue: {
+    notes:
+      "Base strategy **crossvenue** (GitHub #4): uniswap/balancer/curve の最安 venue で買い・最高 venue で売る 2-leg 裁定。revise で spreadThreshold / サイズを磨く。複数 AMM venue 有効時のみ。",
+    params: {
+      spreadThreshold: 0.001,
+      minSizeBps: 250,
+      maxSizeBps: 5000,
+      sizeGain: 200000,
+      slippageBps: 75,
+    },
+    executorTs: CROSSVENUE_EXECUTOR,
+  },
+  lpyield: {
+    notes:
+      "Base strategy **lpyield** (GitHub #11): fair 含意 tick 中心に LP を mint し残った遊休 USDC を Aave に supply する無レバレッジ複合(手数料+利回り)。revise でレンジ幅 / 預入率 / 遊休下限を磨く。uniswap+aave 有効時のみ。",
+    params: {
+      rangeSpacings: 4,
+      depositFraction: 0.5,
+      minIdleUsdc: 10,
+      slippageBps: 75,
+    },
+    executorTs: LPYIELD_EXECUTOR,
   },
 };
 

--- a/src/llm/claudeAgent.ts
+++ b/src/llm/claudeAgent.ts
@@ -33,6 +33,14 @@ const FREEZE_STRATEGY = process.env.ERIS_FREEZE_STRATEGY === "1";
 // 増やすなら採用しない。ERIS_LLM_SANITY_GATE=0 で無効化(決定論測定など)。
 const SANITY_OBS_WINDOW = intEnv("ERIS_LLM_SANITY_WINDOW", 8);
 const SANITY_GATE_ENABLED = process.env.ERIS_LLM_SANITY_GATE !== "0";
+// live PnL ロールバック(ADR 0002 の rollback_condition を機構化)。revise 採用後に実現 PnL を
+// 監視し、採用時評価額から ROLLBACK_DROP 以上下落したら前版へ自動で巻き戻す(事後・反応的ガード)。
+// sanity ゲート(実行時エラーのみ)では捕えられない「正気だが致命的」な改悪を打ち切る。
+// ERIS_LLM_ROLLBACK=0 で無効化。
+const ROLLBACK_ENABLED = process.env.ERIS_LLM_ROLLBACK !== "0";
+const ROLLBACK_WINDOW = intEnv("ERIS_LLM_ROLLBACK_WINDOW", 5); // 判定までの最小経過ラウンド
+const ROLLBACK_DROP = floatEnv("ERIS_LLM_ROLLBACK_DROP", 0.04); // 採用時比の下落率しきい値
+const ROLLBACK_GRADUATE = intEnv("ERIS_LLM_ROLLBACK_GRADUATE", 24); // 監視を打ち切る経過ラウンド
 
 function reportDirRoot(): string {
   return process.env.REPORT_DIR ?? "./runs";
@@ -48,8 +56,14 @@ export type State = {
   agentDir: string | null;
   decisionsPath: string | null;
   callsPath: string | null;
+  rollbacksPath: string | null;
   // sanity ゲート用の直近観測リング(最大 SANITY_OBS_WINDOW)。
   recentObs: AgentObservation[];
+  // PnL ロールバック用: 採用直前の版・採用時評価額・採用ラウンド。
+  prevStrategy: Strategy | null;
+  adoptUsd: number | null;
+  adoptRound: number;
+  pendingAdoption: boolean;
 };
 
 export function createState(
@@ -66,7 +80,12 @@ export function createState(
     agentDir: null,
     decisionsPath: null,
     callsPath: null,
+    rollbacksPath: null,
     recentObs: [],
+    prevStrategy: null,
+    adoptUsd: null,
+    adoptRound: -1,
+    pendingAdoption: false,
   };
 }
 
@@ -191,6 +210,9 @@ export async function handleLine(
   state.history.setInitialUsd(obs.inventory.valueUsdc);
   state.recentObs.push(obs);
   if (state.recentObs.length > SANITY_OBS_WINDOW) state.recentObs.shift();
+
+  // PnL ロールバック: 新版採用直後の評価額を基準化し、悪化していれば前版へ巻き戻す。
+  if (ROLLBACK_ENABLED) maybeRollback(state, obs);
 
   // Kick off background strategy calls if needed. These do not block the response.
   scheduleStrategyWorkIfNeeded(state, strategist, obs);
@@ -379,6 +401,9 @@ async function runStrategistRevise(
       ? passesSanityGate(result.strategy, state.strategy, state.recentObs)
       : null;
     if (!gate || gate.ok) {
+      // ロールバック用に直前の良い版を退避し、採用を handleLine で基準化する。
+      state.prevStrategy = state.strategy;
+      state.pendingAdoption = true;
       state.strategy = result.strategy;
       persistStrategy(state, result.strategy);
       emitStderr(
@@ -427,6 +452,58 @@ export function passesSanityGate(
   return { ok: true };
 }
 
+/**
+ * live PnL ロールバック(ADR 0002 の rollback_condition を機構化)。
+ * 採用直後の評価額を基準化し、ROLLBACK_WINDOW 経過後に基準から ROLLBACK_DROP 以上下落していれば
+ * 前版へ巻き戻す。ROLLBACK_GRADUATE ラウンド生き延びたら「合格」として監視を解除する。
+ * 注意: 市場全体の下落と revise 起因の悪化を厳密に切り分けないため、しきい値は保守的にする。
+ */
+export function maybeRollback(state: State, obs: AgentObservation): void {
+  // 新版が live になった最初のラウンドで基準を取る。
+  if (state.pendingAdoption) {
+    state.adoptUsd = obs.inventory.valueUsdc;
+    state.adoptRound = obs.round;
+    state.pendingAdoption = false;
+    return;
+  }
+  if (!state.prevStrategy || state.adoptUsd === null || state.adoptUsd <= 0) {
+    return;
+  }
+  const elapsed = obs.round - state.adoptRound;
+  if (elapsed < ROLLBACK_WINDOW) return;
+  const drop = (state.adoptUsd - obs.inventory.valueUsdc) / state.adoptUsd;
+  if (drop >= ROLLBACK_DROP) {
+    const from = state.strategy?.version;
+    const to = state.prevStrategy.version;
+    state.strategy = state.prevStrategy;
+    logRollback(state, obs.round, from ?? null, to, drop);
+    emitStderr(
+      `[claude-llm] PnL rollback v${from}→v${to} (drop=${(drop * 100).toFixed(1)}% over ${elapsed}r) — reverted to last good version\n`,
+    );
+    state.prevStrategy = null;
+    state.adoptUsd = null;
+    state.lastReviseRound = obs.round; // 直後の連続 revise を抑制(cooldown)
+  } else if (elapsed >= ROLLBACK_GRADUATE) {
+    // 一定期間崩れなければ合格として監視解除。
+    state.prevStrategy = null;
+    state.adoptUsd = null;
+  }
+}
+
+function logRollback(
+  state: State,
+  round: number,
+  fromVersion: number | null,
+  toVersion: number,
+  drop: number,
+): void {
+  if (!state.rollbacksPath) return;
+  appendFileSync(
+    state.rollbacksPath,
+    `${JSON.stringify({ ts: new Date().toISOString(), round, fromVersion, toVersion, drop })}\n`,
+  );
+}
+
 function nextVersion(state: State): number {
   return state.strategy ? state.strategy.version + 1 : 1;
 }
@@ -438,8 +515,10 @@ function ensureRunDirs(state: State, obs: AgentObservation): void {
     mkdirSync(state.agentDir, { recursive: true });
   state.decisionsPath = join(state.agentDir, "decisions.jsonl");
   state.callsPath = join(state.agentDir, "claude-calls.jsonl");
+  state.rollbacksPath = join(state.agentDir, "rollbacks.jsonl");
   writeFileSync(state.decisionsPath, "");
   writeFileSync(state.callsPath, "");
+  writeFileSync(state.rollbacksPath, "");
 }
 
 function persistStrategy(state: State, strategy: Strategy): void {

--- a/src/llm/claudeAgent.ts
+++ b/src/llm/claudeAgent.ts
@@ -29,6 +29,10 @@ const HISTORY_CAPACITY = intEnv("ERIS_LLM_HISTORY_CAPACITY", 30);
 const EXECUTOR_TIMEOUT_MS = intEnv("ERIS_LLM_EXECUTOR_TIMEOUT_MS", 200);
 // 改訂凍結フラグ。1 なら init/seed 後に revise を一切行わない(決定論・ベース保護)。
 const FREEZE_STRATEGY = process.env.ERIS_FREEZE_STRATEGY === "1";
+// live sanity ゲート(ADR 0002 A-3)。直近 N 観測で revise 候補が前版より実行時エラーを
+// 増やすなら採用しない。ERIS_LLM_SANITY_GATE=0 で無効化(決定論測定など)。
+const SANITY_OBS_WINDOW = intEnv("ERIS_LLM_SANITY_WINDOW", 8);
+const SANITY_GATE_ENABLED = process.env.ERIS_LLM_SANITY_GATE !== "0";
 
 function reportDirRoot(): string {
   return process.env.REPORT_DIR ?? "./runs";
@@ -44,6 +48,8 @@ export type State = {
   agentDir: string | null;
   decisionsPath: string | null;
   callsPath: string | null;
+  // sanity ゲート用の直近観測リング(最大 SANITY_OBS_WINDOW)。
+  recentObs: AgentObservation[];
 };
 
 export function createState(
@@ -60,6 +66,7 @@ export function createState(
     agentDir: null,
     decisionsPath: null,
     callsPath: null,
+    recentObs: [],
   };
 }
 
@@ -182,6 +189,8 @@ export async function handleLine(
 
   ensureRunDirs(state, obs);
   state.history.setInitialUsd(obs.inventory.valueUsdc);
+  state.recentObs.push(obs);
+  if (state.recentObs.length > SANITY_OBS_WINDOW) state.recentObs.shift();
 
   // Kick off background strategy calls if needed. These do not block the response.
   scheduleStrategyWorkIfNeeded(state, strategist, obs);
@@ -366,11 +375,20 @@ async function runStrategistRevise(
   );
   logClaudeCall(state, result, "revise");
   if (result.ok) {
-    state.strategy = result.strategy;
-    persistStrategy(state, result.strategy);
-    emitStderr(
-      `[claude-llm] strategy v${result.strategy.version} adopted (reason=${reason}, pnl=${currentUsd.toFixed(2)}/${initialUsd.toFixed(2)})\n`,
-    );
+    const gate = SANITY_GATE_ENABLED
+      ? passesSanityGate(result.strategy, state.strategy, state.recentObs)
+      : null;
+    if (!gate || gate.ok) {
+      state.strategy = result.strategy;
+      persistStrategy(state, result.strategy);
+      emitStderr(
+        `[claude-llm] strategy v${result.strategy.version} adopted (reason=${reason}, pnl=${currentUsd.toFixed(2)}/${initialUsd.toFixed(2)})\n`,
+      );
+    } else {
+      emitStderr(
+        `[claude-llm] revise v${result.strategy.version} rejected by sanity gate: ${gate.reason} — keeping v${state.strategy.version}\n`,
+      );
+    }
   } else {
     emitStderr(
       `[claude-llm] revise failed: ${result.reason} — keeping v${state.strategy.version}\n`,
@@ -379,6 +397,34 @@ async function runStrategistRevise(
   state.pendingPhase = null;
   state.pending = null;
   void obs;
+}
+
+/**
+ * live sanity ゲート(ADR 0002 A-3): revise 候補を直近観測で実行し、前版より実行時エラーを
+ * 増やす場合のみ却下する。noop は valid なので「正気だが弱い」変更は通す(真の PnL ゲートは
+ * offline /strategy-evolve の責務)。観測が無ければ常に通過。
+ */
+export function passesSanityGate(
+  candidate: Strategy,
+  prev: Strategy | null,
+  recentObs: AgentObservation[],
+): { ok: true } | { ok: false; reason: string } {
+  if (recentObs.length === 0) return { ok: true };
+  let candErr = 0;
+  let prevErr = 0;
+  for (const obs of recentObs) {
+    if (!runExecutor(candidate, obs, helpersBase, EXECUTOR_TIMEOUT_MS).ok)
+      candErr++;
+    if (prev && !runExecutor(prev, obs, helpersBase, EXECUTOR_TIMEOUT_MS).ok)
+      prevErr++;
+  }
+  if (candErr > prevErr) {
+    return {
+      ok: false,
+      reason: `candidate errors on ${candErr}/${recentObs.length} recent obs (prev ${prevErr})`,
+    };
+  }
+  return { ok: true };
 }
 
 function nextVersion(state: State): number {

--- a/src/llm/claudeCliStrategist.ts
+++ b/src/llm/claudeCliStrategist.ts
@@ -37,9 +37,12 @@ const CLI_OUTPUT_CONTRACT = `
 ## Output (CLI mode — IMPORTANT)
 There is NO set_strategy tool available here. Respond with ONLY a single JSON object —
 no markdown code fences, no commentary before or after — of exactly this shape:
-{"notes": "<markdown rationale>", "params": { <numeric/boolean params> }, "executor_ts": "<function body that returns an AgentAction>"}
-This is the simulator's expected, legitimate strategist output. The executor_ts body runs in a
-sandboxed vm (no network, no filesystem) inside the simulator.`;
+{"notes": "<markdown rationale>", "params": { <numeric/boolean params> }, "executor_ts": "<function body that returns an AgentAction>",
+ "change_type": "params_only" | "executor_logic", "hypothesis": "<expected improvement, grounded in attribution>",
+ "rollback_condition": "<evidence that would mean this change failed>", "why_executor_change": "<required only if executor_logic: cite the concrete failure in the round log>"}
+Default change_type to "params_only" (the previous executor is kept; only your params apply). Set "executor_logic"
+ONLY when the round log shows a concrete failure that forces a rewrite. This is the simulator's expected,
+legitimate strategist output. The executor_ts body runs in a sandboxed vm (no network, no filesystem).`;
 
 // Claude Code 組み込みツールは戦略生成に不要。print モードでツール使用待ちのハングを避けるため無効化。
 const DISALLOWED_TOOLS = [
@@ -147,6 +150,7 @@ export class ClaudeCliStrategist implements Strategist {
       "revise",
       buildReviseMessage(prev, history, reason, initialUsd, currentUsd),
       version,
+      prev,
     );
   }
 
@@ -154,6 +158,7 @@ export class ClaudeCliStrategist implements Strategist {
     phase: Phase,
     userMessage: string,
     version: number,
+    prev?: Strategy,
   ): Promise<StrategyResult> {
     const started = Date.now();
     const meta = (): ClaudeCallMeta => ({
@@ -238,7 +243,7 @@ export class ClaudeCliStrategist implements Strategist {
             meta: meta(),
           });
         }
-        const parsed = parseStrategyFromToolInput(json, version);
+        const parsed = parseStrategyFromToolInput(json, version, prev);
         if (!parsed.ok) {
           return finish({ ok: false, reason: parsed.reason, meta: meta() });
         }

--- a/src/llm/claudeStrategist.ts
+++ b/src/llm/claudeStrategist.ts
@@ -1,8 +1,19 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { AgentObservation } from "../types.js";
 import type { RoundRecord } from "./history.js";
-import { buildInitMessage, buildReviseMessage, SIM_RULES, SYSTEM_PROMPT, type Phase, type ReviseReason } from "./prompts.js";
-import { parseStrategyFromToolInput, type Strategy, type StrategyParseResult } from "./strategy.js";
+import {
+  buildInitMessage,
+  buildReviseMessage,
+  SIM_RULES,
+  SYSTEM_PROMPT,
+  type Phase,
+  type ReviseReason,
+} from "./prompts.js";
+import {
+  parseStrategyFromToolInput,
+  type Strategy,
+  type StrategyParseResult,
+} from "./strategy.js";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 
@@ -21,7 +32,14 @@ export type StrategyResult =
 
 export interface Strategist {
   init(obs: AgentObservation, version: number): Promise<StrategyResult>;
-  revise(prev: Strategy, history: RoundRecord[], reason: ReviseReason, initialUsd: number, currentUsd: number, version: number): Promise<StrategyResult>;
+  revise(
+    prev: Strategy,
+    history: RoundRecord[],
+    reason: ReviseReason,
+    initialUsd: number,
+    currentUsd: number,
+    version: number,
+  ): Promise<StrategyResult>;
 }
 
 const SET_STRATEGY_TOOL = {
@@ -32,20 +50,41 @@ const SET_STRATEGY_TOOL = {
     properties: {
       notes: {
         type: "string",
-        description: "Markdown rationale: thesis, edge, risks, what would make you revise."
+        description:
+          "Markdown rationale: thesis, edge, risks, what would make you revise.",
       },
       params: {
         type: "object",
-        description: "JSON object of numeric/boolean parameters the executor reads at runtime."
+        description:
+          "JSON object of numeric/boolean parameters the executor reads at runtime.",
       },
       executor_ts: {
         type: "string",
         description:
-          "TypeScript function body (no signature). Receives (obs, params, helpers) and must return an AgentAction. See SIM_RULES for the contract."
-      }
+          "TypeScript function body (no signature). Receives (obs, params, helpers) and must return an AgentAction. See SIM_RULES for the contract.",
+      },
+      change_type: {
+        type: "string",
+        enum: ["params_only", "executor_logic"],
+        description:
+          "Default 'params_only' (the previous executor is kept; only params apply). Use 'executor_logic' ONLY with cited evidence of a concrete failure.",
+      },
+      hypothesis: {
+        type: "string",
+        description: "Expected improvement, grounded in the PnL attribution.",
+      },
+      rollback_condition: {
+        type: "string",
+        description: "Evidence that would mean this change failed.",
+      },
+      why_executor_change: {
+        type: "string",
+        description:
+          "Required only if change_type is 'executor_logic': quote the concrete failure in the round log.",
+      },
     },
-    required: ["notes", "params", "executor_ts"]
-  }
+    required: ["notes", "params", "executor_ts"],
+  },
 };
 
 export class ClaudeStrategist implements Strategist {
@@ -53,7 +92,9 @@ export class ClaudeStrategist implements Strategist {
   private model: string;
 
   constructor(opts: { apiKey?: string; model?: string } = {}) {
-    this.client = new Anthropic({ apiKey: opts.apiKey ?? process.env.ANTHROPIC_API_KEY });
+    this.client = new Anthropic({
+      apiKey: opts.apiKey ?? process.env.ANTHROPIC_API_KEY,
+    });
     this.model = opts.model ?? process.env.ERIS_LLM_MODEL ?? DEFAULT_MODEL;
   }
 
@@ -67,12 +108,22 @@ export class ClaudeStrategist implements Strategist {
     reason: ReviseReason,
     initialUsd: number,
     currentUsd: number,
-    version: number
+    version: number,
   ): Promise<StrategyResult> {
-    return this.call("revise", buildReviseMessage(prev, history, reason, initialUsd, currentUsd), version);
+    return this.call(
+      "revise",
+      buildReviseMessage(prev, history, reason, initialUsd, currentUsd),
+      version,
+      prev,
+    );
   }
 
-  private async call(phase: Phase, userMessage: string, version: number): Promise<StrategyResult> {
+  private async call(
+    phase: Phase,
+    userMessage: string,
+    version: number,
+    prev?: Strategy,
+  ): Promise<StrategyResult> {
     const started = Date.now();
     let meta: ClaudeCallMeta | undefined;
     try {
@@ -81,11 +132,15 @@ export class ClaudeStrategist implements Strategist {
         max_tokens: 8192,
         system: [
           { type: "text", text: SYSTEM_PROMPT },
-          { type: "text", text: SIM_RULES, cache_control: { type: "ephemeral" } }
+          {
+            type: "text",
+            text: SIM_RULES,
+            cache_control: { type: "ephemeral" },
+          },
         ],
         messages: [{ role: "user", content: userMessage }],
         tools: [SET_STRATEGY_TOOL],
-        tool_choice: { type: "tool", name: "set_strategy" }
+        tool_choice: { type: "tool", name: "set_strategy" },
       });
       const latencyMs = Date.now() - started;
       const usage = response.usage as {
@@ -100,20 +155,26 @@ export class ClaudeStrategist implements Strategist {
         inputTokens: usage.input_tokens ?? 0,
         outputTokens: usage.output_tokens ?? 0,
         cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
-        cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0
+        cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
       };
-      const toolBlock = response.content.find((block) => block.type === "tool_use" && block.name === "set_strategy");
+      const toolBlock = response.content.find(
+        (block) => block.type === "tool_use" && block.name === "set_strategy",
+      );
       if (!toolBlock || toolBlock.type !== "tool_use") {
         return { ok: false, reason: "model did not call set_strategy", meta };
       }
-      const parsed: StrategyParseResult = parseStrategyFromToolInput(toolBlock.input, version);
+      const parsed: StrategyParseResult = parseStrategyFromToolInput(
+        toolBlock.input,
+        version,
+        prev,
+      );
       if (!parsed.ok) return { ok: false, reason: parsed.reason, meta };
       return { ok: true, strategy: parsed.strategy, meta };
     } catch (error) {
       return {
         ok: false,
         reason: `claude call failed: ${error instanceof Error ? error.message : String(error)}`,
-        meta
+        meta,
       };
     }
   }
@@ -125,15 +186,37 @@ export class ClaudeStrategist implements Strategist {
  */
 export class MockStrategist implements Strategist {
   async init(_obs: AgentObservation, version: number): Promise<StrategyResult> {
-    return { ok: true, strategy: defaultMockStrategy(version), meta: mockMeta("init") };
+    return {
+      ok: true,
+      strategy: defaultMockStrategy(version),
+      meta: mockMeta("init"),
+    };
   }
-  async revise(_prev: Strategy, _h: RoundRecord[], _r: ReviseReason, _i: number, _c: number, version: number): Promise<StrategyResult> {
-    return { ok: true, strategy: defaultMockStrategy(version), meta: mockMeta("revise") };
+  async revise(
+    _prev: Strategy,
+    _h: RoundRecord[],
+    _r: ReviseReason,
+    _i: number,
+    _c: number,
+    version: number,
+  ): Promise<StrategyResult> {
+    return {
+      ok: true,
+      strategy: defaultMockStrategy(version),
+      meta: mockMeta("revise"),
+    };
   }
 }
 
 function mockMeta(phase: Phase): ClaudeCallMeta {
-  return { phase, latencyMs: 0, inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 };
+  return {
+    phase,
+    latencyMs: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+  };
 }
 
 function defaultMockStrategy(version: number): Strategy {
@@ -141,6 +224,6 @@ function defaultMockStrategy(version: number): Strategy {
     version,
     notes: "Mock strategy: noop always. Replace with real ANTHROPIC_API_KEY.",
     params: { minGapBps: 15 },
-    executorTs: `return { type: "noop", reason: "mock strategy v${version}" };`
+    executorTs: `return { type: "noop", reason: "mock strategy v${version}" };`,
   };
 }

--- a/src/llm/claudeSubscriptionStrategist.ts
+++ b/src/llm/claudeSubscriptionStrategist.ts
@@ -105,6 +105,7 @@ export class ClaudeSubscriptionStrategist implements Strategist {
       "revise",
       buildReviseMessage(prev, history, reason, initialUsd, currentUsd),
       version,
+      prev,
     );
   }
 
@@ -112,6 +113,7 @@ export class ClaudeSubscriptionStrategist implements Strategist {
     phase: Phase,
     userMessage: string,
     version: number,
+    prev?: Strategy,
   ): Promise<StrategyResult> {
     const started = Date.now();
     let captured: unknown;
@@ -139,6 +141,28 @@ export class ClaudeSubscriptionStrategist implements Strategist {
               .string()
               .describe(
                 "TypeScript function body (no signature). Receives (obs, params, helpers) and must return an AgentAction.",
+              ),
+            change_type: z
+              .enum(["params_only", "executor_logic"])
+              .optional()
+              .describe(
+                "Default 'params_only' (previous executor kept; only params apply). Use 'executor_logic' ONLY with cited evidence.",
+              ),
+            hypothesis: z
+              .string()
+              .optional()
+              .describe(
+                "Expected improvement, grounded in the PnL attribution.",
+              ),
+            rollback_condition: z
+              .string()
+              .optional()
+              .describe("Evidence that would mean this change failed."),
+            why_executor_change: z
+              .string()
+              .optional()
+              .describe(
+                "Required only if change_type is 'executor_logic': quote the concrete failure in the round log.",
               ),
           },
           async (args) => {
@@ -208,7 +232,7 @@ export class ClaudeSubscriptionStrategist implements Strategist {
 
     if (!captured)
       return { ok: false, reason: "model did not call set_strategy", meta };
-    const parsed = parseStrategyFromToolInput(captured, version);
+    const parsed = parseStrategyFromToolInput(captured, version, prev);
     if (!parsed.ok) return { ok: false, reason: parsed.reason, meta };
     return {
       ok: true,

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -1,4 +1,5 @@
 import type { AgentObservation } from "../types.js";
+import { computeAttribution, formatAttribution } from "./attribution.js";
 import type { RoundRecord } from "./history.js";
 import type { Strategy } from "./strategy.js";
 
@@ -11,7 +12,13 @@ Your job has two phases:
    - params: a JSON object of numeric parameters your executor reads (thresholds, tick widths, fractions). Keep keys descriptive.
    - executor_ts: a TypeScript function BODY (no signature, no enclosing braces) that takes (obs, params, helpers) and returns an AgentAction. This runs every round in a sandbox with a 200ms timeout.
 
-2. REVISION: When given the previous strategy plus the last N round records and a reason ("scheduled" or "pnl_drop"), produce a new strategy version. You may keep the executor the same and only tune params, or rewrite the executor entirely. Explain in notes what you changed and why.
+2. REVISION: When given the previous strategy plus the last N round records and a reason ("scheduled" or "pnl_drop"), produce a new strategy version.
+
+## Revision discipline (read carefully)
+- DEFAULT to params-only changes. Tune thresholds/sizes/fractions in the direction the recent attribution justifies; keep the executor and the core thesis.
+- Only rewrite the executor (change_type: "executor_logic") when the recent round log shows a CONCRETE failure you can cite (e.g. repeated executor errors, validator rejections, or an action that is provably wrong). When you do, set why_executor_change quoting that evidence.
+- ANTI-HALLUCINATION: do NOT assume a bug that the observation/logs do not show. balancerSwap / curveSwap / aaveSupply / aaveBorrow / gmxIncrease / gmxDecrease ARE valid AgentAction types (see SIM_RULES). If you are unsure, return a params-only change or keep the strategy unchanged — never invent a fix.
+- Preserve a working edge: do not discard a profitable action (positive netUsd in the attribution) to chase a new idea.
 
 Be opinionated. Start simple. Iterate.`;
 
@@ -174,6 +181,7 @@ export function buildReviseMessage(
   currentUsd: number,
 ): string {
   const pnlPct = ((currentUsd - initialUsd) / initialUsd) * 100;
+  const attribution = formatAttribution(computeAttribution(history));
   const recent = history.slice(-12);
   const lines = recent.map(
     (r) =>
@@ -198,14 +206,22 @@ ${JSON.stringify(prev.params, null, 2)}
 ${prev.executorTs}
 \`\`\`
 
+## PnL attribution (which actions earned/lost; use this to decide what to change)
+${attribution}
+
 ## Recent ${recent.length} rounds
 ${lines.join("\n")}
 
 ## Your task
-Call set_strategy with an updated version. This strategy may have started from a hand-tuned base
-(see the notes above); treat it as a working baseline to **refine incrementally**, not replace by default:
-- Prefer tuning params (thresholds, sizes, fractions) in the direction the recent rounds justify.
-- Keep the executor and the core thesis unless the evidence shows it is clearly wrong; then rewrite.
-- Preserve what already works (do not discard a profitable edge to chase a new idea).
-Briefly explain in notes what changed vs v${prev.version} and why.`;
+Produce an updated strategy. This strategy may have started from a hand-tuned base (see notes above);
+treat it as a working baseline to **refine incrementally**, not replace by default.
+
+Include a "change contract" alongside notes/params/executor_ts:
+- change_type: "params_only" (DEFAULT) or "executor_logic"
+- hypothesis: what you expect the change to improve and why, grounded in the attribution above
+- rollback_condition: what evidence would mean this change failed
+- why_executor_change: REQUIRED only if change_type is "executor_logic" — quote the concrete failure in the round log that forces a rewrite
+
+Rules: default to params_only. Only set executor_logic with cited evidence. Do not invent bugs (see Revision discipline).
+Keep a profitable action (positive netUsd) alive. Briefly note what changed vs v${prev.version} and why.`;
 }

--- a/src/llm/strategy.ts
+++ b/src/llm/strategy.ts
@@ -33,7 +33,7 @@ export const DEFAULT_ADDRESSES: ExecutorHelpers["ADDRESSES"] = {
   SWAP_ROUTER: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
   QUOTER_V2: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
   NFT_POSITION_MANAGER: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
-  AAVE_POOL: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+  AAVE_POOL: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
 };
 
 export type StrategyParseError = { ok: false; reason: string };
@@ -46,32 +46,64 @@ export type StrategyParseResult = StrategyParseOk | StrategyParseError;
  * - params: object (JSON-serializable)
  * - executor_ts: string, must parse as a function body without syntax errors
  */
-export function parseStrategyFromToolInput(input: unknown, version: number): StrategyParseResult {
-  if (!input || typeof input !== "object") return { ok: false, reason: "tool input must be an object" };
+/**
+ * Validate a strategist payload against the Strategy schema.
+ *
+ * Change-contract / params-only enforcement (ADR 0002): when `prev` is given and
+ * the payload's `change_type` is not "executor_logic", the previous executor is
+ * kept and the model's executor_ts is ignored. This structurally prevents
+ * hallucinated executor rewrites (the model can still tune params). Callers that
+ * omit `prev` (e.g. init, unit tests) get the legacy behavior: executor_ts required.
+ */
+export function parseStrategyFromToolInput(
+  input: unknown,
+  version: number,
+  prev?: Strategy,
+): StrategyParseResult {
+  if (!input || typeof input !== "object")
+    return { ok: false, reason: "tool input must be an object" };
   const obj = input as Record<string, unknown>;
-  if (typeof obj.notes !== "string" || obj.notes.trim() === "") return { ok: false, reason: "notes must be a non-empty string" };
-  if (!obj.params || typeof obj.params !== "object" || Array.isArray(obj.params)) {
+  if (typeof obj.notes !== "string" || obj.notes.trim() === "")
+    return { ok: false, reason: "notes must be a non-empty string" };
+  if (
+    !obj.params ||
+    typeof obj.params !== "object" ||
+    Array.isArray(obj.params)
+  ) {
     return { ok: false, reason: "params must be a plain object" };
   }
-  if (typeof obj.executor_ts !== "string" || obj.executor_ts.trim() === "") {
-    return { ok: false, reason: "executor_ts must be a non-empty string" };
-  }
-  const syntaxCheck = checkExecutorSyntax(obj.executor_ts);
-  if (!syntaxCheck.ok) return syntaxCheck;
   // params must be JSON-serializable
   try {
     JSON.parse(JSON.stringify(obj.params));
   } catch {
     return { ok: false, reason: "params must be JSON-serializable" };
   }
+
+  const changeType: "params_only" | "executor_logic" =
+    obj.change_type === "executor_logic" ? "executor_logic" : "params_only";
+  const provided = typeof obj.executor_ts === "string" ? obj.executor_ts : "";
+
+  let executorTs: string;
+  if (changeType === "params_only" && prev) {
+    // params-only: 前版の executor を保持し、モデルの executor_ts は無視する。
+    executorTs = prev.executorTs;
+  } else {
+    if (provided.trim() === "") {
+      return { ok: false, reason: "executor_ts must be a non-empty string" };
+    }
+    const syntaxCheck = checkExecutorSyntax(provided);
+    if (!syntaxCheck.ok) return syntaxCheck;
+    executorTs = provided;
+  }
+
   return {
     ok: true,
     strategy: {
       version,
       notes: obj.notes,
       params: obj.params as Record<string, unknown>,
-      executorTs: obj.executor_ts
-    }
+      executorTs,
+    },
   };
 }
 
@@ -79,13 +111,18 @@ export function parseStrategyFromToolInput(input: unknown, version: number): Str
  * Verify the executor source compiles. We wrap it in a function and try to construct it.
  * `new Function` throws on syntax errors but does not execute the body.
  */
-export function checkExecutorSyntax(source: string): { ok: true } | StrategyParseError {
+export function checkExecutorSyntax(
+  source: string,
+): { ok: true } | StrategyParseError {
   try {
     // Wrap exactly the way runExecutor wraps it so the parser sees the same shape.
     new Function("obs", "params", "helpers", source);
     return { ok: true };
   } catch (error) {
-    return { ok: false, reason: `executor_ts syntax error: ${errorMessage(error)}` };
+    return {
+      ok: false,
+      reason: `executor_ts syntax error: ${errorMessage(error)}`,
+    };
   }
 }
 
@@ -103,39 +140,54 @@ export function runExecutor(
   strategy: Strategy,
   obs: AgentObservation,
   helpersBase: Omit<ExecutorHelpers, "log">,
-  timeoutMs = 200
+  timeoutMs = 200,
 ): ExecutorRunResult {
   const logs: string[] = [];
   const helpers: ExecutorHelpers = {
     ...helpersBase,
     log: (msg: string) => {
-      if (typeof msg === "string" && logs.length < 32) logs.push(msg.slice(0, 500));
-    }
+      if (typeof msg === "string" && logs.length < 32)
+        logs.push(msg.slice(0, 500));
+    },
   };
   const ctx = createContext({
     obs,
     params: strategy.params,
     helpers,
     __result: undefined,
-    console: { log: helpers.log }
+    console: { log: helpers.log },
   });
   const wrapped = `__result = ((obs, params, helpers) => { ${strategy.executorTs} })(obs, params, helpers);`;
   try {
-    new Script(wrapped, { filename: `strategy-v${strategy.version}.executor.js` }).runInContext(ctx, {
+    new Script(wrapped, {
+      filename: `strategy-v${strategy.version}.executor.js`,
+    }).runInContext(ctx, {
       timeout: timeoutMs,
-      displayErrors: true
+      displayErrors: true,
     });
   } catch (error) {
-    return { ok: false, reason: `executor threw: ${errorMessage(error)}`, logs };
+    return {
+      ok: false,
+      reason: `executor threw: ${errorMessage(error)}`,
+      logs,
+    };
   }
   if ((ctx as { __result: unknown }).__result === undefined) {
-    return { ok: false, reason: "executor returned undefined (must return AgentAction)", logs };
+    return {
+      ok: false,
+      reason: "executor returned undefined (must return AgentAction)",
+      logs,
+    };
   }
   let action: AgentAction;
   try {
     action = parseAction((ctx as { __result: unknown }).__result);
   } catch (error) {
-    return { ok: false, reason: `invalid AgentAction: ${errorMessage(error)}`, logs };
+    return {
+      ok: false,
+      reason: `invalid AgentAction: ${errorMessage(error)}`,
+      logs,
+    };
   }
   return { ok: true, action, logs };
 }

--- a/src/protocols/aave.ts
+++ b/src/protocols/aave.ts
@@ -6,7 +6,13 @@ import {
   type PublicClient,
 } from "viem";
 import { AAVE, TOKENS, stableBalanceOf } from "../constants.js";
-import { accountAddress, sendAndMine, sendAsImpersonated } from "../chain.js";
+import {
+  accountAddress,
+  increaseTime,
+  mine,
+  sendAndMine,
+  sendAsImpersonated,
+} from "../chain.js";
 import type {
   AaveObservation,
   AgentObservation,
@@ -42,6 +48,13 @@ export const aavePoolAbi = parseAbi([
 
 export const aaveDataProviderAbi = parseAbi([
   "function getUserReserveData(address asset, address user) view returns (uint256 currentATokenBalance, uint256 currentStableDebt, uint256 currentVariableDebt, uint256 principalStableDebt, uint256 scaledVariableDebt, uint256 stableBorrowRate, uint256 liquidityRate, uint40 stableRateLastUpdated, bool usageAsCollateralEnabled)",
+]);
+
+// Pool.getReserveData は「生の」格納値（index/rate/lastUpdate）を返す。利息計算を
+// 行わないため、後述の lastUpdateTimestamp が block.timestamp より未来でも revert しない。
+// （getUserAccountData / PoolDataProvider.getReserveData は利息を計算するため revert する。）
+export const aaveReserveDataAbi = parseAbi([
+  "function getReserveData(address asset) view returns ((uint256 configuration, uint128 liquidityIndex, uint128 currentLiquidityRate, uint128 variableBorrowIndex, uint128 currentVariableBorrowRate, uint128 currentStableBorrowRate, uint40 lastUpdateTimestamp, uint16 id, address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress, address interestRateStrategyAddress, uint128 accruedToTreasury, uint128 unbacked, uint128 isolationModeTotalDebt))",
 ]);
 
 export const aaveOracleAbi = parseAbi([
@@ -239,6 +252,47 @@ export async function readAaveFlowReserves(
   return { wethSupplied: weth.supplied, usdcBorrowed: usdc.borrowed };
 }
 
+// reserve の最終更新時刻（生の格納値。利息計算しないので未来でも revert しない）。
+async function reserveLastUpdate(
+  publicClient: PublicClient,
+  asset: Address,
+): Promise<bigint> {
+  const r = (await publicClient.readContract({
+    address: AAVE.Pool,
+    abi: aaveReserveDataAbi,
+    functionName: "getReserveData",
+    args: [asset],
+  })) as { lastUpdateTimestamp: number | bigint };
+  return BigInt(r.lastUpdateTimestamp);
+}
+
+// Aave フォークの時刻整合を取る。Arbitrum を anvil でフォークすると、ブロックの
+// block.timestamp が reserve の lastUpdateTimestamp より過去になることがある
+// （フォークブロックの timestamp と state スナップショットのズレ。間欠的に発生）。
+// その状態では Aave の利息計算 `dt = block.timestamp - lastUpdateTimestamp` が
+// uint アンダーフロー(panic 0x11)を起こし、getUserAccountData / getReserveData が
+// revert → 最初の observe で sim 全体がクラッシュする。
+// 対策: 我々が使う WETH/USDC reserve の lastUpdateTimestamp を読み、block.timestamp が
+// それ以下(dt<=0)なら超えるまで EVM 時間を進める。これでラウンドループ中の Aave 読取が
+// 常に dt>0 となり、（間欠クラッシュせず）長走行でも aave 戦略を評価できる。
+// resetFork が forking 付き再フォークを行えば block.timestamp は通常 lastUpdate より後に
+// なるためここは発火しないが、フォークブロック次第で稀に逆転するため防御として残す。
+const AAVE_WARP_BUFFER_SECONDS = 3600n; // 1h。発火時に dt>0 を安定させる余裕。
+async function warpPastReserveLastUpdate(ctx: SimContext): Promise<void> {
+  const [wethUpdate, usdcUpdate] = await Promise.all([
+    reserveLastUpdate(ctx.publicClient, TOKENS.WETH.address),
+    reserveLastUpdate(ctx.publicClient, AAVE_STABLE),
+  ]);
+  const maxUpdate = wethUpdate > usdcUpdate ? wethUpdate : usdcUpdate;
+  const now = (await ctx.publicClient.getBlock()).timestamp;
+  if (now > maxUpdate) return; // dt>0 済み（健全なフォークブロック）→ 何もしない
+  await increaseTime(
+    ctx.publicClient,
+    Number(maxUpdate - now + AAVE_WARP_BUFFER_SECONDS),
+  );
+  await mine(ctx.publicClient);
+}
+
 export const aaveAdapter: ProtocolAdapter = {
   id: "aave",
   stableToken: AAVE_STABLE,
@@ -303,6 +357,9 @@ export const aaveAdapter: ProtocolAdapter = {
 
   async setupGlobal(ctx: SimContext): Promise<void> {
     const admin = accountAddress(ctx.adminPk);
+    // フォークの時刻ズレを補正（負の dt による利息計算アンダーフローを防ぐ）。
+    // 以降の setup / ラウンドループでの Aave 読取が常に有効になる。
+    await warpPastReserveLastUpdate(ctx);
     // 現在の Aave オラクル価格を初期値にして mock を差し込む（連続性のため）
     const [wethUsd8, usdcUsd8] = (await Promise.all([
       ctx.publicClient.readContract({

--- a/test/base-strategies.test.ts
+++ b/test/base-strategies.test.ts
@@ -142,6 +142,105 @@ test("lp ベース: 既にポジションがあれば hold(noop)", () => {
   if (r.ok) assert.equal(r.action.type, "noop");
 });
 
+test("venue ベース: 最も乖離した venue で fair に寄せる swap", () => {
+  const s = getBaseStrategy("venue");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.protocols.uniswap!.pool.priceUsdcPerWeth = 1695; // gap ~29bps
+  obs.protocols.balancer = { priceUsdcPerWeth: 1650 }; // gap ~294bps（最大）
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "balancerSwap"); // balancer が最大乖離
+    if (r.action.type === "balancerSwap") {
+      assert.equal(r.action.tokenIn, "USDC"); // pool<fair → WETH 割安 → USDC in
+      assert.ok(BigInt(r.action.amountIn) > 0n);
+    }
+  }
+});
+
+test("venue ベース: どの venue も乖離が小さければ noop", () => {
+  const s = getBaseStrategy("venue");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.protocols.uniswap!.pool.priceUsdcPerWeth = 1700; // gap 0
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(r.action.type, "noop");
+});
+
+test("aave ベース: 担保未供給なら WETH を supply", () => {
+  const s = getBaseStrategy("aave");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.limits.maxAaveSupplyWethWei = "5000000000000000000";
+  obs.limits.maxAaveBorrowUsdcUnits = "5000000000";
+  obs.protocols.aave = {
+    healthFactor: "0",
+    totalCollateralBase: "0",
+    totalDebtBase: "0",
+    availableBorrowsBase: "0",
+    supplied: {},
+    borrowed: {},
+  };
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "aaveSupply");
+    if (r.action.type === "aaveSupply") {
+      assert.equal(r.action.asset, "WETH");
+      assert.ok(BigInt(r.action.amount) > 0n);
+    }
+  }
+});
+
+test("aave ベース: 担保あり借入無しなら USDC を borrow", () => {
+  const s = getBaseStrategy("aave");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.limits.maxAaveBorrowUsdcUnits = "5000000000";
+  obs.protocols.aave = {
+    healthFactor: "0",
+    totalCollateralBase: "0",
+    totalDebtBase: "0",
+    availableBorrowsBase: "0",
+    supplied: { WETH: "2500000000000000000" },
+    borrowed: {},
+  };
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "aaveBorrow");
+    if (r.action.type === "aaveBorrow") assert.equal(r.action.asset, "USDC");
+  }
+});
+
+test("statarb ベース: 窓が貯まり |z| が大きければ swap、burn-in 中は noop", () => {
+  const s = getBaseStrategy("statarb");
+  assert.ok(s);
+  // 履歴不足 → burn-in noop
+  const cold = syntheticObs();
+  cold.history = [];
+  const r0 = runExecutor(s, cold, helpers);
+  assert.equal(r0.ok, true);
+  if (r0.ok) assert.equal(r0.action.type, "noop");
+
+  // 12 点の小ノイズ履歴(平均~0, std>0)+ 現在 pool=1600(gap +6.25% → |z| 大)
+  const hot = syntheticObs();
+  hot.history = Array.from({ length: 12 }, (_, i) => ({
+    round: i + 1,
+    poolPriceUsdcPerWeth: i % 2 === 0 ? 1699 : 1701,
+    fairPriceUsdcPerWeth: 1700,
+  }));
+  hot.protocols.uniswap!.pool.priceUsdcPerWeth = 1600;
+  const r = runExecutor(s, hot, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "swap");
+    if (r.action.type === "swap") assert.equal(r.action.tokenIn, "USDC");
+  }
+});
+
 test("getBaseStrategy: 未知 id / undefined は null", () => {
   assert.equal(getBaseStrategy("nope"), null);
   assert.equal(getBaseStrategy(undefined), null);

--- a/test/base-strategies.test.ts
+++ b/test/base-strategies.test.ts
@@ -421,6 +421,116 @@ test("ladder ベース: 空なら次段を mint、満杯なら noop", () => {
   if (rf.ok) assert.equal(rf.action.type, "noop");
 });
 
+function emptyAave() {
+  return {
+    healthFactor: "0",
+    totalCollateralBase: "0",
+    totalDebtBase: "0",
+    availableBorrowsBase: "0",
+    supplied: {} as Record<string, string>,
+    borrowed: {} as Record<string, string>,
+  };
+}
+
+test("aaveloop ベース: 担保未供給・遊休USDC無しなら WETH を supply", () => {
+  const s = getBaseStrategy("aaveloop");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.balances.usdcUnits = "0";
+  obs.limits.maxAaveSupplyWethWei = "5000000000000000000";
+  obs.limits.maxAaveBorrowUsdcUnits = "5000000000";
+  obs.protocols.aave = emptyAave();
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "aaveSupply");
+    if (r.action.type === "aaveSupply") assert.equal(r.action.asset, "WETH");
+  }
+});
+
+test("aaveloop ベース: 担保あり・LTV 未達・借入余力ありなら USDC を borrow", () => {
+  const s = getBaseStrategy("aaveloop");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.balances.usdcUnits = "0";
+  obs.balances.wethWei = "0";
+  obs.limits.maxAaveBorrowUsdcUnits = "5000000000";
+  obs.protocols.aave = {
+    ...emptyAave(),
+    totalCollateralBase: String(5000n * 10n ** 8n), // $5000
+    availableBorrowsBase: String(3000n * 10n ** 8n), // $3000
+    supplied: { WETH: "3000000000000000000" },
+  };
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "aaveBorrow");
+    if (r.action.type === "aaveBorrow") assert.equal(r.action.asset, "USDC");
+  }
+});
+
+test("crossvenue ベース: 最安 venue で買い最高 venue で売る 2-leg bundle", () => {
+  const s = getBaseStrategy("crossvenue");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.protocols.uniswap!.pool.priceUsdcPerWeth = 1700;
+  obs.protocols.balancer = { priceUsdcPerWeth: 1650 }; // 最安
+  obs.protocols.curve = { priceUsdcPerWeth: 1720 }; // 最高
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "bundle");
+    if (r.action.type === "bundle") {
+      assert.equal(r.action.actions[0].type, "balancerSwap"); // 最安で買い
+      assert.equal(r.action.actions[1].type, "curveSwap"); // 最高で売り
+    }
+  }
+});
+
+test("crossvenue ベース: venue が 2 未満なら noop", () => {
+  const s = getBaseStrategy("crossvenue");
+  assert.ok(s);
+  const obs = syntheticObs(); // uniswap のみ
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(r.action.type, "noop");
+});
+
+test("lpyield ベース: LP 無→mint、LP 有+遊休USDC→Aave supply", () => {
+  const s = getBaseStrategy("lpyield");
+  assert.ok(s);
+  // LP 無し → mint
+  const a = syntheticObs();
+  a.protocols.aave = emptyAave();
+  const ra = runExecutor(s, a, helpers);
+  assert.equal(ra.ok, true);
+  if (ra.ok) assert.equal(ra.action.type, "mintLiquidity");
+
+  // LP 有り + 遊休 USDC → Aave へ park
+  const b = syntheticObs();
+  b.protocols.aave = emptyAave();
+  b.balances.usdcUnits = "10000000000"; // 10000 USDC
+  b.protocols.uniswap!.positions = [
+    {
+      tokenId: "1",
+      tickLower: 199900,
+      tickUpper: 200100,
+      liquidity: "1000",
+      tokensOwedWethWei: "0",
+      tokensOwedUsdcUnits: "0",
+      amountWethWei: "0",
+      amountUsdcUnits: "0",
+      valueUsdc: 1,
+    },
+  ];
+  const rb = runExecutor(s, b, helpers);
+  assert.equal(rb.ok, true);
+  if (rb.ok) {
+    assert.equal(rb.action.type, "aaveSupply");
+    if (rb.action.type === "aaveSupply") assert.equal(rb.action.asset, "USDC");
+  }
+});
+
 test("getBaseStrategy: 未知 id / undefined は null", () => {
   assert.equal(getBaseStrategy("nope"), null);
   assert.equal(getBaseStrategy(undefined), null);

--- a/test/base-strategies.test.ts
+++ b/test/base-strategies.test.ts
@@ -241,6 +241,186 @@ test("statarb ベース: 窓が貯まり |z| が大きければ swap、burn-in �
   }
 });
 
+test("cvbal ベース: balancer↔curve のスプレッド超で両建て bundle", () => {
+  const s = getBaseStrategy("cvbal");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.protocols.balancer = { priceUsdcPerWeth: 1650 }; // 割安
+  obs.protocols.curve = { priceUsdcPerWeth: 1700 }; // 割高 → spread ~3%
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "bundle");
+    if (r.action.type === "bundle") {
+      assert.equal(r.action.actions.length, 2);
+      assert.equal(r.action.actions[0].type, "balancerSwap"); // 割安側で買い
+      assert.equal(r.action.actions[1].type, "curveSwap"); // 割高側で売り
+    }
+  }
+});
+
+test("cvbal ベース: スプレッドが小さければ noop", () => {
+  const s = getBaseStrategy("cvbal");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.protocols.balancer = { priceUsdcPerWeth: 1700 };
+  obs.protocols.curve = { priceUsdcPerWeth: 1700 };
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(r.action.type, "noop");
+});
+
+test("dnlp ベース: LP 無→mint、LP 有/short 無→GMX short ヘッジ", () => {
+  const s = getBaseStrategy("dnlp");
+  assert.ok(s);
+  // State A: LP 無し → mint
+  const a = syntheticObs();
+  a.protocols.gmx = { marketPriceUsd: 1700 };
+  const ra = runExecutor(s, a, helpers);
+  assert.equal(ra.ok, true);
+  if (ra.ok) assert.equal(ra.action.type, "mintLiquidity");
+
+  // State B: LP 有り(WETH エクスポージャ)/ short 無し → gmxIncrease short
+  const b = syntheticObs();
+  b.limits.maxGmxSizeUsd = "100000000000000000000000000000000000"; // 1e35
+  b.protocols.gmx = { marketPriceUsd: 1700 };
+  b.protocols.uniswap!.positions = [
+    {
+      tokenId: "1",
+      tickLower: 199900,
+      tickUpper: 200100,
+      liquidity: "1000",
+      tokensOwedWethWei: "0",
+      tokensOwedUsdcUnits: "0",
+      amountWethWei: "1000000000000000000", // 1 WETH エクスポージャ
+      amountUsdcUnits: "0",
+      valueUsdc: 1700,
+    },
+  ];
+  const rb = runExecutor(s, b, helpers);
+  assert.equal(rb.ok, true);
+  if (rb.ok) {
+    assert.equal(rb.action.type, "gmxIncrease");
+    if (rb.action.type === "gmxIncrease") assert.equal(rb.action.isLong, false);
+  }
+});
+
+test("gmxperp ベース: ポジション無しなら ETH long を open", () => {
+  const s = getBaseStrategy("gmxperp");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.limits.maxGmxSizeUsd = "100000000000000000000000000000000000"; // 1e35
+  obs.protocols.gmx = { marketPriceUsd: 1700 };
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "gmxIncrease");
+    if (r.action.type === "gmxIncrease") assert.equal(r.action.isLong, true);
+  }
+});
+
+test("gmxrev ベース: 価格が MA より高ければ short を open", () => {
+  const s = getBaseStrategy("gmxrev");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.limits.maxGmxSizeUsd = "100000000000000000000000000000000000";
+  obs.protocols.gmx = { marketPriceUsd: 1700 };
+  obs.fairPriceUsdcPerWeth = 1700;
+  obs.history = Array.from({ length: 12 }, (_, i) => ({
+    round: i + 1,
+    poolPriceUsdcPerWeth: 1690,
+    fairPriceUsdcPerWeth: 1690, // MA=1690 < price 1700 → dev +0.59% > 40bps
+  }));
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "gmxIncrease");
+    if (r.action.type === "gmxIncrease") assert.equal(r.action.isLong, false); // 割高→short
+  }
+});
+
+test("gmxtrend ベース: 上昇トレンドなら long を open", () => {
+  const s = getBaseStrategy("gmxtrend");
+  assert.ok(s);
+  const obs = syntheticObs();
+  obs.limits.maxGmxSizeUsd = "100000000000000000000000000000000000";
+  obs.protocols.gmx = { marketPriceUsd: 1700 };
+  obs.history = Array.from({ length: 8 }, (_, i) => ({
+    round: i + 1,
+    poolPriceUsdcPerWeth: 1680 + i * 8,
+    fairPriceUsdcPerWeth: 1680 + i * 8, // 単調増加 → up-trend
+  }));
+  const r = runExecutor(s, obs, helpers);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "gmxIncrease");
+    if (r.action.type === "gmxIncrease") assert.equal(r.action.isLong, true);
+  }
+});
+
+test("fairmm ベース: ポジション無しなら fair 含意 tick 中心に mint", () => {
+  const s = getBaseStrategy("fairmm");
+  assert.ok(s);
+  const r = runExecutor(s, syntheticObs(), helpers); // pool 1690 < fair 1700
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.action.type, "mintLiquidity");
+    if (r.action.type === "mintLiquidity") {
+      assert.equal(r.action.tickLower % 10, 0);
+      assert.equal(r.action.tickUpper % 10, 0);
+      assert.ok(r.action.tickLower < r.action.tickUpper);
+    }
+  }
+});
+
+test("jitlp ベース: 高ボラで mint、低ボラ/履歴不足で noop", () => {
+  const s = getBaseStrategy("jitlp");
+  assert.ok(s);
+  const flat = syntheticObs();
+  flat.history = Array.from({ length: 14 }, (_, i) => ({
+    round: i + 1,
+    poolPriceUsdcPerWeth: 1700,
+    fairPriceUsdcPerWeth: 1700, // vol 0
+  }));
+  const r0 = runExecutor(s, flat, helpers);
+  assert.equal(r0.ok, true);
+  if (r0.ok) assert.equal(r0.action.type, "noop");
+
+  const vol = syntheticObs();
+  vol.history = Array.from({ length: 14 }, (_, i) => ({
+    round: i + 1,
+    poolPriceUsdcPerWeth: i % 2 === 0 ? 1700 : 1785,
+    fairPriceUsdcPerWeth: i % 2 === 0 ? 1700 : 1785, // ~5% スイング
+  }));
+  const r1 = runExecutor(s, vol, helpers);
+  assert.equal(r1.ok, true);
+  if (r1.ok) assert.equal(r1.action.type, "mintLiquidity");
+});
+
+test("ladder ベース: 空なら次段を mint、満杯なら noop", () => {
+  const s = getBaseStrategy("ladder");
+  assert.ok(s);
+  const empty = runExecutor(s, syntheticObs(), helpers);
+  assert.equal(empty.ok, true);
+  if (empty.ok) assert.equal(empty.action.type, "mintLiquidity");
+
+  const full = syntheticObs();
+  full.protocols.uniswap!.positions = [1, 2, 3].map((id) => ({
+    tokenId: String(id),
+    tickLower: 199900,
+    tickUpper: 200100,
+    liquidity: "1000",
+    tokensOwedWethWei: "0",
+    tokensOwedUsdcUnits: "0",
+    amountWethWei: "0",
+    amountUsdcUnits: "0",
+    valueUsdc: 1,
+  }));
+  const rf = runExecutor(s, full, helpers); // steps 既定 3 → 満杯
+  assert.equal(rf.ok, true);
+  if (rf.ok) assert.equal(rf.action.type, "noop");
+});
+
 test("getBaseStrategy: 未知 id / undefined は null", () => {
   assert.equal(getBaseStrategy("nope"), null);
   assert.equal(getBaseStrategy(undefined), null);

--- a/test/llm-agent.test.ts
+++ b/test/llm-agent.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   createState,
   handleLine,
+  maybeRollback,
   passesSanityGate,
   whichReviseReason,
 } from "../src/llm/claudeAgent.js";
@@ -374,4 +375,41 @@ test("passesSanityGate: 候補がクリーンなら前版が壊れていても�
   const obs = [makeObs(1)];
   assert.equal(passesSanityGate(GATE_CLEAN, GATE_BROKEN, obs).ok, true);
   assert.equal(passesSanityGate(GATE_CLEAN, GATE_CLEAN, obs).ok, true);
+});
+
+function rbStrat(v: number): Strategy {
+  return { version: v, notes: "t", params: {}, executorTs: `return { type: "noop" };` };
+}
+
+test("maybeRollback: 採用後の下落で前版へ巻き戻す(window 経過後)", () => {
+  const s = createState("rb");
+  s.strategy = rbStrat(2);
+  s.prevStrategy = rbStrat(1);
+  s.adoptUsd = 100;
+  s.adoptRound = 10;
+  s.pendingAdoption = false;
+  // window(5)未満 → 戻さない
+  maybeRollback(s, makeObs(12, 90));
+  assert.equal(s.strategy?.version, 2);
+  // window 経過 & drop 5% >= 4% → 前版へ
+  maybeRollback(s, makeObs(15, 95));
+  assert.equal(s.strategy?.version, 1);
+  assert.equal(s.prevStrategy, null);
+});
+
+test("maybeRollback: pendingAdoption で基準化、軽微下落は維持し graduate で監視解除", () => {
+  const s = createState("rb");
+  s.strategy = rbStrat(2);
+  s.prevStrategy = rbStrat(1);
+  s.pendingAdoption = true;
+  maybeRollback(s, makeObs(10, 100)); // 基準化
+  assert.equal(s.adoptUsd, 100);
+  assert.equal(s.adoptRound, 10);
+  // 下落 2% < 4% → 維持(graduate 前は監視継続)
+  maybeRollback(s, makeObs(20, 98));
+  assert.equal(s.strategy?.version, 2);
+  assert.notEqual(s.prevStrategy, null);
+  // graduate(24)経過 & 健全 → 監視解除
+  maybeRollback(s, makeObs(40, 101));
+  assert.equal(s.prevStrategy, null);
 });

--- a/test/llm-agent.test.ts
+++ b/test/llm-agent.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   createState,
   handleLine,
+  passesSanityGate,
   whichReviseReason,
 } from "../src/llm/claudeAgent.js";
 import type {
@@ -351,4 +352,26 @@ test("whichReviseReason cadence and drawdown logic", () => {
   assert.equal(whichReviseReason(3, -1, 94.9, 100), "pnl_drop");
   // Initial 0 → never trigger drawdown
   assert.equal(whichReviseReason(3, -1, -10, 0), null);
+});
+
+function gateStrat(executorTs: string): Strategy {
+  return { version: 1, notes: "t", params: {}, executorTs };
+}
+const GATE_CLEAN = gateStrat(`return { type: "noop", reason: "ok" };`);
+const GATE_BROKEN = gateStrat(`throw new Error("boom");`);
+
+test("passesSanityGate: 観測が無ければ常に通過", () => {
+  assert.equal(passesSanityGate(GATE_BROKEN, GATE_CLEAN, []).ok, true);
+});
+
+test("passesSanityGate: 候補が前版よりエラーを増やすなら却下", () => {
+  const obs = [makeObs(1), makeObs(2)];
+  const r = passesSanityGate(GATE_BROKEN, GATE_CLEAN, obs);
+  assert.equal(r.ok, false);
+});
+
+test("passesSanityGate: 候補がクリーンなら前版が壊れていても通過", () => {
+  const obs = [makeObs(1)];
+  assert.equal(passesSanityGate(GATE_CLEAN, GATE_BROKEN, obs).ok, true);
+  assert.equal(passesSanityGate(GATE_CLEAN, GATE_CLEAN, obs).ok, true);
 });

--- a/test/llm-attribution.test.ts
+++ b/test/llm-attribution.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeAttribution,
+  formatAttribution,
+} from "../src/llm/attribution.js";
+import type { RoundRecord } from "../src/llm/history.js";
+
+function rec(
+  round: number,
+  type: string,
+  inventoryUsd: number,
+  opts: { ok?: boolean; reason?: string } = {},
+): RoundRecord {
+  return {
+    round,
+    poolPrice: 1700,
+    fairPrice: 1700,
+    inventoryUsd,
+    weth: 0,
+    usdc: 0,
+    eth: 0,
+    openPositions: 0,
+    action: { type },
+    executorLogs: [],
+    executorOk: opts.ok ?? true,
+    executorReason: opts.reason,
+  };
+}
+
+test("computeAttribution: action 別 netUsd / turnover / drawdown を集計", () => {
+  const records = [
+    rec(1, "swap", 100),
+    rec(2, "noop", 110), // swap@1 → +10
+    rec(3, "swap", 105), // noop@2 → -5
+    rec(4, "noop", 108), // swap@3 → +3
+  ];
+  const a = computeAttribution(records);
+  assert.equal(a.samples, 4);
+  assert.equal(a.turnover, 2); // swap が 2 回
+  assert.equal(a.byAction.swap.rounds, 2);
+  assert.equal(a.byAction.swap.netUsd, 13); // +10 +3
+  assert.equal(a.byAction.noop.netUsd, -5); // r4 は次が無く 0
+  // peak 110 → trough 105 → drawdown 5
+  assert.equal(a.drawdownUsd, 5);
+});
+
+test("computeAttribution: 失敗を failed / noop理由に数える", () => {
+  const records = [
+    rec(1, "noop", 100, { ok: false, reason: "executor error: boom" }),
+    rec(2, "noop", 100, { ok: true, reason: "gap too small" }),
+  ];
+  const a = computeAttribution(records);
+  assert.equal(a.byAction.noop.failed, 1);
+  assert.equal(a.byAction.noop.valid, 1);
+  const reasons = Object.fromEntries(a.topNoopReasons);
+  assert.equal(reasons["executor error: boom"], 1);
+  assert.equal(reasons["gap too small"], 1);
+});
+
+test("formatAttribution: サンプル0は (no rounds yet)", () => {
+  assert.equal(formatAttribution(computeAttribution([])), "(no rounds yet)");
+  const s = formatAttribution(computeAttribution([rec(1, "swap", 100)]));
+  assert.match(s, /per-action PnL attribution/);
+  assert.match(s, /swap:/);
+});

--- a/test/llm-strategy.test.ts
+++ b/test/llm-strategy.test.ts
@@ -192,3 +192,54 @@ test("runExecutor sandbox does not expose process or require", () => {
     assert.equal(result.action.reason, "process=false require=false");
   }
 });
+
+const PREV: Strategy = {
+  version: 1,
+  notes: "prev",
+  params: { gap: 0.001 },
+  executorTs: `return { type: "noop", reason: "prev-executor" };`,
+};
+
+test("parseStrategyFromToolInput: prev あり・change_type 既定(params_only)は prev の executor を保持", () => {
+  const out = parseStrategyFromToolInput(
+    {
+      notes: "tune",
+      params: { gap: 0.002 },
+      executor_ts: `return { type: "swap", tokenIn: "WETH", amountIn: "1" };`,
+    },
+    2,
+    PREV,
+  );
+  assert.equal(out.ok, true);
+  if (out.ok) {
+    assert.equal(out.strategy.executorTs, PREV.executorTs); // モデルの executor は無視
+    assert.deepEqual(out.strategy.params, { gap: 0.002 }); // params は反映
+  }
+});
+
+test("parseStrategyFromToolInput: change_type=executor_logic は新 executor を採用", () => {
+  const newExec = `return { type: "swap", tokenIn: "USDC", amountIn: "1" };`;
+  const out = parseStrategyFromToolInput(
+    { notes: "rewrite", params: {}, executor_ts: newExec, change_type: "executor_logic" },
+    2,
+    PREV,
+  );
+  assert.equal(out.ok, true);
+  if (out.ok) assert.equal(out.strategy.executorTs, newExec);
+});
+
+test("parseStrategyFromToolInput: params_only かつ prev ありなら executor_ts 省略可", () => {
+  const out = parseStrategyFromToolInput({ notes: "tune", params: { gap: 0.003 } }, 2, PREV);
+  assert.equal(out.ok, true);
+  if (out.ok) assert.equal(out.strategy.executorTs, PREV.executorTs);
+});
+
+test("parseStrategyFromToolInput: prev 無し(init)は従来どおり executor_ts 必須", () => {
+  const ok = parseStrategyFromToolInput(
+    { notes: "init", params: {}, executor_ts: `return { type: "noop" };` },
+    1,
+  );
+  assert.equal(ok.ok, true);
+  const missing = parseStrategyFromToolInput({ notes: "init", params: {} }, 1);
+  assert.equal(missing.ok, false);
+});


### PR DESCRIPTION
## 概要

LLM トレード戦略の**自己改善2層アーキテクチャ(ADR 0002)**を実装し、GitHub `[strategy]` issue 5 件(#1/#3/#4/#6/#11)を実装する。あわせて長走行で発覚した Aave 由来のクラッシュ・観測不整合・自己改善の暴走を修正する。

`feat/p1-discrimination-harness` から派生。`main` とは分岐後にマージされた戦略 PR 群(#13-17: fair-mm/jit-lp/ladder-mm/stat-arb)と一部ファイルが重複するため、**マージ時にコンフリクト解消が必要**(本 PR の版は観測ネスト形に正規化済み)。

## 主な変更

### 基盤修正
- **fix(aave)**: anvil フォークの `block.timestamp < reserve.lastUpdateTimestamp` による利息計算アンダーフロー(panic 0x11)を warp で解消。`resetFork` を forking 付き再フォーク化し run/seed 間の状態残留を防止(2000R 完走を確認)。
- **fix(aave-arb)**: 観測パス誤り(`obs.pool`→`obs.protocols.uniswap.pool`)と mainnet アドレスを Arbitrum 値へ修正。
- **feat(roster)**: main の新戦略4種を観測正規化して並行ロスターに統合。

### ADR 0002 — 自己改善2層
- **docs/adr/0002**: live(in-sim revise)+ offline(`/strategy-evolve`)の2層設計を記録(Proposed)。
- **共有コア**: `prompts.ts`(反ハルシネ/Change Contract/PnL 帰属)、`strategy.ts`(params-only 強制)、`attribution.ts`(安価帰属)。3 strategist 経路すべてで params-only を強制。
- **base 戦略ライブラリ拡張**: 2→16(arb/lp/venue/aave/statarb/cvbal/dnlp/gmxperp/gmxrev/gmxtrend/fairmm/jitlp/ladder + 下記 #6/#4/#11)。`INCLUDE_LLM=1` で全戦略が自己改善エージェント化。
- **live sanity ゲート**: revise 候補が実行時エラーを増やすなら採用しない。
- **live PnL ロールバック**: 採用後に実現 PnL が急落したら前版へ自動巻き戻し(`ERIS_LLM_ROLLBACK`)。長走行で観測した暴走(下記)への対策。

### `[strategy]` issue 実装
| issue | 実装 | 自己改善 |
|---|---|---|
| #6 aave looping | `aave-loop.ts` + base `aaveloop` | ✅ |
| #4 cross-venue arb | `cross-venue-arb.ts` + base `crossvenue` | ✅ |
| #11 idle-yield+LP | `lp-yield.ts` + base `lpyield` | ✅ |
| #1 liquidation | victim flow + oracle shock + `liquidator.ts`(env gate) | ❌ RPC 依存 |
| #3 flash arb(+#2) | `FlashArb.sol` + `flash.ts` + `flash-arb.ts`(env gate) | ❌ 契約/RPC 依存 |

## 検証

- `npm run typecheck` OK / `npm test` **131 件 pass**。
- 各 `npm run leaderboard` 完走。#1: liquidator +1,473(victim HF 0.90→清算)。#3: flash-arb +5,757(自己資金版の約19倍)。
- **自己改善ラン**: 512R で全16戦略が黒字化(venue +5,839 首位)。2000R で revise 422/447 成功・v13〜v43 到達、環境は anvil メモリ横ばいで完走。
- **発見と対策**: 2000R で venue が「実行時エラー無しだが致命的」な revise で −185k に暴走 → sanity ゲートでは捕捉不可 → **PnL ロールバック**を追加(ユニット検証済み、512R で過剰発火 0 を確認)。

## マージ注意
- `main` と分岐しており、fair-mm/jit-lp/ladder-mm/stat-arb/genRoster/baseStrategies で重複・コンフリクトの可能性あり(本 PR 版は観測正規化済み)。
- `#1/#3` は **env gate**(`ERIS_LIQUIDATION_DEMO` / `ERIS_FLASH_ARB`)で既定 off。`out/` は gitignore のため flash デモ前に `npm run build:contracts` が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
