### PR TITLE
ci: add GitHub Actions (fast per-PR checks + full deploy/backtest chain)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# Gate for the checks that were previously only run by whoever remembered to.
+#
+# Deliberately excluded: the deployer's tests (they need multi-GB vendor clones), anything requiring
+# ARB_RPC_URL, and simulation runs (ADR 0005 makes those non-deterministic, so they cannot pass or
+# fail a PR meaningfully).
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # test/vulnPools.integration.test.ts checks ADR 0014's load-bearing mechanism against a real
+      # chain and skips itself when anvil is absent -- a skipped test looks green while guarding
+      # nothing, so foundry is installed rather than letting it opt out.
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      # The mock oracles and PriceFeed the integration test deploys.
+      - run: npm run build:contracts
+
+      - run: npm run typecheck
+
+      # example -> sdk <- core (ADR 0015). A violation here is invisible until a bundle breaks.
+      - run: npm run check:boundaries
+
+      # Entry gate for strategy code (cheatcode static check).
+      - run: npm run check:strategy
+
+      - run: npm test

--- a/.github/workflows/deploy-backtest.yml
+++ b/.github/workflows/deploy-backtest.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: npm ci
 
+      # The mock oracles and PriceFeed the run deploys at setup. The deployer's own `forge build`
+      # writes to deployer/out and does not cover these.
+      - run: npm run build:contracts
+
       - name: Set up the deployer
         working-directory: deployer
         run: |
@@ -112,5 +116,6 @@ jobs:
           path: |
             runs/
             deployer/deployments/deployments.json
+            backtest/state/manifest.json
             ${{ runner.temp }}/anvil.log
           retention-days: 7

--- a/.github/workflows/deploy-backtest.yml
+++ b/.github/workflows/deploy-backtest.yml
@@ -1,0 +1,116 @@
+# Full-chain check: deploy every venue to a bare anvil, dump the state, and prove a backtest runs
+# against that dump.
+#
+# This is the only thing that would have caught the GMX localhost market bug (#42's `1502616`), where
+# `npm run deploy` had been dying at GM seeding -- nothing in the fast CI touches the deployer, and
+# the state dump is gitignored, so no per-PR job can exercise this path.
+#
+# ~25-40 minutes, dominated by the gmx-synthetics clone + yarn install and the hardhat deploy, so it
+# only runs when something it actually covers changes.
+name: deploy + backtest
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deployer/**"
+      - "scripts/genStateDump.ts"
+      - "scripts/genLocalConstants.ts"
+      - "core/src/cli/backtest.ts"
+      - "core/src/backtest/**"
+      - "sdk/src/constants.ts"
+      - "sdk/src/constants.local.ts"
+      - "config/regimes/**"
+      - ".github/workflows/deploy-backtest.yml"
+
+concurrency:
+  group: deploy-backtest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-and-backtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - run: npm ci
+
+      - name: Set up the deployer
+        working-directory: deployer
+        run: |
+          npm install
+          forge build
+          cp .env.example .env
+          # anvil is started by this workflow, not by the deployer, so gen:state-dump can talk to the
+          # same chain after the deploy process has exited.
+          sed -i 's/^MANAGE_ANVIL=.*/MANAGE_ANVIL=false/' .env
+          ./scripts/setup-vendors.sh
+
+      - name: Start anvil
+        working-directory: deployer
+        run: |
+          npm run anvil > "$RUNNER_TEMP/anvil.log" 2>&1 &
+          for _ in $(seq 1 60); do
+            cast block-number --rpc-url http://127.0.0.1:8545 >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "anvil did not come up"; cat "$RUNNER_TEMP/anvil.log"; exit 1
+
+      - name: Deploy all venues
+        working-directory: deployer
+        run: npm run deploy -- --keep-fresh
+
+      - name: Generate constants and the state dump
+        run: |
+          npm run gen:local-constants
+          npm run gen:state-dump
+
+      - name: Backtest against the dump
+        run: npm run backtest -- --regime calm-01 --blocks 12
+
+      # The backtest exits 0 even when the scorer quietly read nothing, which is the failure mode
+      # this whole job exists to catch, so assert on the run's own output.
+      - name: Check the run is healthy
+        run: |
+          node -e '
+            const { readdirSync, readFileSync } = require("node:fs");
+            const runs = readdirSync("runs").filter((d) => /^\d{4}-/.test(d)).sort();
+            const id = runs.at(-1);
+            if (!id) throw new Error("no run directory was produced");
+            const s = JSON.parse(readFileSync(`runs/${id}/summary.json`, "utf8"));
+            const problems = [];
+            if (s.valueSeries?.failedReads !== 0)
+              problems.push(`failedReads=${s.valueSeries?.failedReads}`);
+            if ((s.violations ?? []).length) problems.push(`violations=${JSON.stringify(s.violations)}`);
+            if (!s.agents?.length) problems.push("no agents were scored");
+            for (const a of s.agents ?? []) {
+              if (!Number.isFinite(a.finalValueUsdc) || a.finalValueUsdc <= 0)
+                problems.push(`${a.id} finalValueUsdc=${a.finalValueUsdc}`);
+            }
+            const unpriced = s.valueSeries?.unpricedHoldings ?? [];
+            if (unpriced.length) console.log(`note: ${unpriced.length} unpriced holding(s):`, JSON.stringify(unpriced));
+            if (problems.length) throw new Error(`unhealthy run ${id}: ${problems.join(", ")}`);
+            console.log(`run ${id} ok: ${s.agents.length} agents, ${s.blocksProcessed} blocks, failedReads 0`);
+          '
+
+      - name: Upload the run and deploy logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-backtest-output
+          path: |
+            runs/
+            deployer/deployments/deployments.json
+            ${{ runner.temp }}/anvil.log
+          retention-days: 7


