### PR TITLE
fix(scoring): report reads that failed instead of decoding them to zero

### DIFF
--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -1175,19 +1175,34 @@ export async function runRealtimeSimulation(
     // agent -> α (β-removed PnL versus fair at execution; ADR 0015 Notes / equivalent to the amm-challenge edge).
     let alphaByAgent: Record<string, number> = {};
     if (finalBlock >= runStartBlock) {
-      const meta = await reconstructValueSeries({
-        publicClient,
-        logger,
-        agents: agentRuntimes.map((a) => ({ id: a.id, address: a.address })),
-        enabledIds,
-        activeStables: activeStables(),
-        priceFeed: priceFeedAddress,
-        fromBlock: runStartBlock,
-        toBlock: finalBlock,
-      });
-      valueSeries = meta;
-      alphaByAgent = meta.alphaByAgent;
-      logger.event({ type: "value_series_reconstructed", ...meta });
+      try {
+        const meta = await reconstructValueSeries({
+          publicClient,
+          logger,
+          agents: agentRuntimes.map((a) => ({ id: a.id, address: a.address })),
+          enabledIds,
+          activeStables: activeStables(),
+          priceFeed: priceFeedAddress,
+          fromBlock: runStartBlock,
+          toBlock: finalBlock,
+        });
+        valueSeries = meta;
+        alphaByAgent = meta.alphaByAgent;
+        logger.event({ type: "value_series_reconstructed", ...meta });
+      } catch (err) {
+        // The reconstruction refuses a cross-section it cannot read rather than emitting a cliff in
+        // the value series (issue #44). Losing the series is bad; publishing a wrong one is worse —
+        // so keep the run's other artifacts and make the gap explicit instead of letting
+        // summary.json read as if the series were complete.
+        const error = err instanceof Error ? err.message : String(err);
+        valueSeries = {
+          source: "post-run-reconstruction",
+          failed: true,
+          error,
+        };
+        logger.event({ type: "value_series_reconstruction_failed", error });
+        console.error(`[reconstruct] value series unavailable: ${error}`);
+      }
     }
 
     // ---- post-run rule check (ADR 0006 §5): exceeding the fee cap is grounds for invalidating a run ----

--- a/core/src/realtime/reconstruct.ts
+++ b/core/src/realtime/reconstruct.ts
@@ -25,6 +25,7 @@ import { getAdapter, hasAdapter } from "@eris/sdk/protocols/registry.js";
 import type {
   AgentProtocolValue,
   ProtocolAdapter,
+  UnpricedHoldingDetail,
   ValuationContext,
   ValuationRun,
 } from "@eris/sdk/protocols/types.js";
@@ -47,14 +48,37 @@ export type ReconstructionMeta = {
   toBlock: number;
   blocks: number;
   failedReads: number;
+  // Which contract/function the failed reads were, so a value that dropped can be traced back to the
+  // read that hid it. The bare counter above said something went wrong but never what (issue #44).
+  failedReadTargets: FailedReadTarget[];
   elapsedMs: number;
   // The fixed reference fair used for α evaluation (USDC/WETH; the fair at run end).
   alphaRefFairUsdcPerWeth: number;
   // agent -> α (= value at the fixed reference fair, toBlock − fromBlock; β-removed trade-derived PnL).
   alphaByAgent: Record<string, number>;
-  // Holdings excluded from the value series because they could not be priced (issue #41).
+  // Holdings excluded from the value series because they could not be priced (issue #41) or could not
+  // be read (issue #44).
   unpricedHoldings: UnpricedHolding[];
 };
+
+// A contract/function whose reads failed during the reconstruction, and how often.
+export type FailedReadTarget = {
+  address: Address;
+  functionName: string;
+  count: number;
+};
+
+function mergeFailedReads(
+  into: Map<string, FailedReadTarget>,
+  from: Iterable<FailedReadTarget>,
+): void {
+  for (const t of from) {
+    const key = `${t.address.toLowerCase()}|${t.functionName}`;
+    const existing = into.get(key);
+    if (existing) existing.count += t.count;
+    else into.set(key, { ...t });
+  }
+}
 
 type MulticallContract = {
   address: Address;
@@ -102,17 +126,10 @@ export type AgentValueSnapshot = {
   alphaValueUsdc: number;
 };
 
-// A holding excluded from an agent's value (issue #41), either because the scorer cannot price it or
-// because nothing sums it. Either way a zero in summary.json is indistinguishable from a trading
-// loss, so the exclusion is reported instead of being applied silently.
-export type UnpricedHolding = {
-  agentId: string;
-  // Where the holding came from, e.g. "uniswap-lp:<tokenId>" / "balancer-bpt" / "erc20-unaccounted".
-  source: string;
-  token: Address;
-  // Raw token amount, or "" when even the amount could not be derived.
-  amountRaw: string;
-};
+// A holding excluded from an agent's value: the scorer cannot price it, nothing sums it (issue #41),
+// or the read that would have revealed it failed (issue #44). Either way a zero in summary.json is
+// indistinguishable from a trading loss, so the exclusion is reported instead of being applied silently.
+export type UnpricedHolding = UnpricedHoldingDetail & { agentId: string };
 
 export type ValueSnapshot = {
   blockNumber: number;
@@ -120,6 +137,7 @@ export type ValueSnapshot = {
   // Pool price (from slot0) only when Uniswap is enabled. null if disabled.
   poolPriceUsdcPerWeth: number | null;
   failedReads: number;
+  failedReadTargets: FailedReadTarget[];
   values: AgentValueSnapshot[];
   unpriced: UnpricedHolding[];
 };
@@ -193,6 +211,7 @@ export async function readValueSnapshotAtBlock(opts: {
 }): Promise<ValueSnapshot> {
   const { publicClient, agents, enabledIds, activeStables, priceFeed } = opts;
   let failedReads = 0;
+  const failedReadTargets = new Map<string, FailedReadTarget>();
 
   const call: MulticallFn = async (contracts, blockNumber) => {
     if (contracts.length === 0) return [];
@@ -202,9 +221,18 @@ export async function readValueSnapshotAtBlock(opts: {
       multicallAddress: MULTICALL3,
       allowFailure: true,
     })) as Array<{ status: "success" | "failure"; result?: unknown }>;
-    return results.map((r) => {
+    return results.map((r, i) => {
       if (r.status === "failure") {
         failedReads++;
+        // Name the read, not just the fact that one failed: the whole point of #44 is being able to
+        // say which holding went missing.
+        mergeFailedReads(failedReadTargets, [
+          {
+            address: contracts[i].address,
+            functionName: contracts[i].functionName,
+            count: 1,
+          },
+        ]);
         return undefined;
       }
       return r.result;
@@ -235,34 +263,36 @@ export async function readValueSnapshotAtBlock(opts: {
   if (wethPool)
     head.push({ address: wethPool, abi: poolAbi, functionName: "slot0" });
 
+  // Per-agent spot reads, described once so that both the request and the decode below work off the
+  // same list. A failed read can then name the holding it hid instead of decoding to zero (issue #44).
+  const spotLayout: SpotRead[] = [
+    { kind: "eth" },
+    { kind: "base", symbol: "WETH", token: TOKENS.WETH.address },
+    ...extraBases.map((symbol) => ({
+      kind: "base" as const,
+      symbol,
+      token: tokenInfo(symbol).address,
+    })),
+    ...activeStables.map((token) => ({ kind: "stable" as const, token })),
+  ];
   const spotBase = head.length;
-  const spotPerAgent = 2 + extraBases.length + activeStables.length;
   for (const agent of agents) {
     head.push(
-      {
-        address: MULTICALL3,
-        abi: multicall3Abi,
-        functionName: "getEthBalance",
-        args: [agent.address],
-      },
-      {
-        address: TOKENS.WETH.address,
-        abi: erc20Abi,
-        functionName: "balanceOf",
-        args: [agent.address],
-      },
-      ...extraBases.map((b) => ({
-        address: tokenInfo(b).address,
-        abi: erc20Abi,
-        functionName: "balanceOf",
-        args: [agent.address],
-      })),
-      ...activeStables.map((token) => ({
-        address: token,
-        abi: erc20Abi,
-        functionName: "balanceOf",
-        args: [agent.address],
-      })),
+      ...spotLayout.map((read) =>
+        read.kind === "eth"
+          ? {
+              address: MULTICALL3,
+              abi: multicall3Abi,
+              functionName: "getEthBalance",
+              args: [agent.address],
+            }
+          : {
+              address: read.token,
+              abi: erc20Abi,
+              functionName: "balanceOf",
+              args: [agent.address],
+            },
+      ),
     );
   }
 
@@ -288,8 +318,19 @@ export async function readValueSnapshotAtBlock(opts: {
     blockNumber,
     onStageZero: (results) => {
       headResults = results;
-      const fairPrice = fromPriceFeedAnswer((results[0] as bigint) ?? 0n);
+      // A zero WETH fair prices every base-denominated holding — spot, LP and perp alike — at
+      // nothing, so the whole cross-section reads as a cliff in the value series. There is no
+      // reading of the chain under which that is the right answer, so refuse the block rather than
+      // score it (issue #44).
+      const answer = results[0];
+      if (typeof answer !== "bigint")
+        throw new Error(fairPriceFailure(opts.blockNumber, "read failed"));
+      const fairPrice = fromPriceFeedAnswer(answer);
+      if (!(fairPrice > 0))
+        throw new Error(fairPriceFailure(opts.blockNumber, "returned 0"));
       fairByBase = { WETH: fairPrice };
+      // Extra bases are different: answerOf returns 0 for a base the run never priced, which is a
+      // real "no entry" rather than a broken read. Holdings of it are reported as unpriced below.
       extraBases.forEach((b, i) => {
         fairByBase[b] = fromPriceFeedAnswer((results[1 + i] as bigint) ?? 0n);
       });
@@ -309,14 +350,47 @@ export async function readValueSnapshotAtBlock(opts: {
   const values: AgentValueSnapshot[] = [];
   const unpriced: UnpricedHolding[] = [];
   agents.forEach((agent, i) => {
-    let idx = spotBase + i * spotPerAgent;
-    const ethWei = (headResults[idx++] as bigint) ?? 0n;
-    const wethWei = (headResults[idx++] as bigint) ?? 0n;
-    const bases: Record<string, bigint> = { WETH: wethWei };
-    for (const b of extraBases) bases[b] = (headResults[idx++] as bigint) ?? 0n;
+    const spotStart = spotBase + i * spotLayout.length;
+    let ethWei = 0n;
     let usdcUnits = 0n;
-    for (let s = 0; s < activeStables.length; s++) {
-      usdcUnits += (headResults[idx++] as bigint) ?? 0n;
+    const bases: Record<string, bigint> = {};
+    spotLayout.forEach((read, k) => {
+      const raw = headResults[spotStart + k];
+      if (typeof raw !== "bigint") {
+        // The balance is unknown, not zero. Keep the zero (there is nothing better to sum) but say
+        // so, otherwise the agent's inventory silently evaporates for this block (issue #44).
+        unpriced.push({
+          agentId: agent.id,
+          source: spotSource(read),
+          ...(read.kind === "eth" ? {} : { token: read.token }),
+          amountRaw: "",
+          reason: "read-failed",
+          read:
+            read.kind === "eth"
+              ? "Multicall3.getEthBalance"
+              : "ERC20.balanceOf",
+        });
+        if (read.kind === "base") bases[read.symbol] = 0n;
+        return;
+      }
+      if (read.kind === "eth") ethWei = raw;
+      else if (read.kind === "base") bases[read.symbol] = raw;
+      else usdcUnits += raw;
+    });
+    const wethWei = bases.WETH ?? 0n;
+    // A base the run never wrote a price for values at zero the same way an unreadable balance does,
+    // so a holding of one is reported rather than quietly counted as nothing (WETH cannot land here:
+    // a missing WETH fair already failed the block above).
+    for (const [symbol, wei] of Object.entries(bases)) {
+      if (wei > 0n && !(fairByBase[symbol] > 0)) {
+        unpriced.push({
+          agentId: agent.id,
+          source: `spot-${symbol}`,
+          token: tokenInfo(symbol).address,
+          amountRaw: wei.toString(),
+          reason: "unpriced",
+        });
+      }
     }
     const balance = { ethWei, wethWei, usdcUnits, bases };
     // Evaluate free inventory two ways: at live fair (β-inclusive) and at the fixed reference fair (β-removed).
@@ -330,10 +404,9 @@ export async function readValueSnapshotAtBlock(opts: {
       alphaTotal += value.valueUsdc;
       for (const holding of value.unpriced) {
         unpriced.push({
+          ...holding,
           agentId: agent.id,
           source: holding.source || id,
-          token: holding.token,
-          amountRaw: holding.amountRaw,
         });
       }
     }
@@ -345,9 +418,31 @@ export async function readValueSnapshotAtBlock(opts: {
     fairPriceUsdcPerWeth: fairPrice,
     poolPriceUsdcPerWeth,
     failedReads,
+    failedReadTargets: [...failedReadTargets.values()],
     values,
     unpriced,
   };
+}
+
+// Per-agent spot read, described so the decode can name what a failed read hid.
+type SpotRead =
+  | { kind: "eth" }
+  | { kind: "base"; symbol: string; token: Address }
+  | { kind: "stable"; token: Address };
+
+function spotSource(read: SpotRead): string {
+  if (read.kind === "eth") return "spot-eth";
+  if (read.kind === "base") return `spot-${read.symbol}`;
+  return "spot-stable";
+}
+
+function fairPriceFailure(blockNumber: number, what: string): string {
+  return (
+    `[reconstruct] fair price unusable at block ${blockNumber} (PriceFeed.latestAnswer ${what}); ` +
+    "refusing to score a cross-section where every base-denominated holding would read as zero. " +
+    `anvil retains only ~${HISTORY_DEPTH_LIMIT} blocks of history, so this usually means the run ` +
+    "window outran it (ADR 0006 §4)"
+  );
 }
 
 const transferEvent = parseAbiItem(
@@ -460,6 +555,7 @@ export async function reconstructValueSeries(opts: {
   } = opts;
   const started = Date.now();
   let failedReads = 0;
+  const failedReadTargets = new Map<string, FailedReadTarget>();
 
   if (toBlock - fromBlock > HISTORY_DEPTH_LIMIT) {
     console.warn(
@@ -479,6 +575,7 @@ export async function reconstructValueSeries(opts: {
     blockNumber: toBlock,
   });
   failedReads += refSnapshot.failedReads;
+  mergeFailedReads(failedReadTargets, refSnapshot.failedReadTargets);
   const refFairByBase: Record<string, number> = { WETH: 0 };
   for (const b of baseTokens().map((t) => t.symbol)) {
     refFairByBase[b] = await readFairForRef(
@@ -491,10 +588,14 @@ export async function reconstructValueSeries(opts: {
 
   const alphaFirst = new Map<string, number>();
   const alphaLast = new Map<string, number>();
-  // Issue #41: holdings the scorer could not price. Deduplicated across the run window (they persist
-  // block to block) and emitted once at the end, so a zero in summary.json is never mistaken for a
-  // trading loss. Keyed by agent + source + token; amountRaw is the last one seen.
+  // Holdings the scorer could not price (issue #41) or could not read (issue #44). Deduplicated
+  // across the run window (they persist block to block) and emitted once at the end, so a zero in
+  // summary.json is never mistaken for a trading loss. amountRaw is the last one seen.
   const unpriced = new Map<string, UnpricedHolding>();
+  // The reason is part of the key: the same holding can be unreadable at one block and unpriceable
+  // at another, and collapsing those into one entry would hide half the story.
+  const unpricedKey = (h: UnpricedHolding) =>
+    `${h.agentId}|${h.source}|${h.token?.toLowerCase() ?? ""}|${h.reason ?? "unpriced"}`;
   for (let b = fromBlock; b <= toBlock; b++) {
     const snapshot = await readValueSnapshotAtBlock({
       publicClient,
@@ -506,9 +607,8 @@ export async function reconstructValueSeries(opts: {
       refFairByBase,
     });
     failedReads += snapshot.failedReads;
-    for (const h of snapshot.unpriced) {
-      unpriced.set(`${h.agentId}|${h.source}|${h.token.toLowerCase()}`, h);
-    }
+    mergeFailedReads(failedReadTargets, snapshot.failedReadTargets);
+    for (const h of snapshot.unpriced) unpriced.set(unpricedKey(h), h);
     for (const { id, valueUsdc: total, alphaValueUsdc } of snapshot.values) {
       if (!alphaFirst.has(id)) alphaFirst.set(id, alphaValueUsdc);
       alphaLast.set(id, alphaValueUsdc);
@@ -547,21 +647,28 @@ export async function reconstructValueSeries(opts: {
     fromBlock,
     toBlock,
   })) {
-    unpriced.set(
-      `${holding.agentId}|${holding.source}|${holding.token.toLowerCase()}`,
-      holding,
-    );
+    unpriced.set(unpricedKey(holding), holding);
   }
 
-  const unpricedHoldings = [...unpriced.values()];
+  // Default the reason once, here, so every site upstream can leave it off when it only ever reports
+  // unpriceable holdings while the emitted event still always says which kind it is.
+  const unpricedHoldings = [...unpriced.values()].map((h) => ({
+    ...h,
+    reason: h.reason ?? ("unpriced" as const),
+  }));
   if (unpricedHoldings.length > 0) {
     logger.event({
       type: "scoring_unpriced_holdings",
       holdings: unpricedHoldings,
+      failedReadTargets: [...failedReadTargets.values()],
     });
+    const unreadable = unpricedHoldings.filter(
+      (h) => h.reason === "read-failed",
+    ).length;
     console.warn(
-      `[reconstruct] ${unpricedHoldings.length} holding(s) could not be priced and are excluded ` +
-        "from agent value (see scoring_unpriced_holdings in events.jsonl); a zero here is not a trading loss",
+      `[reconstruct] ${unpricedHoldings.length} holding(s) excluded from agent value ` +
+        `(${unpricedHoldings.length - unreadable} unpriceable, ${unreadable} unreadable; ` +
+        "see scoring_unpriced_holdings in events.jsonl); a zero here is not a trading loss",
     );
   }
 
@@ -572,6 +679,7 @@ export async function reconstructValueSeries(opts: {
     toBlock,
     blocks: toBlock - fromBlock + 1,
     failedReads,
+    failedReadTargets: [...failedReadTargets.values()],
     elapsedMs: Date.now() - started,
     alphaRefFairUsdcPerWeth: refFairByBase.WETH,
     alphaByAgent,
@@ -588,7 +696,7 @@ async function readFairForRef(
 ): Promise<number> {
   try {
     if (base === "WETH") {
-      return fromPriceFeedAnswer(
+      const weth = fromPriceFeedAnswer(
         (await publicClient.readContract({
           address: priceFeed,
           abi: priceFeedAbi,
@@ -596,6 +704,10 @@ async function readFairForRef(
           blockNumber: BigInt(blockNumber),
         })) as bigint,
       );
+      // This one number is the reference every α in the run is measured against, so swallowing a
+      // failure here would zero the entire α series at once rather than one block of it (issue #44).
+      if (!(weth > 0)) throw new Error("latestAnswer returned 0");
+      return weth;
     }
     return fromPriceFeedAnswer(
       (await publicClient.readContract({
@@ -606,7 +718,12 @@ async function readFairForRef(
         blockNumber: BigInt(blockNumber),
       })) as bigint,
     );
-  } catch {
+  } catch (err) {
+    if (base === "WETH")
+      throw new Error(
+        `[reconstruct] reference fair price unusable at block ${blockNumber}: ${err instanceof Error ? err.message : err}`,
+      );
+    // A base the run never priced is a real "no entry", and holdings of it are reported per block.
     return 0;
   }
 }

--- a/sdk/src/protocols/aave.ts
+++ b/sdk/src/protocols/aave.ts
@@ -499,11 +499,22 @@ export const aaveAdapter: ProtocolAdapter = {
       const account = results[i] as readonly bigint[] | undefined;
       // USD with 8 decimals. Collateral sits outside the wallet and borrows are already counted
       // inside it, so the net cancels the double count.
+      // A failed read is the whole position going missing, and a zero there is indistinguishable
+      // from having been liquidated — report it instead (issue #44).
       const usd = account ? Number(account[0] - account[1]) / 1e8 : 0;
       out[agent.id] = {
         valueUsdc: usd,
         liquidatableValueUsdc: usd,
-        unpriced: [],
+        unpriced: account
+          ? []
+          : [
+              {
+                source: "aave-account",
+                amountRaw: "",
+                reason: "read-failed",
+                read: "AavePool.getUserAccountData",
+              },
+            ],
       };
     });
     return out;

--- a/sdk/src/protocols/gmx.ts
+++ b/sdk/src/protocols/gmx.ts
@@ -1086,12 +1086,17 @@ export const gmxAdapter: ProtocolAdapter = {
     const balanceBase = marketBase + markets.length;
     const fairByBase = ctx.fairByBase();
 
-    const gmBalance = (agentIndex: number, marketIndex: number): bigint => {
-      const raw = stage1[balanceBase + agentIndex * markets.length + marketIndex];
-      return typeof raw === "bigint" ? raw : 0n;
+    // undefined = the balance read failed, which is not the same as holding none (issue #44).
+    const gmBalance = (
+      agentIndex: number,
+      marketIndex: number,
+    ): bigint | undefined => {
+      const raw =
+        stage1[balanceBase + agentIndex * markets.length + marketIndex];
+      return typeof raw === "bigint" ? raw : undefined;
     };
     const anyHolder = ctx.agents.some((_, a) =>
-      markets.some((_m, i) => gmBalance(a, i) > 0n),
+      markets.some((_m, i) => (gmBalance(a, i) ?? 0n) > 0n),
     );
 
     // USD per whole GM token, by market index. Absent means the market could not be priced.
@@ -1147,8 +1152,27 @@ export const gmxAdapter: ProtocolAdapter = {
       const perp = perpValueUsd(positions, fairByBase, wethPrice);
       let valueUsdc = perp.valueUsdc;
       const unpriced: UnpricedHoldingDetail[] = [...perp.unpriced];
+      // An account with no perps decodes to an empty array, so undefined means the read failed.
+      // Both value at zero, which is why the two have to be told apart (issue #44).
+      if (!positions)
+        unpriced.push({
+          source: "gmx-position",
+          amountRaw: "",
+          reason: "read-failed",
+          read: "GmxReader.getAccountPositions",
+        });
       markets.forEach((marketToken, i) => {
         const balance = gmBalance(a, i);
+        if (balance === undefined) {
+          unpriced.push({
+            token: marketToken,
+            amountRaw: "",
+            source: "gmx-gm",
+            reason: "read-failed",
+            read: "ERC20.balanceOf",
+          });
+          return;
+        }
         if (balance <= 0n) return;
         const usdPerToken = gmUsd[i];
         if (usdPerToken === undefined) {

--- a/sdk/src/protocols/types.ts
+++ b/sdk/src/protocols/types.ts
@@ -2,6 +2,7 @@ import type { Address, Hex, PublicClient, WalletClient } from "viem";
 import type { makeChain } from "../chain.js";
 import type { SimConfig } from "../config.js";
 import type { Rng } from "../rng.js";
+import type { UnpricedAmount } from "../valuation.js";
 import type {
   AgentObservation,
   BalanceSnapshot,
@@ -107,11 +108,9 @@ export type ValuationContext = {
   fairByBase(): Record<string, number>;
 };
 
-// A holding the adapter could not fold into its value. Reported rather than silently zeroed.
-export type UnpricedHoldingDetail = {
-  token: Address;
-  // Raw token amount, or "" when even the amount could not be derived.
-  amountRaw: string;
+// A holding the adapter could not fold into its value, either because it cannot be priced (#41) or
+// because the read that would have revealed it failed (#44). Reported rather than silently zeroed.
+export type UnpricedHoldingDetail = UnpricedAmount & {
   // Where it came from, e.g. "uniswap-lp:<tokenId>" / "balancer-bpt".
   source: string;
 };

--- a/sdk/src/protocols/uniswap.ts
+++ b/sdk/src/protocols/uniswap.ts
@@ -567,6 +567,21 @@ export function feeGrowthInsideX128(args: {
   return wrapSub(wrapSub(args.feeGrowthGlobalX128, below), above);
 }
 
+// Whether both of a position's boundaries have a fee-growth snapshot, i.e. whether uncollectedFees
+// can answer at all. Callers use it to report a suppressed fee term instead of silently marking the
+// position as having earned nothing (issue #44).
+export function feeGrowthKnown(
+  pool: PoolFeeGrowth | undefined,
+  tickLower: number,
+  tickUpper: number,
+): boolean {
+  return (
+    pool !== undefined &&
+    pool.outsideByTick[tickLower] !== undefined &&
+    pool.outsideByTick[tickUpper] !== undefined
+  );
+}
+
 // Fees earned since the position's last checkpoint — what collect() would credit before transferring.
 // Returns zero when liquidity is zero (nothing accrues) or when a boundary's fee growth is unknown.
 export function uncollectedFees(args: {
@@ -864,6 +879,8 @@ export function lpPositionValuation(
     tickLower,
     tickUpper,
   });
+  const poolFeeGrowth =
+    key === undefined ? undefined : ctx.feeGrowthByPool?.[key];
   const fees = uncollectedFees({
     liquidity,
     tick,
@@ -871,7 +888,7 @@ export function lpPositionValuation(
     tickUpper,
     feeGrowthInside0LastX128,
     feeGrowthInside1LastX128,
-    pool: key === undefined ? undefined : ctx.feeGrowthByPool?.[key],
+    pool: poolFeeGrowth,
   });
   const totals = [
     [token0, amounts.amount0 + tokensOwed0 + fees.fees0],
@@ -880,6 +897,21 @@ export function lpPositionValuation(
 
   let valueUsdc = 0;
   const unpriced: LpPositionValuation["unpriced"] = [];
+  // Suppressing the fee term when a boundary read failed is deliberate (guessing would mis-mark the
+  // position), but it still removes value from the mark, so it says so rather than only returning
+  // zero fees. The principal above is unaffected and stays valued (issue #44). Only a caller that
+  // asked for fees at all (it passed a feeGrowthByPool) can have a read go missing.
+  if (
+    liquidity > 0n &&
+    ctx.feeGrowthByPool !== undefined &&
+    !feeGrowthKnown(poolFeeGrowth, tickLower, tickUpper)
+  ) {
+    unpriced.push({
+      amountRaw: "",
+      reason: "read-failed",
+      read: "UniswapV3Pool.ticks (uncollected fees only; principal still valued)",
+    });
+  }
   for (const [token, amount] of totals) {
     const usd = tokenAmountUsd(token, amount, ctx.fairByBase);
     if (usd === undefined) {
@@ -1250,12 +1282,30 @@ export const uniswapAdapter: ProtocolAdapter = {
     });
     const owners: Array<{ agentId: string; owner: Address; index: bigint }> =
       [];
+    // An unreadable NFT count makes every position the agent holds disappear at once, which reads
+    // exactly like having closed them all — report it rather than treating it as "holds none" (#44).
+    const countFailed: string[] = [];
     ctx.agents.forEach((agent, i) => {
-      const count = (stage1[markets.length + i] as bigint) ?? 0n;
-      for (let k = 0n; k < count; k++)
+      const raw = stage1[markets.length + i];
+      if (typeof raw !== "bigint") {
+        countFailed.push(agent.id);
+        return;
+      }
+      for (let k = 0n; k < raw; k++)
         owners.push({ agentId: agent.id, owner: agent.address, index: k });
     });
-    if (owners.length === 0) return zero();
+    const unreadableCount = (out: Record<string, AgentProtocolValue>) => {
+      for (const agentId of countFailed) {
+        out[agentId].unpriced.push({
+          source: "uniswap-lp",
+          amountRaw: "",
+          reason: "read-failed",
+          read: "NonfungiblePositionManager.balanceOf",
+        });
+      }
+      return out;
+    };
+    if (owners.length === 0) return unreadableCount(zero());
 
     const tokenIds = yield owners.map(({ owner, index }) => ({
       address: UNISWAP.nonfungiblePositionManager,
@@ -1371,10 +1421,23 @@ export const uniswapAdapter: ProtocolAdapter = {
     }
 
     const fairByBase = ctx.fairByBase();
-    const out = zero();
-    owners.forEach(({ agentId }, j) => {
+    const out = unreadableCount(zero());
+    owners.forEach(({ agentId, index }, j) => {
       const raw = positions[j];
-      if (!raw || tokenIds[j] === undefined) return;
+      if (!raw || tokenIds[j] === undefined) {
+        // The position is known to exist (it was counted) but could not be read, so its value is
+        // unknown rather than zero (issue #44).
+        out[agentId].unpriced.push({
+          source: `uniswap-lp#${index}`,
+          amountRaw: "",
+          reason: "read-failed",
+          read:
+            tokenIds[j] === undefined
+              ? "NonfungiblePositionManager.tokenOfOwnerByIndex"
+              : "NonfungiblePositionManager.positions",
+        });
+        return;
+      }
       const valuation = lpPositionValuation(raw as PositionTuple, {
         tickByPool,
         fairByBase,

--- a/sdk/src/valuation.ts
+++ b/sdk/src/valuation.ts
@@ -23,9 +23,25 @@ function stableVariantDecimals(token: Address): number | undefined {
   return undefined;
 }
 
-// A holding that could not be priced. amountRaw is the raw token amount excluded from the value
-// ("" when even the amount is unknown).
-export type UnpricedAmount = { token: Address; amountRaw: string };
+// Why a holding is missing from a value. "unpriced" means the amount is known but has no USD price;
+// "read-failed" means the read that would have revealed the holding failed, so the holding is
+// *unknown* rather than zero (issue #44). Both are excluded from the value and both are reported —
+// a zero in summary.json must never be mistaken for a trading loss.
+export type ScoringExclusionReason = "unpriced" | "read-failed";
+
+// A holding left out of a value, and why.
+export type UnpricedAmount = {
+  // The token, when the exclusion is token-shaped. Absent when a whole position could not be read
+  // (an Aave account, say, is not one token).
+  token?: Address;
+  // The raw token amount excluded from the value ("" when even the amount is unknown).
+  amountRaw: string;
+  // Defaults to "unpriced" when unset, which is what every issue #41 site reports.
+  reason?: ScoringExclusionReason;
+  // For "read-failed": what could not be read, e.g. "AavePool.getUserAccountData". Prose rather than
+  // a taxonomy — it is read by a human diagnosing a value series, not by code.
+  read?: string;
+};
 
 // USD value of a raw token amount. Stables are $1; bases use the run's fair price. Undefined means
 // the token is outside the registry, i.e. unpriceable — not worthless.

--- a/test/gmxMarketToken.test.ts
+++ b/test/gmxMarketToken.test.ts
@@ -52,9 +52,11 @@ async function drive(stages: Array<(reads: unknown[]) => unknown[]>) {
 }
 
 // stage 1 = [positions per agent, getMarket per market, GM balance per agent per market]
+// An account with no perps decodes to an empty array; undefined is reserved for a read that failed
+// (issue #44), so these fixtures must not use it to mean "holds nothing".
 const stage1 = (gmBalances: bigint[]) => () => [
-  undefined, // holder has no perp positions
-  undefined, // empty has none either
+  [], // holder has no perp positions
+  [], // empty has none either
   marketProps,
   ...gmBalances,
 ];
@@ -100,7 +102,7 @@ test("GM prices are not read when nobody holds any", async () => {
 test("an unreadable market reports the holding instead of zeroing it (#41)", async () => {
   const { values, asked } = await drive([
     // getMarket failed -> undefined, so the market cannot be priced.
-    () => [undefined, undefined, undefined, 5n * 10n ** 18n, 0n],
+    () => [[], [], undefined, 5n * 10n ** 18n, 0n],
   ]);
   assert.equal(asked.length, 1, "no price read without market props");
   assert.equal(values.holder.valueUsdc, 0);
@@ -128,6 +130,36 @@ test("a failed price read reports the holding instead of zeroing it (#41)", asyn
   ]);
 });
 
+test("an unreadable position list is reported, not scored as holding no perps (#44)", async () => {
+  // undefined, unlike the empty array a real read returns for an account with no perps.
+  const { values } = await drive([() => [undefined, [], marketProps, 0n, 0n]]);
+  assert.equal(values.holder.valueUsdc, 0);
+  assert.deepEqual(values.holder.unpriced, [
+    {
+      source: "gmx-position",
+      amountRaw: "",
+      reason: "read-failed",
+      read: "GmxReader.getAccountPositions",
+    },
+  ]);
+  // The agent whose read succeeded is left alone.
+  assert.deepEqual(values.empty.unpriced, []);
+});
+
+test("an unreadable GM balance is reported, not scored as holding none (#44)", async () => {
+  const { values } = await drive([() => [[], [], marketProps, undefined, 0n]]);
+  assert.deepEqual(values.holder.unpriced, [
+    {
+      token: MARKET,
+      amountRaw: "",
+      source: "gmx-gm",
+      reason: "read-failed",
+      read: "ERC20.balanceOf",
+    },
+  ]);
+  assert.deepEqual(values.empty.unpriced, []);
+});
+
 test("gmx accounts for its market tokens so they are not double-reported", async () => {
   const accounted = await gmxAdapter.accountedTokens!(undefined as never);
   assert.deepEqual(
@@ -144,7 +176,12 @@ test("gmx accounts for its market tokens so they are not double-reported", async
 // ---------------------------------------------------------------------------
 
 const FLOAT = 10n ** 30n;
-function perp(market: Address, sizeUsd: bigint, sizeTokens: bigint, collateral: bigint) {
+function perp(
+  market: Address,
+  sizeUsd: bigint,
+  sizeTokens: bigint,
+  collateral: bigint,
+) {
   return {
     addresses: {
       account: AGENTS[0].address,
@@ -163,7 +200,7 @@ function perp(market: Address, sizeUsd: bigint, sizeTokens: bigint, collateral: 
 test("a perp in a configured market is valued at its base's fair price", () => {
   // 1 WETH long entered at $3,000 with 1,000 USDC collateral, marked at $3,000: PnL 0.
   const position = perp(MARKET, 3000n * FLOAT, 10n ** 18n, 1000n * 10n ** 6n);
-  return drive([() => [[position], undefined, marketProps, 0n, 0n]]).then(
+  return drive([() => [[position], [], marketProps, 0n, 0n]]).then(
     ({ values }) => {
       assert.ok(Math.abs(values.holder.valueUsdc - 1000) < 1e-6);
       assert.deepEqual(values.holder.unpriced, []);
@@ -175,9 +212,7 @@ test("a perp in an unconfigured market is reported, not scored at zero (#41)", a
   // Before the fix this whole position -- collateral included -- silently vanished.
   const other = "0x000000000000000000000000000000000000be7f" as Address;
   const position = perp(other, 5000n * FLOAT, 10n ** 18n, 2000n * 10n ** 6n);
-  const { values } = await drive([
-    () => [[position], undefined, marketProps, 0n, 0n],
-  ]);
+  const { values } = await drive([() => [[position], [], marketProps, 0n, 0n]]);
   assert.equal(values.holder.valueUsdc, 0);
   assert.deepEqual(values.holder.unpriced, [
     {
@@ -198,13 +233,7 @@ test("a perp whose base has no fair price is reported, not scored at zero", asyn
     fairByBase: () => ({}), // price feed read failed for every base
   });
   const first = await run.next();
-  const done = await run.next([
-    [position],
-    undefined,
-    marketProps,
-    0n,
-    0n,
-  ] as never);
+  const done = await run.next([[position], [], marketProps, 0n, 0n] as never);
   assert.equal(first.done, false);
   assert.equal(done.done, true);
   const values = done.value as never as Record<

--- a/test/scoringExclusions.test.ts
+++ b/test/scoringExclusions.test.ts
@@ -1,0 +1,183 @@
+// Read failures must be reported, not decoded to zero (issue #44).
+//
+// #41 fixed one door into a silent zero (a holding nothing could price); this covers the other one
+// (a read that failed, so the holding is unknown). A zero that reaches summary.json either way is
+// indistinguishable from the agent having traded the value away.
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Address } from "viem";
+import { readValueSnapshotAtBlock } from "../core/src/realtime/reconstruct.js";
+import { toPriceFeedAnswer } from "@eris/sdk/priceFeed.js";
+import { TOKENS, USDC_VARIANTS } from "@eris/sdk/constants.js";
+import { aaveAdapter } from "@eris/sdk/protocols/aave.js";
+import type { ValuationContext } from "@eris/sdk/protocols/types.js";
+
+const PRICE_FEED = "0x00000000000000000000000000000000feed0001" as Address;
+const AGENT = {
+  id: "a1",
+  address: "0x00000000000000000000000000000000000a0001" as Address,
+};
+const USDC = USDC_VARIANTS.native;
+const FAIR = 2000;
+
+type Call = { address: Address; functionName: string };
+// A read that failed comes back as a failure entry, exactly as viem's allowFailure multicall does.
+type Reply = bigint | "fail";
+
+// Fake client that answers each read by functionName, so a test can make exactly one read fail.
+function clientReturning(reply: (call: Call) => Reply) {
+  const calls: Call[][] = [];
+  return {
+    calls,
+    client: {
+      multicall: async ({ contracts }: { contracts: Call[] }) => {
+        calls.push(contracts);
+        return contracts.map((c) => {
+          const value = reply(c);
+          return value === "fail"
+            ? { status: "failure" as const }
+            : { status: "success" as const, result: value };
+        });
+      },
+    } as never,
+  };
+}
+
+// Healthy answers: $2000 fair, 1 ETH, 2 WETH, 500 USDC.
+const ETH_WEI = 10n ** 18n;
+const WETH_WEI = 2n * 10n ** 18n;
+const USDC_UNITS = 500_000_000n;
+function healthy(call: Call): Reply {
+  if (call.functionName === "latestAnswer") return toPriceFeedAnswer(FAIR);
+  if (call.functionName === "getEthBalance") return ETH_WEI;
+  if (call.address.toLowerCase() === TOKENS.WETH.address.toLowerCase())
+    return WETH_WEI;
+  return USDC_UNITS;
+}
+
+function snapshot(reply: (call: Call) => Reply) {
+  const { client } = clientReturning(reply);
+  return readValueSnapshotAtBlock({
+    publicClient: client,
+    agents: [AGENT],
+    enabledIds: [],
+    activeStables: [USDC],
+    priceFeed: PRICE_FEED,
+    blockNumber: 100,
+  });
+}
+
+test("a healthy cross-section reports nothing excluded", async () => {
+  const s = await snapshot(healthy);
+  assert.equal(s.failedReads, 0);
+  assert.deepEqual(s.unpriced, []);
+  // 1 ETH + 2 WETH at $2000, plus 500 USDC.
+  assert.ok(Math.abs(s.values[0].valueUsdc - (3 * FAIR + 500)) < 1e-6);
+});
+
+test("an unreadable token balance names the holding it hid", async () => {
+  const s = await snapshot((c) =>
+    c.functionName === "balanceOf" &&
+    c.address.toLowerCase() === TOKENS.WETH.address.toLowerCase()
+      ? "fail"
+      : healthy(c),
+  );
+  assert.equal(s.failedReads, 1);
+  assert.deepEqual(s.unpriced, [
+    {
+      agentId: "a1",
+      source: "spot-WETH",
+      token: TOKENS.WETH.address,
+      amountRaw: "",
+      reason: "read-failed",
+      read: "ERC20.balanceOf",
+    },
+  ]);
+  // The value still has to be a number, and the WETH is simply missing from it — which is exactly
+  // why the exclusion above has to be reported.
+  assert.ok(Math.abs(s.values[0].valueUsdc - (FAIR + 500)) < 1e-6);
+});
+
+test("an unreadable ETH balance is reported without a token", async () => {
+  const s = await snapshot((c) =>
+    c.functionName === "getEthBalance" ? "fail" : healthy(c),
+  );
+  assert.deepEqual(s.unpriced, [
+    {
+      agentId: "a1",
+      source: "spot-eth",
+      amountRaw: "",
+      reason: "read-failed",
+      read: "Multicall3.getEthBalance",
+    },
+  ]);
+});
+
+test("failed reads are attributed to a contract and function", async () => {
+  const s = await snapshot((c) =>
+    c.functionName === "balanceOf" ? "fail" : healthy(c),
+  );
+  // Both the WETH and the USDC balance failed, and they are separate targets.
+  assert.equal(s.failedReads, 2);
+  assert.deepEqual(
+    s.failedReadTargets.map((t) => `${t.address}|${t.functionName}|${t.count}`),
+    [`${TOKENS.WETH.address}|balanceOf|1`, `${USDC}|balanceOf|1`],
+  );
+});
+
+test("an unreadable fair price fails the block instead of zeroing every holding", async () => {
+  await assert.rejects(
+    snapshot((c) => (c.functionName === "latestAnswer" ? "fail" : healthy(c))),
+    /fair price unusable at block 100.*read failed/s,
+  );
+});
+
+test("a zero fair price fails the block too", async () => {
+  await assert.rejects(
+    snapshot((c) => (c.functionName === "latestAnswer" ? 0n : healthy(c))),
+    /fair price unusable at block 100.*returned 0/s,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Adapters report their own failed reads through the same channel.
+// ---------------------------------------------------------------------------
+
+function valuationCtx(): ValuationContext {
+  return {
+    publicClient: {} as never,
+    blockNumber: 100,
+    agents: [AGENT],
+    activeStables: [USDC],
+    fairByBase: () => ({ WETH: FAIR }),
+  };
+}
+
+test("aave reports an unreadable account instead of scoring it as closed", async () => {
+  const run = aaveAdapter.valueAtBlock?.(valuationCtx());
+  assert.ok(run);
+  const reads = await run.next();
+  assert.equal((reads.value as unknown[]).length, 1);
+  // The one read failed.
+  const done = await run.next([undefined]);
+  assert.ok(done.done);
+  const value = done.value[AGENT.id];
+  assert.equal(value.valueUsdc, 0);
+  assert.deepEqual(value.unpriced, [
+    {
+      source: "aave-account",
+      amountRaw: "",
+      reason: "read-failed",
+      read: "AavePool.getUserAccountData",
+    },
+  ]);
+});
+
+test("aave stays silent when the account simply holds nothing", async () => {
+  const run = aaveAdapter.valueAtBlock?.(valuationCtx());
+  assert.ok(run);
+  await run.next();
+  const done = await run.next([[0n, 0n, 0n, 0n, 0n, 0n]]);
+  assert.ok(done.done);
+  assert.deepEqual(done.value[AGENT.id].unpriced, []);
+});


### PR DESCRIPTION
Fixes #44.

## Problem

The scorer decoded a failed multicall read to `0` and carried on. The agent's value dropped by whatever that read was worth, and nothing in `events.jsonl` said **which holding had vanished** — only that `failedReads` went up, with no attribution.

This is the #41 failure mode (a zero indistinguishable from a trading loss) reached through a different door. #42 built the reporting channel `scoring_unpriced_holdings`, but routed only *unpriceable* holdings into it, not *unreadable* ones.

## Fix

Give the channel a `reason` (`"unpriced"` / `"read-failed"`) and a `read` naming what could not be read, then route every silent-zero site into it.

| Site | What silently became zero |
|---|---|
| `reconstruct.ts` spot balances | ETH / WETH / extra base / stable — each now reported with its token |
| `aave.ts` `getUserAccountData` | The whole position, i.e. indistinguishable from having been liquidated |
| `uniswap.ts` LP NFT `balanceOf` | Every position at once |
| `uniswap.ts` `tokenOfOwnerByIndex` / `positions` | One position |
| `uniswap.ts` `ticks()` | The fee term only (principal still valued). Suppressing it is deliberate, but it still removes value from the mark, so it says so |
| `gmx.ts` `getAccountPositions` / GM `balanceOf` | The perp position list / a GM holding |

`call()` now records **which contract and function failed, and how often**, aggregated into `ReconstructionMeta.failedReadTargets`, so a value that dropped can be traced back to the read that hid it.

### The fair price fails the block rather than being reported

`results[0]` failing set `fairByBase.WETH = 0`, which prices **every base-denominated holding — spot, LP and perp alike — at nothing**, putting a cliff in the value series. There is no reading of the chain under which that is the right answer, so the block is refused. The reference fair (the one number every α in the run is measured against) refuses at the run level.

The coordinator catches it, **keeps the run's other artifacts** and records `value_series_reconstruction_failed`: losing the series is bad, publishing a wrong one is worse.

### Also

- An extra base whose feed has no entry is reported as unpriced rather than counted as nothing. Unlike WETH, `answerOf` returning 0 there is a real "no entry" rather than a broken read
- The `gmxMarketToken` fixtures used `undefined` to mean "this account holds no perps", which a real `getAccountPositions` expresses as an empty array. They now use `[]`, so `undefined` keeps its single meaning

## Tests

`test/scoringExclusions.test.ts` (8 new). Drives `readValueSnapshotAtBlock` with a fake client and covers: attribution of a failed spot read (token / source / read), a failed ETH balance reported without a token, `failedReadTargets` aggregating contract + function + count, fail-fast on both a failed and a zero fair price, and the Aave adapter reporting a failed read while staying silent on an empty account.

`test/gmxMarketToken.test.ts` gains two #44 cases (unreadable position list, unreadable GM balance), both asserting the agent whose read succeeded is left alone.

231 tests pass / typecheck / `check:boundaries` green.

## Verification

Beyond unit tests, the happy path was measured end to end:

- **Arbitrum fork run** (uniswap / balancer / curve): `failedReads: 0`, `failedReadTargets: []`, `unpricedHoldings: []`, observations emitted and α computed. No false positives.
- **`deploy + backtest` E2E** on this branch, regime `calm-01` = all five venues (`uniswap, balancer, curve, gmx, aave`), so GMX and Aave `valueAtBlock` ran against real local-deploy state: `run ... ok: 3 agents, 12 blocks, failedReads 0`.

Not verified: forcing an actual read failure against a live chain (e.g. reading past anvil's ~1,050-block retention depth). The failure paths are covered by fake-client unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)