### PR TITLE
fix(balancer): seed the fork pool at the live price

### DIFF
--- a/scripts/genLocalConstants.ts
+++ b/scripts/genLocalConstants.ts
@@ -352,8 +352,6 @@ export type LocalDeployment = {
     tokens: Address[];
     usdcToken: Address;
     seedWethWei: bigint;
-    seedUsdcUnits: bigint;
-    seedUsdtUnits: bigint;
   };
   CURVE: { pool: Address; wethIndex: number; usdtIndex: number; usdcToken: Address };
   GMX: {
@@ -401,8 +399,6 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     tokens: [${d.bal.tokens.map((x) => a(x)).join(", ")}],
     usdcToken: ${a(d.usdc)},
     seedWethWei: 100_000_000_000_000_000_000n,
-    seedUsdcUnits: 50_000_000_000n,
-    seedUsdtUnits: 0n,
   },
   // Curve: twocrypto-ng's WETH/USDC crypto pool (uint256 index get_dy/exchange).
   // coin0=USDC(stable)=${d.curve.usdtIndex}, coin1=WETH=${d.curve.wethIndex}. usdcToken is the pool's stable=USDC.

--- a/sdk/src/abis.ts
+++ b/sdk/src/abis.ts
@@ -7,6 +7,9 @@ export const erc20Abi = parseAbi([
   "function allowance(address owner, address spender) view returns (uint256)",
   // LP-token share valuation (issue #41).
   "function totalSupply() view returns (uint256)",
+  // Balancer seeding (issue #43) sizes legs in USD, so it needs the scale of tokens the registry
+  // does not carry (the fork pool's USD₮0 leg).
+  "function decimals() view returns (uint8)",
 ]);
 
 export const wethAbi = parseAbi([
@@ -53,6 +56,12 @@ export const balancerVaultAbi = parseAbi([
   "function getPoolTokens(bytes32 poolId) view returns (address[] tokens, uint256[] balances, uint256 lastChangeBlock)",
   "function swap((bytes32 poolId, uint8 kind, address assetIn, address assetOut, uint256 amount, bytes userData) singleSwap, (address sender, bool fromInternalBalance, address recipient, bool toInternalBalance) funds, uint256 limit, uint256 deadline) payable returns (uint256 amountCalculated)",
   "function joinPool(bytes32 poolId, address sender, address recipient, (address[] assets, uint256[] maxAmountsIn, bytes userData, bool fromInternalBalance) request) payable",
+]);
+
+// Balancer v2 WeightedPool. The spot price of a weighted pool is set by the balance/weight ratios,
+// so seeding it at the live price needs the weights (issue #43).
+export const balancerWeightedPoolAbi = parseAbi([
+  "function getNormalizedWeights() view returns (uint256[])",
 ]);
 
 export const balancerQueriesAbi = parseAbi([

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -34,8 +34,6 @@ export type LocalDeployment = {
     tokens: Address[];
     usdcToken: Address;
     seedWethWei: bigint;
-    seedUsdcUnits: bigint;
-    seedUsdtUnits: bigint;
   };
   CURVE: { pool: Address; wethIndex: number; usdtIndex: number; usdcToken: Address };
   GMX: {
@@ -84,8 +82,6 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     tokens: ["0x5FbDB2315678afecb367f032d93F642f64180aa3" as Address, "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address],
     usdcToken: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address,
     seedWethWei: 100_000_000_000_000_000_000n,
-    seedUsdcUnits: 50_000_000_000n,
-    seedUsdtUnits: 0n,
   },
   // Curve: twocrypto-ng's WETH/USDC crypto pool (uint256 index get_dy/exchange).
   // coin0=USDC(stable)=0, coin1=WETH=1. usdcToken is the pool's stable=USDC.

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -113,10 +113,10 @@ export const BALANCER = L?.BALANCER ?? {
     "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", // USDT
   ] as Address[],
   usdcToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" as Address,
-  // Seed amounts (admin joins). Roughly balanced at 33/33/34 assuming ETH~$2100.
+  // Depth of the admin join, on the WETH leg only. The stable legs used to be constants too, which
+  // pinned the seeded pool at ETH~$2100 and made every fork run fail the startup no-arb check as
+  // spot drifted away from it (issue #43); they are now derived from the live price at setup.
   seedWethWei: 200_000_000_000_000_000_000n, // 200 WETH
-  seedUsdcUnits: 420_000_000_000n, // 420,000 USDC
-  seedUsdtUnits: 420_000_000_000n, // 420,000 USDT
 };
 
 // ---------------------------------------------------------------------------

--- a/sdk/src/protocols/balancer.ts
+++ b/sdk/src/protocols/balancer.ts
@@ -11,15 +11,17 @@ import {
 import {
   balancerQueriesAbi,
   balancerVaultAbi,
+  balancerWeightedPoolAbi,
   erc20Abi,
   wethAbi,
 } from "../abis.js";
 import { poolShareValueUsdc } from "../valuation.js";
-import { BALANCER, TOKENS, stableBalanceOf } from "../constants.js";
+import { BALANCER, stableBalanceOf } from "../constants.js";
 import {
   marketFor,
   marketsFor,
   tokenInfo,
+  tokenInfoByAddress,
   type MarketConfig,
 } from "../markets.js";
 import {
@@ -44,7 +46,7 @@ import type {
   UnpricedHoldingDetail,
   ValidationResult,
 } from "./types.js";
-import { approveTx } from "./uniswap.js";
+import { approveTx, getPoolPriceUsdcPerWeth } from "./uniswap.js";
 import { accountAddress } from "../chain.js";
 
 const DECIMAL_INTEGER = /^[0-9]+$/;
@@ -376,6 +378,134 @@ function encodeExactTokensInJoin(amountsIn: bigint[], minBpt: bigint): Hex {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Admin seed of the fork pool (issue #43)
+//
+// The Arbitrum pool is depleted at the fork block, so setupGlobal admin-joins it to make it
+// tradeable. A weighted pool's spot price is set by its balance/weight ratios, so joining at fixed
+// notionals pins the pool at whatever price those notionals imply: the old seed constants meant
+// ETH~$2,100, and once spot left that level every fork run died on the startup no-arb check. The
+// stable legs are therefore sized from the live price instead — each leg lands on its weight share
+// of one total USD value, which is the state at which the pool quotes exactly that price.
+// ---------------------------------------------------------------------------
+
+export type SeedLeg = {
+  token: Address;
+  decimals: number;
+  // USD per whole token ($1 for the pool's stable legs).
+  priceUsd: number;
+  // Normalized weight as the pool reports it (1e18 = 100%).
+  weight: bigint;
+  // What the pool already holds (raw units). The join adds on top of it.
+  balance: bigint;
+};
+
+// Amounts to join so the pool ends up quoting each leg at its priceUsd, holding anchorAmount of the
+// anchor leg (the base; its notional is the pool's depth knob).
+export function seedAmountsIn(
+  legs: SeedLeg[],
+  anchorIndex: number,
+  anchorAmount: bigint,
+): bigint[] {
+  const anchor = legs[anchorIndex];
+  if (!anchor) throw new Error("balancer seed: anchor leg out of range");
+  const weightTotal = legs.reduce((sum, l) => sum + Number(l.weight), 0);
+  if (!(weightTotal > 0))
+    throw new Error("balancer seed: pool reported no normalized weights");
+  for (const l of legs) {
+    if (!(l.priceUsd > 0))
+      throw new Error(`balancer seed: no USD price for leg ${l.token}`);
+  }
+  const share = (l: SeedLeg) => Number(l.weight) / weightTotal;
+  // Total pool value implied by holding anchorAmount of the anchor at its weight share.
+  const totalUsd =
+    ((Number(anchorAmount) / 10 ** anchor.decimals) * anchor.priceUsd) /
+    share(anchor);
+  const target = legs.map((l, i) =>
+    i === anchorIndex
+      ? anchorAmount
+      : BigInt(
+          Math.round(((share(l) * totalUsd) / l.priceUsd) * 10 ** l.decimals),
+        ),
+  );
+  // A join cannot drain a leg that already holds more than its target, and joining the other legs
+  // anyway would seed the pool off-price. Scale every target up instead: the ratios (and so the
+  // price) are preserved and the pool only comes out deeper than asked for.
+  let scale = 1;
+  legs.forEach((l, i) => {
+    if (target[i] > 0n && l.balance > target[i])
+      scale = Math.max(scale, Number(l.balance) / Number(target[i]));
+  });
+  return legs.map((l, i) => {
+    const t =
+      scale > 1 ? BigInt(Math.round(Number(target[i]) * scale)) : target[i];
+    return t > l.balance ? t - l.balance : 0n;
+  });
+}
+
+// Read the pool's registered tokens, weights and residual balances, and price each leg: the base at
+// the live market price (the same Uniswap pool the run takes its initial fair price from), the rest
+// at $1. The stable legs are the pool's dollar tokens (native USDC / USD₮0), and USD₮0 is not in the
+// token registry, so "not a registered base" is what identifies them.
+async function readSeedLegs(
+  ctx: SimContext,
+): Promise<{ assets: Address[]; legs: SeedLeg[]; anchorIndex: number }> {
+  const client = ctx.publicClient;
+  const [tokens, balances] = (await client.readContract({
+    address: BALANCER.vault,
+    abi: balancerVaultAbi,
+    functionName: "getPoolTokens",
+    args: [BALANCER.poolId],
+  })) as readonly [readonly Address[], readonly bigint[], bigint];
+  const [weights, decimals, basePriceUsd] = await Promise.all([
+    client.readContract({
+      address: bptAddressOf(BALANCER.poolId),
+      abi: balancerWeightedPoolAbi,
+      functionName: "getNormalizedWeights",
+    }) as Promise<readonly bigint[]>,
+    Promise.all(
+      tokens.map(
+        (token) =>
+          client.readContract({
+            address: token,
+            abi: erc20Abi,
+            functionName: "decimals",
+          }) as Promise<number>,
+      ),
+    ),
+    getPoolPriceUsdcPerWeth(client),
+  ]);
+  if (weights.length !== tokens.length)
+    throw new Error(
+      `balancer seed: pool reports ${weights.length} weights for ${tokens.length} tokens`,
+    );
+
+  const baseToken = tokenInfo(wethMarket().base).address.toLowerCase();
+  let anchorIndex = -1;
+  const legs = tokens.map((token, i) => {
+    const isAnchor = token.toLowerCase() === baseToken;
+    if (isAnchor) anchorIndex = i;
+    // Another base in the pool would need its own live price; seeding it at $1 would silently
+    // mis-seed the pool, so refuse instead.
+    if (!isAnchor && tokenInfoByAddress(token)?.kind === "base")
+      throw new Error(
+        `balancer seed: pool leg ${token} is a second base token; seeding needs its price`,
+      );
+    return {
+      token,
+      decimals: decimals[i],
+      priceUsd: isAnchor ? basePriceUsd : 1,
+      weight: weights[i],
+      balance: balances[i],
+    };
+  });
+  if (anchorIndex < 0)
+    throw new Error(
+      `balancer seed: pool ${BALANCER.pool} does not hold the market base ${baseToken}`,
+    );
+  return { assets: [...tokens], legs, anchorIndex };
+}
+
 export const balancerAdapter: ProtocolAdapter = {
   id: "balancer",
   stableToken: BALANCER.usdcToken,
@@ -521,7 +651,8 @@ export const balancerAdapter: ProtocolAdapter = {
     return txs;
   },
 
-  // The pool is empty at the fork point, so admin joins and seeds it.
+  // The pool is empty at the fork point, so admin joins and seeds it — at the live price, not at a
+  // constant (issue #43; see seedAmountsIn).
   // Only the WETH market is seeded here (seeding the WBTC pool is separate work on the deployer side).
   async setupGlobal(ctx: SimContext): Promise<void> {
     // On local deploy the bundled deployer/ has already seeded the WETH/USDC pool
@@ -530,36 +661,34 @@ export const balancerAdapter: ProtocolAdapter = {
       return;
     }
     const admin = accountAddress(ctx.adminPk);
-    // Prepare seed tokens for admin (wrap for WETH, deal for the stables)
-    await sendAndMine(
-      ctx.publicClient,
-      ctx.walletClient,
-      ctx.chain,
-      ctx.adminPk,
-      {
-        to: TOKENS.WETH.address,
-        data: encodeFunctionData({
-          abi: wethAbi,
-          functionName: "deposit",
-          args: [],
-        }),
-        value: BALANCER.seedWethWei,
-      },
-    );
-    await dealErc20(
-      ctx.publicClient,
-      BALANCER.tokens[1],
-      admin,
-      BALANCER.seedUsdcUnits,
-    );
-    await dealErc20(
-      ctx.publicClient,
-      BALANCER.tokens[2],
-      admin,
-      BALANCER.seedUsdtUnits,
-    );
+    const { assets, legs, anchorIndex } = await readSeedLegs(ctx);
+    const amountsIn = seedAmountsIn(legs, anchorIndex, BALANCER.seedWethWei);
 
-    for (const token of BALANCER.tokens) {
+    // Prepare seed tokens for admin (wrap for WETH, deal for the stables)
+    for (const [i, leg] of legs.entries()) {
+      if (amountsIn[i] <= 0n) continue;
+      if (i === anchorIndex) {
+        await sendAndMine(
+          ctx.publicClient,
+          ctx.walletClient,
+          ctx.chain,
+          ctx.adminPk,
+          {
+            to: leg.token,
+            data: encodeFunctionData({
+              abi: wethAbi,
+              functionName: "deposit",
+              args: [],
+            }),
+            value: amountsIn[i],
+          },
+        );
+      } else {
+        await dealErc20(ctx.publicClient, leg.token, admin, amountsIn[i]);
+      }
+    }
+
+    for (const token of assets) {
       const approve = approveTx(token, BALANCER.vault);
       await sendAndMine(
         ctx.publicClient,
@@ -570,11 +699,6 @@ export const balancerAdapter: ProtocolAdapter = {
       );
     }
 
-    const amountsIn = [
-      BALANCER.seedWethWei,
-      BALANCER.seedUsdcUnits,
-      BALANCER.seedUsdtUnits,
-    ];
     const userData = encodeExactTokensInJoin(amountsIn, 0n);
     const joinData = encodeFunctionData({
       abi: balancerVaultAbi,
@@ -584,7 +708,7 @@ export const balancerAdapter: ProtocolAdapter = {
         admin,
         admin,
         {
-          assets: BALANCER.tokens,
+          assets,
           maxAmountsIn: amountsIn,
           userData,
           fromInternalBalance: false,

--- a/test/balancerSeed.test.ts
+++ b/test/balancerSeed.test.ts
@@ -1,0 +1,126 @@
+// Balancer admin seed sizing (issue #43). The seed used to be fixed notionals that implied
+// ETH~$2,100, so every fork run whose spot had left that level died on the startup no-arb check.
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Address } from "viem";
+import { seedAmountsIn, type SeedLeg } from "@eris/sdk/protocols/balancer.js";
+
+const WETH = "0x0000000000000000000000000000000000000001" as Address;
+const USDC = "0x0000000000000000000000000000000000000002" as Address;
+const USDT = "0x0000000000000000000000000000000000000003" as Address;
+
+const ONE = 10n ** 18n;
+const THIRD = ONE / 3n;
+const SEED_WETH = 200n * ONE;
+
+function legsAt(
+  price: number,
+  weights: bigint[] = [THIRD, THIRD, ONE - 2n * THIRD],
+  balances: bigint[] = [0n, 0n, 0n],
+): SeedLeg[] {
+  return [
+    {
+      token: WETH,
+      decimals: 18,
+      priceUsd: price,
+      weight: weights[0],
+      balance: balances[0],
+    },
+    {
+      token: USDC,
+      decimals: 6,
+      priceUsd: 1,
+      weight: weights[1],
+      balance: balances[1],
+    },
+    {
+      token: USDT,
+      decimals: 6,
+      priceUsd: 1,
+      weight: weights[2],
+      balance: balances[2],
+    },
+  ];
+}
+
+// What the pool quotes for the base after the join: a weighted pool's spot price is the ratio of
+// the legs' balance/weight, in whole tokens.
+function impliedBasePrice(
+  legs: SeedLeg[],
+  amountsIn: bigint[],
+  baseIndex: number,
+  quoteIndex: number,
+): number {
+  const perWeight = (i: number) =>
+    Number(legs[i].balance + amountsIn[i]) /
+    10 ** legs[i].decimals /
+    Number(legs[i].weight);
+  return perWeight(quoteIndex) / perWeight(baseIndex);
+}
+
+test("seeds the stable legs at the live price", () => {
+  const legs = legsAt(4000);
+  const amounts = seedAmountsIn(legs, 0, SEED_WETH);
+  assert.equal(amounts[0], SEED_WETH);
+  // 200 WETH at $4,000 = $800,000 per equal-weight leg.
+  assert.equal(amounts[1], 800_000_000_000n);
+  assert.equal(amounts[2], 800_000_000_000n);
+  assert.ok(Math.abs(impliedBasePrice(legs, amounts, 0, 1) - 4000) < 1e-6);
+});
+
+test("tracks the price rather than drifting away from it", () => {
+  for (const price of [1200, 2100, 3456.78, 9000]) {
+    const legs = legsAt(price);
+    const amounts = seedAmountsIn(legs, 0, SEED_WETH);
+    assert.ok(
+      Math.abs(impliedBasePrice(legs, amounts, 0, 1) / price - 1) < 1e-9,
+      `implied price off at $${price}`,
+    );
+  }
+  // At the price the retired constants assumed, the derived seed reproduces them exactly.
+  assert.deepEqual(seedAmountsIn(legsAt(2100), 0, SEED_WETH).slice(1), [
+    420_000_000_000n,
+    420_000_000_000n,
+  ]);
+});
+
+test("sizes each leg by its own weight", () => {
+  // 20/40/40: the stable legs are twice the base leg's weight, so twice its USD value.
+  const legs = legsAt(3000, [ONE / 5n, (ONE * 2n) / 5n, (ONE * 2n) / 5n]);
+  const amounts = seedAmountsIn(legs, 0, SEED_WETH);
+  assert.equal(amounts[1], 1_200_000_000_000n);
+  assert.equal(amounts[2], 1_200_000_000_000n);
+  assert.ok(Math.abs(impliedBasePrice(legs, amounts, 0, 1) - 3000) < 1e-6);
+});
+
+test("subtracts what the depleted pool still holds", () => {
+  const residue = [ONE, 1_000_000_000n, 0n];
+  const legs = legsAt(4000, undefined, residue);
+  const amounts = seedAmountsIn(legs, 0, SEED_WETH);
+  assert.equal(amounts[0], SEED_WETH - ONE);
+  assert.equal(amounts[1], 800_000_000_000n - 1_000_000_000n);
+  assert.equal(amounts[2], 800_000_000_000n);
+  assert.ok(Math.abs(impliedBasePrice(legs, amounts, 0, 1) - 4000) < 1e-6);
+});
+
+test("scales up rather than seeding off-price when a leg is already over its target", () => {
+  // A join cannot remove tokens, so a leg holding 4x its target forces the whole seed 4x deeper.
+  const legs = legsAt(4000, undefined, [0n, 3_200_000_000_000n, 0n]);
+  const amounts = seedAmountsIn(legs, 0, SEED_WETH);
+  assert.equal(amounts[1], 0n);
+  assert.equal(amounts[0], 4n * SEED_WETH);
+  assert.equal(amounts[2], 3_200_000_000_000n);
+  assert.ok(Math.abs(impliedBasePrice(legs, amounts, 0, 1) - 4000) < 1e-6);
+});
+
+test("refuses to seed on inputs it cannot price", () => {
+  assert.throws(() => seedAmountsIn(legsAt(0), 0, SEED_WETH), /no USD price/);
+  assert.throws(
+    () => seedAmountsIn(legsAt(4000, [0n, 0n, 0n]), 0, SEED_WETH),
+    /no normalized weights/,
+  );
+  assert.throws(
+    () => seedAmountsIn(legsAt(4000), 3, SEED_WETH),
+    /anchor leg out of range/,
+  );
+});


### PR DESCRIPTION
Fixes #43.

## 問題

fork run で `run.protocols` に `balancer` を含めると、1 ブロック目の前に必ず落ちる:

```
Error: no-arbitrage check failed at startup: executable 1007.4bps arb on WETH
       (buy uniswap / sell balancer) exceeds 300bps
```

Arbitrum の Balancer プールは fork ブロック時点で枯渇しているため `setupGlobal` が admin join で seed し直すが、その量が定数（200 WETH / 420,000 USDC / 420,000 USDT）だった。weighted pool の spot は balance/weight 比で決まるので、この比率がプールを **ETH~$2,100 に固定**する。実勢がそこから離れるほど乖離し、時間とともに悪化する種類のバグ。

Uniswap / Curve は fork した実プールをそのまま使う＝定義上いつでも実勢価格なので、乖離するのは seed し直す Balancer だけ。

## 修正（issue の Option 1）

seed 量をライブ価格から導出する。

- `readSeedLegs()` — プールの登録トークン・`getNormalizedWeights()`・残余 balance・decimals をオンチェーンで読み、base leg は run が fair0 に使うのと同じ Uniswap プール価格、stable leg は $1 で値付け
- `seedAmountsIn()`（純粋関数） — 「各 leg が同一総 USD の weight シェアに乗る」状態を目標に join 量を算出。weighted pool ではこれがちょうど目標価格を quote する状態になる
  - 枯渇プールの残余は差し引く
  - ある leg が既に目標超（join では減らせない）なら、比率を保ったまま全体をスケールアップ = 価格は正しいまま深さだけ増える
  - weights を実測するので 33/33/34 の近似も不要になった
- join の `assets` は `getPoolTokens` の登録順をそのまま使い、定数の順序ドリフトを排除

`seedUsdcUnits` / `seedUsdtUnits` は撤去。`seedWethWei` はプールの深さノブとして残置。

ローカルデプロイは元々この経路を通らない（同梱 deployer が全 venue を単一の自己整合な価格で seed する）ため影響なし。生成物 `constants.local.ts` と `genLocalConstants.ts` からは未使用フィールドを落とした。

## 検証

同一の Arbitrum fork anvil（spot ~\$1,903）に対して `protocols: [uniswap, balancer, curve]` / `localDeploy: false` で実走:

| | 結果 |
|---|---|
| 修正前（stash して再現） | `executable 967.6bps arb on WETH (buy uniswap / sell balancer)` で起動失敗 = issue の症状を再現 |
| 修正後 | run 完走。`no_arb_startup` の findings は `uniswap→curve の -2.3bps`（負＝健全）のみ、`warned: []` |

`test/balancerSeed.test.ts`（6 件）を追加: 価格追従（\$1,200〜\$9,000 で implied price 誤差 <1e-9）／weight 別サイジング／残余の差し引き／超過 leg でのスケールアップ／異常入力の fail-fast。\$2,100 では退役した定数（420,000 USDC・USDT）を厳密に再現することも回帰アンカーとして固定。

`npm run typecheck` / `npm test`（221 pass）/ `npm run check:boundaries` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)