### PR DESCRIPTION
## Why

The repository has no automated checks. #42 merged ~2,400 lines into the scoring path — code that fails silently, losing value rather than throwing — and the only gate was whoever remembered to run the commands locally. #43, #44 and #45 all touch the same area next.

The checks already exist and take about 15 seconds. This is a workflow file, not new infrastructure.

It would have caught a concrete regression from #42's own development: adding two fields to `LpPositionObservation` broke `test/action.ts` at the type level. `npm run typecheck` catches that, but nothing on a contributor's PR would have.

## What runs

`npm ci` → `build:contracts` → `typecheck` → `check:boundaries` → `check:strategy` → `test`, on PRs to `main` and pushes to `main`.

foundry is installed rather than skipped: `test/vulnPools.integration.test.ts` checks ADR 0014's load-bearing mechanism (skim / honest / dry-run detection) against a real chain and **opts itself out when anvil is absent**. A skipped test reads as green while guarding nothing, so the toolchain is worth the ~30s.

`check:boundaries` and `check:strategy` are included because both are invisible failures otherwise — a boundary violation (ADR 0015's `example → sdk ← core`) does not surface until a submission bundle breaks, and the strategy static check is the entry gate for cheatcode use.

## What is deliberately excluded

- **The deployer's tests** — they need multi-GB vendor clones (`setup-vendors.sh`) and network access.
- **Anything needing `ARB_RPC_URL`** — no secret in CI, and fork reads are slow and rate-limited.
- **Simulation runs** — ADR 0005 makes tx timing and intra-block ordering non-deterministic, so a run cannot pass or fail a PR meaningfully. A nightly fork job is a plausible follow-up (it would catch breakage like #43, where fork runs including Balancer fail at startup), but it needs secret handling and a flake policy first.

## Verification

The exact step sequence run locally on `main`:

```
build:contracts    ok
typecheck          ok
check:boundaries   PASS (example → sdk ← core)
check:strategy     PASS (28 files)
test               215 pass, 0 fail, 0 skipped
```

This PR's own CI run is the check that the workflow itself is correct.

## Note

This does not block anything by itself. Making it a required status check is a branch-protection setting in the repository, which has to be done in the GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
