### PR TITLE
ci: run the backtest when scoring code changes

### DIFF
--- a/.github/workflows/deploy-backtest.yml
+++ b/.github/workflows/deploy-backtest.yml
@@ -22,6 +22,13 @@ on:
       - "sdk/src/constants.ts"
       - "sdk/src/constants.local.ts"
       - "config/regimes/**"
+      # Scoring. A run's value series cannot be regression-tested any other way: tx timing and
+      # ordering are non-deterministic (ADR 0005), so a golden run does not exist and unit tests can
+      # only pin individual functions. This job is the only thing that puts the scorer in front of
+      # real venue state across all five venues. #44 changed the scorer and skipped this job.
+      - "core/src/realtime/reconstruct.ts"
+      - "sdk/src/valuation.ts"
+      - "sdk/src/protocols/**"
       - ".github/workflows/deploy-backtest.yml"
 
 concurrency:


### PR DESCRIPTION
## Problem

The `deploy + backtest` job is path-filtered to the deployer and the backtest itself, so **a change to the scorer does not trigger it**. #44 (PR #49) rewrote how `reconstruct.ts` and every adapter's `valueAtBlock` decode their reads, and this job stayed green by never running.

## Why this path needs a net

A run's value series **cannot be regression-tested any other way**:

- Tx timing and ordering are non-deterministic (ADR 0005), so `summary.json` varies between runs of the same regime — **there is no golden run to diff against**
- Unit tests can only pin individual functions against canned results; they never put the code in front of real venue state

This job is the only thing that runs the scorer against all five venues on real state.

## Change

Add the three things that decide what an agent is worth:

- `core/src/realtime/reconstruct.ts` — the cross-section reader and the reference fair for α
- `sdk/src/valuation.ts` — shared USD valuation primitives
- `sdk/src/protocols/**` — each adapter's `valueAtBlock` / `accountedTokens`

On cost: the job is heavy (~25-40 min), so the filter itself stays. Only the files that make a valuation decision were added — the coordinator and flow are still out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)