### PR TITLE
Liquid staking (LST) venue: wstETH-style vault, LST/WETH market, and leverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/*.yaml
 !config/all18-mixed.yaml
 !config/claude-llm.yaml
 !config/vuln-test.yaml
+!config/lst.yaml
 runs/
 cache/
 out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,18 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
     **discount は開かない**（プールが rate oracle 追随でリプライスする＝oracle が正しく効いている証拠）。
     slash は「保有者が損をする」リスクであって裁定機会ではない。よって magnitude は利回りスケールで較正する
     （70 ブロック run の利回り ~3-8bps に対し 10-30bps。最初に試した 100-300bps は利回りの 15 倍でステーク自体が常に負けになった）
+- **Phase 3（レバレッジ）実装済み**。`run.protocols` に `aave` を足すと有効:
+  - deployer が LST を **Aave の担保専用 reserve** として登録（`registerLstReserve`。LTV 70% / LT 75% /
+    bonus 7.5%。**borrow は無効**＝現実の LST 上場と同じで、狙いは「LST を担保に ETH を借りる」レバステーキング）。
+    Aave 自身の同名 reserve から clone できないため **LTV/LT は明示指定**（issue #38 が指摘した通り）。
+    rate strategy のみ WETH から借用
+  - **価格は WETH × 償還レート**。専用 MockAggregator を持ち、`sdk/src/protocols/oracles.ts` が
+    他の全オラクルと同じ 3 経路（mined / mempool / storage）で毎ブロック書く。よって **1 ブロック遅れ**を継承し、
+    slash はまず vault に効き、次ブロックで HF に届く = liquidation cascade の起点
+  - `aaveSupply`/`aaveWithdraw` の asset に `"LST"` を指定可能（`TokenKind` に `"lst"` を追加し、
+    scorer の spot 掃引から外して二重計上を防いでいる。評価は Aave の totalCollateralBase 経由）
+  - **同梱 agent はレバレッジしない**。市場側の検証は `test/lstLeverage.test.ts`（要 `ERIS_LOCAL_DEPLOY=1` +
+    ローカルデプロイ。実チェーンで listing → ETH 借入 → slash → HF 低下 を検査。CI では skip）
 - **USDC 建て採点では LST 保有戦略は構造的に β で不利**（実測: noop 0 > lst-carry −203 > lst-carry-wide −233、
   一方で WETH を持たない venue-arb は +115）。alphaUsdc は free inventory の β しか除去せず、
   LST ポジションは live mark のため。ETH 建て採点（DAT 型）が issue #38 の motivation で follow-on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,31 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
 - stress run（events かつ `ERIS_RUN_BLOCKS>0`）は**時間制限を自動無効化**しブロック数で終了する（`ERIS_RUN_SECONDS` が先に切れて crash 窓へ到達しない事故を回避。override は `stress_run_time_limit_disabled` で記録）
 - coordinator は `stress_schedule` / `stress_victim_hf` / `stress_liquidation` を events.jsonl へ emit する。liquidator agent には victim アドレスを `ERIS_LIQUIDATION_VICTIMS` で配布する。清算の帰属は agent ログの `liquidationCall`(rawTx) を一次情報にする（events.jsonl を直接読んで解析する。旧 stress-report ツールは撤去済み）
 
+### LST venue（wstETH 風 vault + LST/WETH 二次市場。issue #38 Phase 1。既定 off・**ローカルデプロイ専用**）
+
+利回りで償還レートが上がる非 rebasing の LST（`deployer/contracts/MockLSTVault.sol`）と、その二次市場
+（既存 stableswap-ng factory 上の LST/WETH plain pool）。**同じ資産に価格が 2 つある**のが本質:
+`redemptionRateWeth`（vault が負う par。ただし出金キュー `withdrawalDelayBlocks` 待ち）と
+`marketPriceWeth`（プールが今払う額。discount 付き）。observation は両方 + `discountBps` /
+`yieldPerBlockBps` / キュー長 / 自分サイズでの `instantExitWethWei` / pending を別々に出す。
+
+- **Arbitrum に対応物が無い**（vault は自作）ので fork では使えない。`run.protocols` に `lst` を入れて
+  ローカルデプロイでないと起動時 fail-fast。有効化済みの雛形が `config/lst.yaml`
+  （`cd deployer && npm run deploy -- --keep-fresh` → `npm run gen:local-constants` → `sim:realtime -- --config config/lst.yaml`）
+- **利回りは EVM 時間でなく経済クロック**（`lst.simulatedSecondsPerBlock` / `lst.apyBps`。既定 1 block=1h・3%/yr
+  = Aave WETH supply と同オーダー。速すぎると他 venue が無意味になる）。原資は事前投入 reward reserve に上限され、
+  `accrueRewards()` は permissionless（額はブロック数の純関数なので誰が叩いても同じ）。coordinator は毎ブロック
+  oracle tx と**同じ admin nonce の直列**で叩く（並列にすると nonce 衝突でレートが凍る）
+- **プールの rate oracle 配線が要**（`stEthPerToken()` を asset_type=1 で登録）。未配線だとレート上昇が全員に開かれた
+  無リスク裁定になる（ADR 0007 を毀損）。deploy 時 assert + 起動時 `lst_setup` で乖離 200bps 超は fail-fast
+- **採点は realizable**（`sdk/src/protocols/lst.ts` `realizableWethWei`）: shares は「今プールで売った額」と
+  「run 終了までに finalize するキューの par」の**良い方**。run 終了後にしか claim できない pending は価値から外し
+  `reason:"unrealizable"` で `scoring_unpriced_holdings` に報告する（黙って 0 にしない）。#41 の staged-read
+  インターフェース（`valueAtBlock` / `liquidatableValueUsdc` / `ValuationContext.horizonBlock`）の最初の消費者
+- Phase 2（seed 由来の APY 変動・キュー混雑・サイズ依存 depeg・`slash` の stress overlay 化）は未実装。
+  そのため Phase 1 では市場が自然に discount を作らない = 参照 agent `lst-carry` は stake しかしない。
+  carry/queue/claim 経路を実走で見るには `config/lst.yaml` のコメント手順でプールを off-peg にする
+
 実時間化（ADR 0005）の前提: **SEED(=regime) は市場条件のラベル**で価格パスは再現可能だが、tx タイミング/着順は非決定 → 同一 regime でも結果はぶれる。run 長は `ERIS_RUN_BLOCKS` 固定で揃える。run の比較が要るときは同一 config を複数回回してサンプルを貯め、`runs/<id>/summary.json` を集計する（旧 evaluate/gate は撤去済み）。
 
 ## アーキテクチャ（環境とエージェント実行の分離。ADR 0006 / ADR 0015）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,20 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
   「run 終了までに finalize するキューの par」の**良い方**。run 終了後にしか claim できない pending は価値から外し
   `reason:"unrealizable"` で `scoring_unpriced_holdings` に報告する（黙って 0 にしない）。#41 の staged-read
   インターフェース（`valueAtBlock` / `liquidatableValueUsdc` / `ValuationContext.horizonBlock`）の最初の消費者
-- Phase 2（seed 由来の APY 変動・キュー混雑・サイズ依存 depeg・`slash` の stress overlay 化）は未実装。
-  そのため Phase 1 では市場が自然に discount を作らない = at-par の断面から始めると `lst-carry` は stake しかしない。
-  carry/queue/claim 経路を実走で見るには `config/lst.yaml` のコメント手順でプールを off-peg にする
-  （実証済み: 38bps の discount から prompt 駆動の LLM が carry→queue→claim を完走し唯一の黒字。
-  期限切れは `blocksRemaining <= withdrawalDelayBlocks+4` を理由に自分で noop した）
+- **Phase 2（選択を非自明にする）実装済み**。`config/lst.yaml` の `lst:` / `stress:` に較正例:
+  - **APY 変動** — `lst.apyRangeBps` + `apyStepBlocks` で seed 由来 Rng（独立 salt）から N ブロックごとに再サンプル
+    → coordinator が `setRewardRate`。固定利回りだと「block 0 で全ステーク」が恒久最適になるため
+  - **キュー混雑 + サイズ依存** — vault の finalize をスループット律速に（`queueThroughputWeiPerBlock`）。
+    `claimableAt = max(floor, queueDrainBlock) + ceil(assets/throughput)` = 大口ほど待ち、先客がいるほど待つ。
+    観測は実効待ちを `estimatedQueueDelayBlocks`（自分の全保有）と `queueDelayPerWethBlocks`（限界 1 WETH）で分けて出す。
+    **採点も実効待ちを使う**（floor で判定すると完了不能な exit を par 評価してしまう）
+  - **`lstSlash`** — ADR 0009 と同じレンジ config で `stress.events` に書ける点イベント。1 ブロックで rate を恒久的に下げる。
+    **discount は開かない**（プールが rate oracle 追随でリプライスする＝oracle が正しく効いている証拠）。
+    slash は「保有者が損をする」リスクであって裁定機会ではない。よって magnitude は利回りスケールで較正する
+    （70 ブロック run の利回り ~3-8bps に対し 10-30bps。最初に試した 100-300bps は利回りの 15 倍でステーク自体が常に負けになった）
+- **USDC 建て採点では LST 保有戦略は構造的に β で不利**（実測: noop 0 > lst-carry −203 > lst-carry-wide −233、
+  一方で WETH を持たない venue-arb は +115）。alphaUsdc は free inventory の β しか除去せず、
+  LST ポジションは live mark のため。ETH 建て採点（DAT 型）が issue #38 の motivation で follow-on
 
 実時間化（ADR 0005）の前提: **SEED(=regime) は市場条件のラベル**で価格パスは再現可能だが、tx タイミング/着順は非決定 → 同一 regime でも結果はぶれる。run 長は `ERIS_RUN_BLOCKS` 固定で揃える。run の比較が要るときは同一 config を複数回回してサンプルを貯め、`runs/<id>/summary.json` を集計する（旧 evaluate/gate は撤去済み）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,12 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
     slash はまず vault に効き、次ブロックで HF に届く = liquidation cascade の起点
   - `aaveSupply`/`aaveWithdraw` の asset に `"LST"` を指定可能（`TokenKind` に `"lst"` を追加し、
     scorer の spot 掃引から外して二重計上を防いでいる。評価は Aave の totalCollateralBase 経由）
-  - **同梱 agent はレバレッジしない**。市場側の検証は `test/lstLeverage.test.ts`（要 `ERIS_LOCAL_DEPLOY=1` +
-    ローカルデプロイ。実チェーンで listing → ETH 借入 → slash → HF 低下 を検査。CI では skip）
+  - `lst-carry` は **`ERIS_LST_LEVERAGE_TARGET_HF` で opt-in**（既定 0=off）。ループは
+    stake→collateralize→borrow→stake で、目標 HF に**着地する**サイズだけ借りる（headroom 基準で借りると
+    目標も下限も突き抜けて borrow/repay が振動する: 実測 24/22 → 2/0）。HF が下限を割ったら他の何より先に返済。
+    prompt 版は spot に専念（LLM に env の opt-in は効かないため、手を出さないよう明記）
+  - 市場側の検証は `test/lstLeverage.test.ts`（要 `ERIS_LOCAL_DEPLOY=1` + ローカルデプロイ。実チェーンで
+    listing → ETH 借入 → slash 後も HF 不変(=oracle lag) → oracle 更新で HF 低下 を検査。CI では skip）
 - **USDC 建て採点では LST 保有戦略は構造的に β で不利**（実測: noop 0 > lst-carry −203 > lst-carry-wide −233、
   一方で WETH を持たない venue-arb は +115）。alphaUsdc は free inventory の β しか除去せず、
   LST ポジションは live mark のため。ETH 建て採点（DAT 型）が issue #38 の motivation で follow-on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ validate 失敗はエラー内容を会話に追記して再試行（上限超�
 
 run の設定値とエージェントロスターは **`config/local.yaml` 一本**で管理する（env からの設定読取は廃止）。
 解決順は `--config <path>` > `ERIS_CONFIG` > `config/local.yaml` > `config/example.yaml`（committed 雛形 = zero-config 既定）。
+**雛形は `run.localDeploy: true` 既定**（README Quick Start と config/regimes/* に揃えた。fork 用フラグは不要になり
+`npm run sim:realtime` だけで走る）。fork に戻すには `localDeploy: false` + `run.protocols` から `lst` を外す
+（LST の vault は自作で Arbitrum に対応物が無い）+ `ARB_RPC_URL` + 別端末で `npm run anvil`。
 キーは**ネスト lowercase**（`run` / `funding` / `limits` / `flow` / `stress` / `vuln` + `agents`）で
 `sdk/src/runConfig.ts` の `SCHEMA` が内部キーへ写す。ロスターは規約解決（ADR 0015 §6）:
 
@@ -98,8 +101,9 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
 `yieldPerBlockBps` / キュー長 / 自分サイズでの `instantExitWethWei` / pending を別々に出す。
 
 - **Arbitrum に対応物が無い**（vault は自作）ので fork では使えない。`run.protocols` に `lst` を入れて
-  ローカルデプロイでないと起動時 fail-fast。有効化済みの雛形が `config/lst.yaml`
-  （`cd deployer && npm run deploy -- --keep-fresh` → `npm run gen:local-constants` → `sim:realtime -- --config config/lst.yaml`）
+  ローカルデプロイでないと起動時 fail-fast。**`config/example.yaml` の既定ロスターに入っている**
+  （`cd deployer && npm run deploy -- --keep-fresh` → `npm run gen:local-constants` → `npm run sim:realtime`）。
+  LST 単独で見たいときは競合参加者と較正ノブを明示した `config/lst.yaml`
 - **利回りは EVM 時間でなく経済クロック**（`lst.simulatedSecondsPerBlock` / `lst.apyBps`。既定 1 block=1h・3%/yr
   = Aave WETH supply と同オーダー。速すぎると他 venue が無意味になる）。原資は事前投入 reward reserve に上限され、
   `accrueRewards()` は permissionless（額はブロック数の純関数なので誰が叩いても同じ）。coordinator は毎ブロック
@@ -111,8 +115,10 @@ OU の base price はそのまま進め、その上に **SEED 由来でランダ
   `reason:"unrealizable"` で `scoring_unpriced_holdings` に報告する（黙って 0 にしない）。#41 の staged-read
   インターフェース（`valueAtBlock` / `liquidatableValueUsdc` / `ValuationContext.horizonBlock`）の最初の消費者
 - Phase 2（seed 由来の APY 変動・キュー混雑・サイズ依存 depeg・`slash` の stress overlay 化）は未実装。
-  そのため Phase 1 では市場が自然に discount を作らない = 参照 agent `lst-carry` は stake しかしない。
+  そのため Phase 1 では市場が自然に discount を作らない = at-par の断面から始めると `lst-carry` は stake しかしない。
   carry/queue/claim 経路を実走で見るには `config/lst.yaml` のコメント手順でプールを off-peg にする
+  （実証済み: 38bps の discount から prompt 駆動の LLM が carry→queue→claim を完走し唯一の黒字。
+  期限切れは `blocksRemaining <= withdrawalDelayBlocks+4` を理由に自分で noop した）
 
 実時間化（ADR 0005）の前提: **SEED(=regime) は市場条件のラベル**で価格パスは再現可能だが、tx タイミング/着順は非決定 → 同一 regime でも結果はぶれる。run 長は `ERIS_RUN_BLOCKS` 固定で揃える。run の比較が要るときは同一 config を複数回回してサンプルを貯め、`runs/<id>/summary.json` を集計する（旧 evaluate/gate は撤去済み）。
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flowchart LR
 
 ## What is this
 
-- **Multi-protocol DeFi environment** — Uniswap V3 / Balancer v2 / Curve / Aave v3 / GMX v2 are all provisioned on a single Anvil, and enabled pluggably through the protocol adapter registry (`sdk/src/protocols/`).
+- **Multi-protocol DeFi environment** — Uniswap V3 / Balancer v2 / Curve / Aave v3 / GMX v2, plus a liquid-staking venue (a wstETH-style vault and its LST/WETH market), are all provisioned on a single Anvil and enabled pluggably through the protocol adapter registry (`sdk/src/protocols/`).
 - **Multi-agent competition** — agents run as fully independent processes, subscribe to blocks at their own pace, and sign and send directly themselves. In-block ordering is determined by anvil `--order fees` (descending priority fee).
 - **Controllable fair price** — the coordinator generates a SEED-derived deterministic fair price every block and writes it to the on-chain `PriceFeed` and mock oracles. Aave health factors and GMX mark prices follow it.
 - **Market stress & liquidation** — price spikes/crashes can be injected to trigger the Aave liquidation path.
@@ -93,15 +93,17 @@ To skip LLMs entirely and run the same strategies rule-based (`agent.ts`), remov
 # Separate terminal: start anvil + deploy all venues via deployer (do not pass --exit)
 cd deployer && npm run deploy -- --keep-fresh
 
-# poc side (repository root): import the deploy addresses and run in local deploy mode
+# poc side (repository root): import the deploy addresses and run
 npm run gen:local-constants
-npm run sim:realtime -- --local-deploy \
-  --seed 1 --blocks 100 --seconds 300 --protocols uniswap,balancer,curve
-# The roster is the inline agents in config/local.yaml (edit the YAML to swap it out.
-# backtest supports swapping via --agents <roster.yaml>)
+npm run sim:realtime
+# The roster and every run knob come from config/local.yaml (edit the YAML to swap them out;
+# backtest supports swapping the roster via --agents <roster.yaml>). One-off overrides are CLI
+# flags: npm run sim:realtime -- --seed 2 --blocks 40
 ```
 
-> The `--local-deploy` flag (or config `run.localDeploy: true`) switches to local deploy mode. The CLI entry point detects this at startup, sets `ERIS_LOCAL_DEPLOY=1` internally, and `sdk/src/constants.ts` overlays the locally-deployed addresses (WETH/USDC/WBTC, etc.) — no need to pass the env by hand.
+> `config/example.yaml` ships with `run.localDeploy: true`, so no flag is needed. The CLI entry point detects it at startup, sets `ERIS_LOCAL_DEPLOY=1` internally, and `sdk/src/constants.ts` overlays the locally-deployed addresses (WETH/USDC/WBTC, etc.) — no need to pass the env by hand. `--local-deploy` still works as a one-off override for a config that does not set it.
+
+> To run against an Arbitrum fork instead, set `run.localDeploy: false` in `config/local.yaml`, remove `lst` from `run.protocols` (its vault is deployed by us and has no Arbitrum counterpart), put `ARB_RPC_URL` in `.env.local`, and start `npm run anvil` in another terminal.
 
 > LLM decisions take ~10s each, hence the 100-block / 300s run above (rule-based runs are fine with 24 blocks / 70s). If the trading agents only emit `noop`, you probably skipped [Choose an LLM backend](#choose-an-llm-backend) — check `runs/<run_id>/agents/<id>.jsonl` for `llm cycle skipped`.
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -12,6 +12,13 @@
 # `.env.local` (ARB_RPC_URL / *_PRIVATE_KEY / ANTHROPIC_API_KEY / OLLAMA_API_KEY).
 # The local Anvil dev keys are used by default even when unspecified.
 #
+# Local deploy by default (run.localDeploy: true), matching the README Quick Start and the official
+# backtest regimes: every venue is deployed onto a bare anvil by the bundled deployer/, so no fork
+# RPC is involved. Start it with `cd deployer && npm run deploy -- --keep-fresh`, then
+# `npm run gen:local-constants` to import the addresses. To run against an Arbitrum fork instead,
+# set localDeploy: false, drop `lst` from run.protocols (its vault has no Arbitrum counterpart) and
+# start `npm run anvil` in another terminal with ARB_RPC_URL set.
+#
 # LLM-driven by default: the trading agents below run in prompt mode (prompt.md, one LLM call per
 # decision; ERIS_AGENT_MODE: "prompt") and need an LLM backend. Pick one:
 #   - Ollama Cloud (default; model gpt-oss:120b): set OLLAMA_API_KEY in `.env.local`
@@ -29,13 +36,20 @@ run:
   blocks: 100
   seconds: 300
   blockTimeSec: 2
-  protocols: [uniswap, balancer, curve]
+  # gmx and aave are left out because they are the slow half of the deploy; add them once
+  # `deployer` has run with them. `lst` is local-only (issue #38) and fails fast on a fork.
+  protocols: [uniswap, balancer, curve, lst]
   economicGas: false
-  localDeploy: false
+  localDeploy: true
   reportDir: ./runs
 
 funding:
-  wethWei: "0" # USDC-only distribution (removes initial directional exposure)
+  # WETH is handed out because the LST venue is WETH-denominated and cannot be traded without it.
+  # That reintroduces price drift (beta) into netPnlUsdc, which is fine for a template you run to
+  # see the thing work — read alphaUsdc for skill. The official regimes under config/regimes/ stay
+  # USDC-only (wethWei: "0") so evaluation runs keep their clean alpha; drop this to "0" too if you
+  # are measuring rather than exploring, and take `lst` out of run.protocols with it.
+  wethWei: "20000000000000000000" # 20 WETH
   usdcUnits: "25000000000"
   # base: { WBTC: "0" }   # initial inventory of additional bases (default 0)
 
@@ -103,18 +117,10 @@ agents:
     description: base-agnostic cross-venue arbitrage (all active bases x all venues; LLM-driven via prompt.md)
     env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }
     # env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1", ERIS_LLM_MODEL: "claude-cli:haiku" }
-  # The LST venue (issue #38) is left out of this file's roster on purpose: the vault has no
-  # Arbitrum counterpart, so it exists only under local deploy, and enabling it here would break
-  # the fork Quick Start above. To trade it, use the ready-made config instead:
-  #
-  #   cd deployer && npm run deploy -- --keep-fresh && cd ..
-  #   npm run gen:local-constants
-  #   npm run sim:realtime -- --config config/lst.yaml
-  #
-  # That config adds `lst` to run.protocols, funds WETH (the venue is WETH-denominated) and runs
-  # example/agents/lst-carry/. To add it here instead, set run.localDeploy: true, add `lst` to
-  # run.protocols, set funding.wethWei above zero, and uncomment:
-  # - id: lst-carry
-  #   wallet: AGENT4_PRIVATE_KEY
-  #   description: liquid staking — stake for yield, or trade the redemption/market gap
-  #   env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }
+  - id: lst-carry
+    wallet: AGENT4_PRIVATE_KEY
+    description: liquid staking — stake for yield, or trade the LST redemption/market gap (LLM-driven via prompt.md)
+    env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }
+    # env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1", ERIS_LLM_MODEL: "claude-cli:haiku" }
+  # config/lst.yaml is the same venue with a second competing participant and the calibration knobs
+  # spelled out, if you want to look at the LST market on its own.

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -103,3 +103,18 @@ agents:
     description: base-agnostic cross-venue arbitrage (all active bases x all venues; LLM-driven via prompt.md)
     env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }
     # env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1", ERIS_LLM_MODEL: "claude-cli:haiku" }
+  # The LST venue (issue #38) is left out of this file's roster on purpose: the vault has no
+  # Arbitrum counterpart, so it exists only under local deploy, and enabling it here would break
+  # the fork Quick Start above. To trade it, use the ready-made config instead:
+  #
+  #   cd deployer && npm run deploy -- --keep-fresh && cd ..
+  #   npm run gen:local-constants
+  #   npm run sim:realtime -- --config config/lst.yaml
+  #
+  # That config adds `lst` to run.protocols, funds WETH (the venue is WETH-denominated) and runs
+  # example/agents/lst-carry/. To add it here instead, set run.localDeploy: true, add `lst` to
+  # run.protocols, set funding.wethWei above zero, and uncomment:
+  # - id: lst-carry
+  #   wallet: AGENT4_PRIVATE_KEY
+  #   description: liquid staking — stake for yield, or trade the redemption/market gap
+  #   env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -35,8 +35,12 @@ run:
   # Add `aave` to get the phase 3 layer: the deploy lists the LST as Aave collateral (LTV 70% / LT
   # 75%, collateral only), priced at WETH x the vault's redemption rate and rewritten every block.
   # That makes leveraged staking possible -- supply LST, borrow WETH, stake again -- and makes a
-  # slash reach health factors one block after it reaches the vault. No shipped agent levers by
-  # default; test/lstLeverage.test.ts exercises the market end to end.
+  # slash reach health factors one block after it reaches the vault.
+  #
+  # To watch an agent lever, add `aave` here and give lst-carry
+  # `env: { ERIS_LST_LEVERAGE_TARGET_HF: "2.0" }`. It then runs stake -> post -> borrow -> stake up
+  # to that health factor and repays if it drops under 1.6. Off by default: leverage multiplies the
+  # slashing exposure as readily as the yield.
   protocols: [uniswap, balancer, curve, lst]
   economicGas: false
   localDeploy: true

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -83,18 +83,24 @@ agents:
     wallet: AGENT1_PRIVATE_KEY
     baseline: true
     description: does nothing (baseline)
-  # Rule-based by default so the venue is exercised without an LLM backend. Add
-  # `env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }` to drive the same agent
-  # through prompt.md instead (needs OLLAMA_API_KEY or a CLI backend; see docs/guide/llm-agents.md).
+  # LLM-driven through prompt.md, matching the committed example.yaml roster: the venue's default
+  # path is the one a participant actually submits (ADR 0015 §2, issue #38). Needs OLLAMA_API_KEY
+  # in .env.local. Without a backend the run completes and this agent fails closed to noop, so if
+  # it never trades, check agents/lst-carry.jsonl for the reason before blaming the strategy.
+  # Remove the `env:` line to run the same strategy rule-based via agent.ts.
   - id: lst-carry
     wallet: AGENT2_PRIVATE_KEY
-    description: liquid staking — stake for yield, or trade the redemption/market gap
-  # A second instance that demands a wider discount before it acts, so the two compete for the same
-  # dislocation and the venue sees more than one participant.
+    description: liquid staking — stake for yield, or trade the redemption/market gap (LLM-driven via prompt.md)
+    env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }
+    # Claude Code / Codex subscription instead of Ollama (no API key) — use this env line instead.
+    # This is the combination the prompt was verified on (see docs/guide/llm-agents.md):
+    # env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1", ERIS_LLM_MODEL: "claude-cli:haiku" }
+  # The same strategy run rule-based (agent.ts) with a wider entry threshold: a second participant
+  # competing for the same dislocation, and a control for the prompt-driven one above.
   - id: lst-carry-wide
     dir: lst-carry
     wallet: AGENT3_PRIVATE_KEY
-    description: lst-carry with a wider entry threshold
+    description: lst-carry with a wider entry threshold (rule-based via agent.ts)
     env: { ERIS_LST_SAFETY_BPS: "40" }
   - id: venue-arb
     wallet: AGENT4_PRIVATE_KEY

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -31,6 +31,12 @@ run:
   blockTimeSec: 2
   # The AMM venues stay on so the LST market is not the only thing moving, and so a run exercises
   # the same cross-venue no-arbitrage guard as usual.
+  #
+  # Add `aave` to get the phase 3 layer: the deploy lists the LST as Aave collateral (LTV 70% / LT
+  # 75%, collateral only), priced at WETH x the vault's redemption rate and rewritten every block.
+  # That makes leveraged staking possible -- supply LST, borrow WETH, stake again -- and makes a
+  # slash reach health factors one block after it reaches the vault. No shipped agent levers by
+  # default; test/lstLeverage.test.ts exercises the market end to end.
   protocols: [uniswap, balancer, curve, lst]
   economicGas: false
   localDeploy: true

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -1,0 +1,101 @@
+# config/lst.yaml — the LST venue (issue #38): a wstETH-style vault plus its LST/WETH market.
+#
+#   npm run sim:realtime -- --config config/lst.yaml
+#
+# Prerequisites. This venue has no Arbitrum counterpart — the vault is ours — so unlike every other
+# venue it runs **only on a local deploy**:
+#
+#   1. cd deployer && npm run deploy -- --keep-fresh        # includes the lst protocol
+#   2. npm run gen:local-constants                          # picks up LST from deployments.json
+#   3. npm run sim:realtime -- --config config/lst.yaml
+#
+# A fork run that lists `lst` in run.protocols fails fast at startup rather than reading zeros.
+#
+# Funding note: the LST venue is WETH-denominated, so unlike the USDC-only evaluation profile this
+# config hands out WETH. That reintroduces price drift (beta) into netPnlUsdc. alphaUsdc removes it
+# from *free inventory* by evaluating at a fixed reference fair, but a staked position is marked
+# live like every other protocol position, so some beta survives there too — the same approximation
+# Aave supply has always had. Scoring the venue in ETH terms outright is the DAT-style follow-on
+# (issue #38's motivation), not this phase. Compare agents within one run, not across price paths.
+
+run:
+  seed: 1
+  blocks: 80
+  seconds: 400 # end by block count (well above blocks x blockTimeSec)
+  blockTimeSec: 2
+  # The AMM venues stay on so the LST market is not the only thing moving, and so a run exercises
+  # the same cross-venue no-arbitrage guard as usual.
+  protocols: [uniswap, balancer, curve, lst]
+  economicGas: false
+  localDeploy: true
+  reportDir: ./runs
+
+funding:
+  # WETH to stake with (see the funding note above). USDC is still handed out so the AMM agents in
+  # the roster have something to trade.
+  wethWei: "20000000000000000000" # 20 WETH
+  usdcUnits: "25000000000"
+
+limits:
+  agentWethWei: "1000000000000000000"
+  agentUsdcUnits: "5000000000"
+
+# LST venue calibration (issue #38).
+#
+# Yield runs on a compressed *economic* clock rather than EVM time — warping time would also move
+# Aave's accrual and GMX funding. One block stands for simulatedSecondsPerBlock seconds of staking.
+#
+# apyBps is deliberately the same order as the Aave WETH supply rate: a 1000x-speed LST would make
+# every other venue irrelevant. At the defaults below (3%/yr on a one-hour-per-block clock) an
+# 80-block run accrues roughly 2.7bps of yield — small against the pool's ~12bps round trip, which
+# is the point: in phase 1 the money is in the discount and the queue decision, not in the carry.
+# Phase 2 (seed-driven APY variation, queue congestion, size-dependent depeg, slashing) is what
+# makes the choice non-trivial.
+lst:
+  simulatedSecondsPerBlock: 3600 # one block == one hour of staking
+  apyBps: 300 # 3%/yr, ~ Aave WETH supply
+  # Blocks between requesting a redemption and being able to claim it. 0 keeps whatever the deploy
+  # baked in (24). Kept well under run.blocks so the queue is a real, usable option — raise it above
+  # run.blocks to see agents correctly refuse to queue at all.
+  withdrawalDelayBlocks: 20
+  maxDepositWethWei: "5000000000000000000" # cap per stake
+
+flow:
+  uninformedMaxWethWei: "1000000000000000000"
+  informedMaxWethWei: "2000000000000000000"
+  balancerMaxWethWei: "1000000000000000000"
+  curveMaxWethWei: "1000000000000000000"
+  informedArbFeeBps: 30
+  uninformedArrivalRate: "0.9"
+  uninformedSizeSigma: "1.0"
+  # There is no LST flow bot yet: the secondary market moves only when agents trade it. That is
+  # deliberate for phase 1 — an environment-driven depeg is phase 2's job. Consequence: from a
+  # freshly deployed (at-par) chain the discount stays near zero, so lst-carry will stake and
+  # nothing else. To watch the carry / queue / claim path actually run, put the pool off-peg first
+  # by selling LST into it, e.g. with the deployer account:
+  #   cast send $VAULT 'deposit(uint256,address)(uint256)' 18e18 $DEPLOYER
+  #   cast send $POOL  'exchange(int128,int128,uint256,uint256)(uint256)' 1 0 17e18 0
+  # At the pool's calibration (100 WETH a side, A=100) that is ~70bps of discount; the agents then
+  # trade it back toward par and stop, which is the venue working as intended.
+
+agents:
+  - id: noop
+    wallet: AGENT1_PRIVATE_KEY
+    baseline: true
+    description: does nothing (baseline)
+  # Rule-based by default so the venue is exercised without an LLM backend. Add
+  # `env: { ERIS_AGENT_MODE: "prompt", ERIS_PROMPT_LOG_CALLS: "1" }` to drive the same agent
+  # through prompt.md instead (needs OLLAMA_API_KEY or a CLI backend; see docs/guide/llm-agents.md).
+  - id: lst-carry
+    wallet: AGENT2_PRIVATE_KEY
+    description: liquid staking — stake for yield, or trade the redemption/market gap
+  # A second instance that demands a wider discount before it acts, so the two compete for the same
+  # dislocation and the venue sees more than one participant.
+  - id: lst-carry-wide
+    dir: lst-carry
+    wallet: AGENT3_PRIVATE_KEY
+    description: lst-carry with a wider entry threshold
+    env: { ERIS_LST_SAFETY_BPS: "40" }
+  - id: venue-arb
+    wallet: AGENT4_PRIVATE_KEY
+    description: WETH-only cross-venue arbitrage (keeps the AMM venues honest)

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -15,8 +15,14 @@
 # config hands out WETH. That reintroduces price drift (beta) into netPnlUsdc. alphaUsdc removes it
 # from *free inventory* by evaluating at a fixed reference fair, but a staked position is marked
 # live like every other protocol position, so some beta survives there too — the same approximation
-# Aave supply has always had. Scoring the venue in ETH terms outright is the DAT-style follow-on
-# (issue #38's motivation), not this phase. Compare agents within one run, not across price paths.
+# Aave supply has always had. Compare agents within one run, not across price paths.
+#
+# Read scores here with that in mind: **a strategy that holds LST is structurally penalised against
+# one that holds none**, because it carries WETH exposure that a USDC-denominated score treats as
+# risk without reward. Measured on this config: noop 0 > lst-carry -203 > lst-carry-wide -233, while
+# venue-arb (which ends flat in WETH) makes +115 on the same blocks. That is the scoring frame, not
+# the venue. Scoring in ETH terms is exactly the DAT-style competition issue #38 opens with, and it
+# is the follow-on this phase makes possible rather than something this phase does.
 
 run:
   seed: 1
@@ -53,12 +59,40 @@ limits:
 # makes the choice non-trivial.
 lst:
   simulatedSecondsPerBlock: 3600 # one block == one hour of staking
-  apyBps: 300 # 3%/yr, ~ Aave WETH supply
-  # Blocks between requesting a redemption and being able to claim it. 0 keeps whatever the deploy
+  apyBps: 300 # 3%/yr, ~ Aave WETH supply. The starting point when apyRangeBps varies it.
+  # Floor on the wait between requesting a redemption and claiming it. 0 keeps whatever the deploy
   # baked in (24). Kept well under run.blocks so the queue is a real, usable option — raise it above
   # run.blocks to see agents correctly refuse to queue at all.
   withdrawalDelayBlocks: 20
   maxDepositWethWei: "5000000000000000000" # cap per stake
+  # ---- phase 2: what makes the choice non-trivial ----
+  # Without variation the optimum is "stake everything at block 0" and stays there. The APY is
+  # resampled from this range every apyStepBlocks off a seed-derived Rng (independent of the price
+  # path), so the opportunity cost of holding LST moves against the pool's discount. Comment it out
+  # to pin the yield at apyBps.
+  apyRangeBps: [100, 900]
+  apyStepBlocks: 10
+  # The queue finalizes at most this much per block, so the wait covers what is queued ahead of you
+  # plus your own size draining. This is what makes a large exit expensive in time as well as in
+  # price, and what makes a busy queue worth watching. 0 keeps the deploy default (1 WETH/block);
+  # observation reports the effective wait as estimatedQueueDelayBlocks.
+  queueThroughputWeiPerBlock: "1000000000000000000"
+
+# A staking penalty placed by the same seed-driven schedule as spike/crash (ADR 0009 style, ranges
+# rather than values). It lands on a single block and permanently lowers the redemption rate.
+#
+# Two things about it, both measured:
+#
+#   - It does not open a discount. The pool reads the vault's rate as its oracle, so the market
+#     reprices with the cut instead of lagging it. That is the rate oracle working, not a bug: what
+#     a slash creates is a *loss for whoever is holding*, not an arbitrage for whoever is watching.
+#   - So the magnitude has to be read against the yield, not against a price crash. On this clock a
+#     70-block run earns roughly 3-8bps, so 10-30bps below is "a slash costs you a few runs' worth
+#     of yield" — a real reason to weigh staking against holding WETH. The 100-300bps first tried
+#     dwarfed the yield by 15x and simply made staking a losing move on every seed.
+stress:
+  events:
+    - { type: lstSlash, magnitudeRange: [0.001, 0.003], windowFrac: [0.3, 0.5] }
 
 flow:
   uninformedMaxWethWei: "1000000000000000000"

--- a/config/regimes/lst-01.yaml
+++ b/config/regimes/lst-01.yaml
@@ -1,0 +1,81 @@
+# config/regimes/lst-01.yaml — official regime: the liquid staking venue (issue #38). ADR 0016 §2
+#
+# regime = this file (market conditions) + seed. Same discipline as calm-01/crash-01: ranges rather
+# than values, blockTimeSec fixed to the production value, and the published seed is one sample of
+# many (the production run uses a different one).
+# Run: npm run backtest -- --regime lst-01 [--agents <roster>] [--repeat N]
+#
+# What this regime tests that the others do not: an asset with two prices at once. The vault owes
+# `redemptionRateWeth` per share but only through a withdrawal queue; the LST/WETH pool pays
+# `marketPriceWeth` immediately at whatever discount it trades. Scoring marks the position at what
+# it could realize, so an exit the run does not have time to finish is worth what the pool would
+# pay for it, not par.
+#
+# Funding note: this venue is WETH-denominated and cannot be traded from a USDC-only wallet, so
+# unlike calm-01 this regime hands out WETH. That reintroduces price drift into netPnlUsdc — read
+# alphaUsdc, and read scores within a run rather than across price paths.
+
+run:
+  seed: 301
+  blocks: 60
+  seconds: 600 # end by block count (set well above blocks x blockTimeSec)
+  blockTimeSec: 2 # fixed to the regime (ADR 0016 §2)
+  # aave is included so the phase 3 layer (LST as collateral, leveraged staking) is reachable;
+  # gmx is left out to keep the run short.
+  protocols: [uniswap, balancer, curve, aave, lst]
+  economicGas: false
+  localDeploy: true # backtest runs on a local anvil loaded with the distributed state
+  reportDir: ./runs
+
+funding:
+  wethWei: "20000000000000000000" # 20 WETH: the venue is WETH-denominated
+  usdcUnits: "25000000000"
+
+limits:
+  agentWethWei: "1000000000000000000"
+  agentUsdcUnits: "5000000000"
+
+# Phase 2 is what keeps "stake everything at block 0" from being the answer: the yield moves, the
+# queue congests, and a slash can cut the redemption rate mid-run. See config/lst.yaml for the
+# reasoning behind each number.
+lst:
+  simulatedSecondsPerBlock: 3600
+  apyBps: 300
+  withdrawalDelayBlocks: 20
+  maxDepositWethWei: "5000000000000000000"
+  apyRangeBps: [100, 900]
+  apyStepBlocks: 10
+  queueThroughputWeiPerBlock: "1000000000000000000"
+
+stress:
+  events:
+    - { type: lstSlash, magnitudeRange: [0.001, 0.003], windowFrac: [0.3, 0.5] }
+
+flow:
+  uninformedMaxWethWei: "1000000000000000000"
+  informedMaxWethWei: "2000000000000000000"
+  balancerMaxWethWei: "1000000000000000000"
+  curveMaxWethWei: "1000000000000000000"
+  informedArbFeeBps: 30
+  uninformedArrivalRate: "0.9"
+  uninformedSizeSigma: "1.0"
+  # No LST flow bot yet, so the secondary market moves only when agents trade it: from an at-par
+  # start the discount stays near zero and the carry path does not fire. That is phase 2's
+  # remaining gap, not a property of this regime.
+
+agents:
+  - id: noop
+    wallet: AGENT1_PRIVATE_KEY
+    baseline: true
+    description: does nothing (baseline)
+  - id: lst-carry
+    wallet: AGENT2_PRIVATE_KEY
+    description: liquid staking — stake for yield, or trade the redemption/market gap
+  - id: lst-carry-levered
+    dir: lst-carry
+    wallet: AGENT3_PRIVATE_KEY
+    description: the same strategy with the phase 3 leverage loop switched on
+    env: { ERIS_LST_LEVERAGE_TARGET_HF: "2.0" }
+  - id: venue-arb
+    wallet: AGENT4_PRIVATE_KEY
+    description: WETH-only cross-venue arbitrage (keeps the AMM venues honest)

--- a/core/src/backtest/shared.ts
+++ b/core/src/backtest/shared.ts
@@ -196,6 +196,7 @@ const VENUE_TO_DEPLOYMENT_KEY: Record<string, string> = {
   curve: "curve",
   gmx: "gmxV2",
   aave: "aaveV3",
+  lst: "lst",
 };
 
 // Whether the venues the regime requires are all present in the state dump (deployments bundled in

--- a/core/src/realtime/agentProcess.ts
+++ b/core/src/realtime/agentProcess.ts
@@ -92,19 +92,38 @@ export class RealtimeAgentProcess {
       this.stderr += data.toString();
       if (this.stderr.length > 20_000) this.stderr = this.stderr.slice(-20_000);
     });
-    this.child.on("error", () => {
+    this.child.on("error", (error) => {
       this.alive = false;
+      this.onExit?.({ reason: `spawn error: ${error.message}` });
     });
-    this.child.on("exit", () => {
+    this.child.on("exit", (code, signal) => {
+      const wasAlive = this.alive;
       this.alive = false;
+      // Only interesting if it went on its own. close() kills every agent at the end of the run,
+      // and that is not news.
+      if (wasAlive && !this.stopped) {
+        this.onExit?.({
+          code: code ?? undefined,
+          signal: signal ?? undefined,
+          reason: "exited before the run ended",
+        });
+      }
     });
   }
+
+  /// Notified when the process dies on its own. Without this an agent that crashes mid-run just
+  /// stops trading, and the run looks like one where it chose not to act -- indistinguishable in
+  /// summary.json, and the difference is the whole result.
+  onExit?: (info: { code?: number; signal?: string; reason: string }) => void;
+
+  private stopped = false;
 
   isAlive(): boolean {
     return this.alive && !this.child.killed;
   }
 
   close(): void {
+    this.stopped = true;
     this.child.kill();
   }
 

--- a/core/src/realtime/agentProcess.ts
+++ b/core/src/realtime/agentProcess.ts
@@ -28,6 +28,11 @@ export class RealtimeAgentProcess {
     runDir: string,
     direct: DirectAccess,
     agentsDir: string,
+    // The run's block budget as the environment resolved it. Passed explicitly because the child
+    // rebuilds its config from the YAML and would otherwise miss a CLI --blocks override: an agent
+    // that thinks the run is longer than it is will start exits it cannot finish (issue #38's
+    // withdrawal queue makes that a scoring loss, not just a missed trade).
+    runBlocks: number,
     // Extra env the environment injects into all agents (e.g. ADR 0009 stress victim addresses).
     // If spec.env specifies a value it takes precedence (extraEnv acts as the default).
     extraEnv?: Record<string, string>,
@@ -55,6 +60,7 @@ export class RealtimeAgentProcess {
     childEnv.ERIS_AGENT_PRIVATE_KEY = direct.privateKey;
     childEnv.ERIS_PRICE_FEED_ADDRESS = direct.priceFeedAddress;
     childEnv.ERIS_RUN_ID = direct.runId;
+    if (runBlocks > 0) childEnv.ERIS_RUN_BLOCKS = String(runBlocks);
 
     let command: string;
     let args: string[];

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -638,6 +638,24 @@ export async function runRealtimeSimulation(
         config.runBlocks,
         agentExtraEnv,
       );
+      // An agent that dies mid-run silently stops trading, which reads in summary.json exactly like
+      // an agent that chose not to trade. Record it so the two can be told apart.
+      const runtime = agent;
+      const child = agent.process;
+      if (!child) continue;
+      child.onExit = (info) => {
+        logger.event({
+          type: "agent_process_exited",
+          agentId: runtime.id,
+          ...info,
+          stderrTail: child.getStderr().slice(-2000),
+        });
+        console.error(
+          `[agent] ${runtime.id} ${info.reason}` +
+            (info.code !== undefined ? ` (code ${info.code})` : "") +
+            (info.signal ? ` (signal ${info.signal})` : ""),
+        );
+      };
     }
 
     // ---- flow order handler: relay the bot's orders to the mempool via the flow wallets ----

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -75,6 +75,8 @@ import {
   STARTUP_WARN_BPS,
 } from "./noArb.js";
 import { EventSchedule } from "./events.js";
+import { accrueLst, lstBlockEvent, setupLst, type LstRuntime } from "./lst.js";
+import type { LstState } from "@eris/sdk/protocols/lst.js";
 import { VulnSchedule } from "./vulnEvents.js";
 import {
   deployVulnPools,
@@ -580,6 +582,14 @@ export async function runRealtimeSimulation(
       logger.event({ type: "prewarm_completed", blocks: config.prewarmBlocks });
     }
 
+    // ---- LST venue (issue #38): align the deployed vault with this run's economic clock, and
+    // refuse to start on a secondary market that is not tracking the redemption rate (an unwired
+    // rate oracle would hand every agent the same risk-free arb). Must happen before interval
+    // mining starts, since the reconfiguration is a mined setup tx.
+    const lstRuntime: LstRuntime | null = enabledIds.includes("lst")
+      ? await setupLst(ctx, logger)
+      : null;
+
     // ---- cross-venue no-arbitrage check at startup (phantom-spread guard; see noArb.ts) ----
     // Calibrated pools must not offer a positive *executable* cross-venue round trip. Fail fast on
     // gross breakage (mis-deploy) before agent processes launch; smaller positives are warned and
@@ -618,6 +628,7 @@ export async function runRealtimeSimulation(
         logger.runDir,
         { privateKey: agent.privateKey, priceFeedAddress, runId },
         config.agentsDir,
+        config.runBlocks,
         agentExtraEnv,
       );
     }
@@ -924,6 +935,34 @@ export async function runRealtimeSimulation(
           //   storage write (no tx → no front-run target). GMX is not front-run-relevant because the keeper does not
           //   execute in realtime, so avoid direct mapping-storage writes and keep it a normal-fee mempool tx (undecided).
           // 0010: put PriceFeed/oracle on the next block as fee-topping mempool txs.
+          // LST venue (issue #38): advance the vault's economic clock one block. Accrual is
+          // permissionless and its size is a pure function of blocks elapsed, so this only keeps
+          // the observable rate current -- it grants the environment nothing an agent could not do
+          // itself. It rides inside oracleTask rather than as its own parallel task because it
+          // sends from the same admin key: two concurrent senders race on the nonce, and anvil
+          // rejects the loser as "replacement transaction underpriced" (seen in a live run, which
+          // left the redemption rate frozen for the whole run).
+          const accrueLstTask = async (): Promise<void> => {
+            if (!lstRuntime) return;
+            try {
+              const hash = await accrueLst(ctx, lstRuntime, {
+                priorityFeeWei: oracleFee,
+              });
+              submittedByHash.set(hash.toLowerCase(), {
+                ownerId: "oracle",
+                role: "system",
+                priorityFeeWei: oracleFee,
+                actionType: "lstAccrue",
+              });
+            } catch (error) {
+              logger.event({
+                type: "lst_accrual_failed",
+                blockNumber: bn,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          };
+
           const oracleTask = async (): Promise<void> => {
             try {
               if (economicGas) {
@@ -949,6 +988,7 @@ export async function runRealtimeSimulation(
                     BigInt(bn),
                   );
                 }
+                await accrueLstTask();
                 return;
               }
               const feedHash = await updatePriceFeedMempool(
@@ -991,6 +1031,7 @@ export async function runRealtimeSimulation(
                   actionType: "oracleUpdate",
                 });
               }
+              await accrueLstTask();
             } catch (error) {
               logger.event({
                 type: "oracle_update_failed",
@@ -1024,6 +1065,11 @@ export async function runRealtimeSimulation(
                 consecutiveBlocks: w.consecutiveBlocks,
               });
             }
+            // LST telemetry rides on the state the loop already read: how far the market sits from
+            // redemption, and whether the reward reserve is running dry. The primary post-run
+            // source for whether the venue behaved (issue #38).
+            const lstState = stateById.get("lst") as LstState | undefined;
+            if (lstState) logger.event(lstBlockEvent(lstState, bn));
             const uni = stateById.get("uniswap") as
               { priceUsdcPerWeth?: number } | undefined;
             latestHistory.push({
@@ -1174,6 +1220,9 @@ export async function runRealtimeSimulation(
     };
     // agent -> α (β-removed PnL versus fair at execution; ADR 0015 Notes / equivalent to the amm-challenge edge).
     let alphaByAgent: Record<string, number> = {};
+    // agent -> realizable value at the last cross-section, where it differs from the mark
+    // (issue #38: an LST redemption still in the queue when the run ends).
+    let liquidatableValueByAgent: Record<string, number> = {};
     if (finalBlock >= runStartBlock) {
       try {
         const meta = await reconstructValueSeries({
@@ -1188,6 +1237,7 @@ export async function runRealtimeSimulation(
         });
         valueSeries = meta;
         alphaByAgent = meta.alphaByAgent;
+        liquidatableValueByAgent = meta.liquidatableValueByAgent;
         logger.event({ type: "value_series_reconstructed", ...meta });
       } catch (err) {
         // The reconstruction refuses a cross-section it cannot read rather than emitting a cliff in
@@ -1249,6 +1299,13 @@ export async function runRealtimeSimulation(
         // comparison. undefined when reconstruction did not run (finalBlock<runStartBlock).
         ...(agent.id in alphaByAgent
           ? { alphaUsdc: alphaByAgent[agent.id] }
+          : {}),
+        // What the position could actually be exited for at the run's last block, when the
+        // reconstruction found that it differs from the mark at that same cross-section (issue
+        // #38: an LST redemption whose queue outlives the run). Absent for every venue that exits
+        // at par, which is all of them today.
+        ...(agent.id in liquidatableValueByAgent
+          ? { liquidatableValueUsdc: liquidatableValueByAgent[agent.id] }
           : {}),
         // submission count's primary source is the agent's self-reported log (agents/<id>.jsonl) (ADR 0006 §5)
         includedTxCount: agent.included,

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -933,9 +933,12 @@ export async function runRealtimeSimulation(
           // the redemption rate an agent observes this block already reflects it — and so the gap
           // it opens against the (not yet repriced) market is the opportunity the event creates.
           if (lstRuntime) {
-            for (const ev of schedule.pointEventsAt(blockIndex)) {
+            // The caught-up range, not just this index: onBlock skips notifications while it is
+            // busy, and matching one index exactly let a dropped block swallow the whole event.
+            const fromIndex = Math.max(0, fromBlock - runStartBlock);
+            for (const ev of schedule.pointEventsAt(fromIndex, blockIndex)) {
               try {
-                await slashLst(ctx, lstRuntime, ev.magnitude, logger);
+                await slashLst(ctx, lstRuntime, ev.magnitude, logger, oracleFee);
               } catch (error) {
                 logger.event({
                   type: "lst_slash_failed",

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -75,7 +75,14 @@ import {
   STARTUP_WARN_BPS,
 } from "./noArb.js";
 import { EventSchedule } from "./events.js";
-import { accrueLst, lstBlockEvent, setupLst, type LstRuntime } from "./lst.js";
+import {
+  accrueLst,
+  lstBlockEvent,
+  setupLst,
+  slashLst,
+  stepLstApy,
+  type LstRuntime,
+} from "./lst.js";
 import type { LstState } from "@eris/sdk/protocols/lst.js";
 import { VulnSchedule } from "./vulnEvents.js";
 import {
@@ -903,6 +910,24 @@ export async function runRealtimeSimulation(
             }
           }
 
+          // LST slashing (issue #38 phase 2): a one-shot staking penalty placed by the same
+          // seed-driven schedule as spike/crash. Applied here, before the block's other work, so
+          // the redemption rate an agent observes this block already reflects it — and so the gap
+          // it opens against the (not yet repriced) market is the opportunity the event creates.
+          if (lstRuntime) {
+            for (const ev of schedule.pointEventsAt(blockIndex)) {
+              try {
+                await slashLst(ctx, lstRuntime, ev.magnitude, logger);
+              } catch (error) {
+                logger.event({
+                  type: "lst_slash_failed",
+                  blockIndex,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            }
+          }
+
           // keeper / oracle write / state+flow are mutually independent (separate wallets too), so run them in
           // parallel. tx recording (blocks.csv) is removed from the loop and scanned in bulk after the run (see logBlock).
 
@@ -954,6 +979,20 @@ export async function runRealtimeSimulation(
                 priorityFeeWei: oracleFee,
                 actionType: "lstAccrue",
               });
+              // Phase 2: resample the yield on its own cadence. Sent from the same key, so it is
+              // sequential with the accrual above rather than racing it on the nonce.
+              const apyBps = await stepLstApy(
+                ctx,
+                lstRuntime,
+                blockIndex,
+                oracleFee,
+              );
+              if (apyBps !== null)
+                logger.event({
+                  type: "lst_apy_changed",
+                  blockNumber: bn,
+                  apyBps,
+                });
             } catch (error) {
               logger.event({
                 type: "lst_accrual_failed",

--- a/core/src/realtime/events.ts
+++ b/core/src/realtime/events.ts
@@ -142,11 +142,20 @@ export class EventSchedule {
 
   // The overlay at this blockIndex. Overlapping events compose their multipliers multiplicatively
   // (if non-overlapping, each event appears as-is).
-  // Events that land exactly on this blockIndex and are applied once rather than as an overlay
-  // (currently the LST slash). The coordinator executes them; the price path never sees them.
-  pointEventsAt(blockIndex: number): ResolvedStressEvent[] {
+  // Events applied once rather than as an overlay (currently the LST slash), for every index in
+  // the caught-up range fromIndex..toIndex.
+  //
+  // A range rather than a single index because the coordinator skips block notifications while it
+  // is still processing the previous one (`if (processing) return`), and every other consumer here
+  // already compensates the same way (keeperTask, vulnTask, logBlock all take fromBlock..toBlock).
+  // Matching one index exactly meant a dropped block silently swallowed the whole stress axis: the
+  // run logged its schedule and then never slashed.
+  pointEventsAt(fromIndex: number, toIndex = fromIndex): ResolvedStressEvent[] {
     return this.events.filter(
-      (ev) => ev.type === "lstSlash" && ev.startBlock === blockIndex,
+      (ev) =>
+        ev.type === "lstSlash" &&
+        ev.startBlock >= fromIndex &&
+        ev.startBlock <= toIndex,
     );
   }
 
@@ -207,8 +216,11 @@ function parseOne(raw: unknown, i: number): StressEventConfig {
     {
       min: 0,
       exclusiveMin: true,
-      // A slash is a fraction of the pool; anything at or above 1 would wipe it out.
-      ...(o.type === "lstSlash" ? { max: 1 } : {}),
+      // A slash is a fraction of the pool, and wiping it out entirely is not a stress event: at
+      // 100% totalPooledWeth hits zero, convertToAssets falls back to its 1:1 branch, the pool's
+      // rate oracle snaps back to par, and every staker is silently erased while the discount
+      // reads 0. Exclusive, matching the sentence above it.
+      ...(o.type === "lstSlash" ? { max: 1, exclusiveMax: true } : {}),
     },
   );
   const windowFrac = parseRange(o.windowFrac, `${label}.windowFrac`, {
@@ -248,7 +260,12 @@ function parseOne(raw: unknown, i: number): StressEventConfig {
 function parseRange(
   value: unknown,
   label: string,
-  bounds: { min?: number; max?: number; exclusiveMin?: boolean },
+  bounds: {
+    min?: number;
+    max?: number;
+    exclusiveMin?: boolean;
+    exclusiveMax?: boolean;
+  },
 ): [number, number] {
   if (
     !Array.isArray(value) ||
@@ -263,8 +280,12 @@ function parseRange(
     if (bounds.exclusiveMin ? lo <= bounds.min : lo < bounds.min)
       throw new Error(`${label} min must be >= ${bounds.min}`);
   }
-  if (bounds.max !== undefined && hi > bounds.max)
-    throw new Error(`${label} max must be <= ${bounds.max}`);
+  if (bounds.max !== undefined) {
+    if (bounds.exclusiveMax ? hi >= bounds.max : hi > bounds.max)
+      throw new Error(
+        `${label} max must be ${bounds.exclusiveMax ? "<" : "<="} ${bounds.max}`,
+      );
+  }
   return [lo, hi];
 }
 

--- a/core/src/realtime/events.ts
+++ b/core/src/realtime/events.ts
@@ -18,7 +18,12 @@
 import { Rng } from "@eris/sdk/rng.js";
 import type { TokenSymbol } from "@eris/sdk/types.js";
 
-export type StressEventType = "spike" | "crash";
+// spike / crash distort a base's price through the overlay. lstSlash is different in kind: it is a
+// one-shot staking penalty applied to the LST vault (issue #38 phase 2), so it carries no price
+// multiplier and no trapezoid -- it happens on a single block and the exchange rate is permanently
+// lower afterwards. It shares this config section because it is the same thing from a run's point
+// of view: a seed-placed shock the agents have to survive.
+export type StressEventType = "spike" | "crash" | "lstSlash";
 
 // Event spec given via env (ERIS_STRESS_EVENTS). Ranges are given, not values.
 export type StressEventConfig = {
@@ -26,14 +31,19 @@ export type StressEventConfig = {
   // ADR 0013: the base the event targets (default WETH). Lets crash/spike apply to WBTC etc.
   base?: TokenSymbol;
   // Deviation width of the price multiplier. spike acts as +, crash as −. The seed picks from [min,max].
+  // For lstSlash this is the fraction of the staking pool burnt (0.02 = a 2% slash).
   magnitudeRange: [number, number];
   // Fraction of run length for the event start position [min,max]. The seed picks.
   windowFrac: [number, number];
-  // Length of each trapezoid segment (block count; fixed).
+  // Length of each trapezoid segment (block count; fixed). Not applicable to lstSlash, which is
+  // instantaneous, so they default to 0 there.
   rampBlocks: number;
   holdBlocks: number;
   decayBlocks: number;
 };
+
+// A slash is instantaneous, so its window is the single block it lands on.
+const POINT_EVENT_SPAN = 1;
 
 // Event resolved by the seed (blockIndex is 0-based from runStart).
 export type ResolvedStressEvent = {
@@ -95,7 +105,10 @@ export class EventSchedule {
         rng.next(),
       );
       const startFrac = lerp(c.windowFrac[0], c.windowFrac[1], rng.next());
-      const span = c.rampBlocks + c.holdBlocks + c.decayBlocks;
+      const span =
+        c.type === "lstSlash"
+          ? POINT_EVENT_SPAN
+          : c.rampBlocks + c.holdBlocks + c.decayBlocks;
       // Clamp startBlock so the window fits inside the run window (scoring history depth; event window ⊂ run window).
       const maxStart = Math.max(0, runBlocks - span);
       const startBlock = Math.max(
@@ -129,9 +142,18 @@ export class EventSchedule {
 
   // The overlay at this blockIndex. Overlapping events compose their multipliers multiplicatively
   // (if non-overlapping, each event appears as-is).
+  // Events that land exactly on this blockIndex and are applied once rather than as an overlay
+  // (currently the LST slash). The coordinator executes them; the price path never sees them.
+  pointEventsAt(blockIndex: number): ResolvedStressEvent[] {
+    return this.events.filter(
+      (ev) => ev.type === "lstSlash" && ev.startBlock === blockIndex,
+    );
+  }
+
   at(blockIndex: number): OverlayState {
     const baseMults: Record<string, number> = {};
     for (const ev of this.events) {
+      if (ev.type === "lstSlash") continue; // not a price distortion
       const e = envelope(ev, blockIndex);
       if (e === 0) continue;
       const sign = ev.type === "crash" ? -1 : 1;
@@ -173,8 +195,8 @@ function parseOne(raw: unknown, i: number): StressEventConfig {
     throw new Error(`${label} must be an object`);
   }
   const o = raw as Record<string, unknown>;
-  if (o.type !== "spike" && o.type !== "crash") {
-    throw new Error(`${label}.type must be "spike" or "crash"`);
+  if (o.type !== "spike" && o.type !== "crash" && o.type !== "lstSlash") {
+    throw new Error(`${label}.type must be "spike", "crash" or "lstSlash"`);
   }
   if (o.base !== undefined && typeof o.base !== "string") {
     throw new Error(`${label}.base must be a token symbol string`);
@@ -185,16 +207,29 @@ function parseOne(raw: unknown, i: number): StressEventConfig {
     {
       min: 0,
       exclusiveMin: true,
+      // A slash is a fraction of the pool; anything at or above 1 would wipe it out.
+      ...(o.type === "lstSlash" ? { max: 1 } : {}),
     },
   );
   const windowFrac = parseRange(o.windowFrac, `${label}.windowFrac`, {
     min: 0,
     max: 1,
   });
-  const rampBlocks = parseNonNegInt(o.rampBlocks, `${label}.rampBlocks`);
-  const holdBlocks = parseNonNegInt(o.holdBlocks, `${label}.holdBlocks`);
-  const decayBlocks = parseNonNegInt(o.decayBlocks, `${label}.decayBlocks`);
-  if (rampBlocks + holdBlocks + decayBlocks <= 0) {
+  // A slash lands on one block, so the trapezoid fields do not apply and are optional there.
+  const isPoint = o.type === "lstSlash";
+  const rampBlocks = parseNonNegInt(
+    isPoint ? (o.rampBlocks ?? 0) : o.rampBlocks,
+    `${label}.rampBlocks`,
+  );
+  const holdBlocks = parseNonNegInt(
+    isPoint ? (o.holdBlocks ?? 0) : o.holdBlocks,
+    `${label}.holdBlocks`,
+  );
+  const decayBlocks = parseNonNegInt(
+    isPoint ? (o.decayBlocks ?? 0) : o.decayBlocks,
+    `${label}.decayBlocks`,
+  );
+  if (!isPoint && rampBlocks + holdBlocks + decayBlocks <= 0) {
     throw new Error(
       `${label} must have a positive total window (ramp+hold+decay)`,
     );

--- a/core/src/realtime/lst.ts
+++ b/core/src/realtime/lst.ts
@@ -1,0 +1,197 @@
+// LST venue: the environment's side of the clock (issue #38).
+//
+// Yield does not come from EVM time. Warping time would also move Aave's rate accrual and GMX
+// funding, so the vault runs on its own compressed *economic* clock instead: one block stands for
+// `lst.simulatedSecondsPerBlock` seconds of staking, and the target APY is deliberately the same
+// order as Aave's WETH supply rate -- a 1000x-speed LST would make every other venue irrelevant.
+//
+// Everything else about the venue is deployed (the vault and its pool are baked into the ADR 0016
+// state dump for backtest fingerprinting). Only the per-block accrual and the phase-2 slash belong
+// to the coordinator, which is all this file does.
+import { encodeFunctionData, type Address, type Hex } from "viem";
+import { lstVaultAbi } from "@eris/sdk/abis.js";
+import { accountAddress, sendAndMine, sendNoMine } from "@eris/sdk/chain.js";
+import { LST } from "@eris/sdk/constants.js";
+import { getLstState, rewardRatePerBlockRay } from "@eris/sdk/protocols/lst.js";
+import type { SimContext } from "@eris/sdk/protocols/types.js";
+import type { RunLogger } from "../logger.js";
+
+// accrueRewards touches a handful of slots. Pinning the gas skips viem's eth_estimateGas (an extra
+// EVM execution) on a tx the environment sends every block.
+const ACCRUE_GAS = 200_000n;
+
+// A discount this large right after setup means the pool is not tracking the vault's redemption
+// rate -- almost always an unwired rate oracle, which hands every agent the same risk-free arb
+// (a beta-style freebie that destroys discrimination, ADR 0007). Calibration noise is far smaller.
+export const LST_STARTUP_WARN_BPS = 25;
+export const LST_STARTUP_FAIL_BPS = 200;
+
+export type LstRuntime = {
+  vault: Address;
+  // Whether the environment's admin key can reconfigure the vault. Without it the run inherits the
+  // rate baked in at deploy time, which is legitimate -- it just cannot be retuned per run.
+  canConfigure: boolean;
+  rewardRatePerBlockRay: bigint;
+};
+
+/// Align the deployed vault with this run's economic clock, and refuse to start on a market that
+/// is not tracking the redemption rate.
+export async function setupLst(
+  ctx: SimContext,
+  logger: RunLogger,
+): Promise<LstRuntime | null> {
+  if (!LST) {
+    throw new Error(
+      "the lst protocol is enabled but no LST deployment is available: the venue exists only " +
+        "under local deploy (issue #38). Enable run.localDeploy with a state dump that includes lst, or drop lst from run.protocols.",
+    );
+  }
+  const admin = accountAddress(ctx.adminPk);
+  const canConfigure = (await ctx.publicClient.readContract({
+    address: LST.vault,
+    abi: lstVaultAbi,
+    functionName: "operators",
+    args: [admin],
+  })) as boolean;
+
+  const targetRate = rewardRatePerBlockRay(
+    ctx.config.lstApyBps,
+    ctx.config.lstSimulatedSecondsPerBlock,
+  );
+  if (canConfigure) {
+    await sendAndMine(
+      ctx.publicClient,
+      ctx.walletClient,
+      ctx.chain,
+      ctx.adminPk,
+      {
+        to: LST.vault,
+        data: encodeCall("setRewardRate", [targetRate]),
+      },
+    );
+    if (ctx.config.lstWithdrawalDelayBlocks > 0) {
+      await sendAndMine(
+        ctx.publicClient,
+        ctx.walletClient,
+        ctx.chain,
+        ctx.adminPk,
+        {
+          to: LST.vault,
+          data: encodeCall("setWithdrawalDelayBlocks", [
+            BigInt(ctx.config.lstWithdrawalDelayBlocks),
+          ]),
+        },
+      );
+    }
+  }
+
+  const state = await getLstState(ctx);
+  logger.event({
+    type: "lst_setup",
+    vault: LST.vault,
+    pool: LST.pool,
+    configured: canConfigure,
+    // What the run asked for versus what the vault is actually running, so an inherited rate is
+    // visible rather than silently different from the config.
+    requestedApyBps: ctx.config.lstApyBps,
+    effectiveApyBps: state.apyBps,
+    simulatedSecondsPerBlock: ctx.config.lstSimulatedSecondsPerBlock,
+    withdrawalDelayBlocks: state.withdrawalDelayBlocks,
+    rewardReserveWei: state.rewardReserveWei.toString(),
+    redemptionRateWeth: state.redemptionRateWeth,
+    marketPriceWeth: state.midPriceWeth,
+    discountBps: state.discountBps,
+  });
+  if (!canConfigure) {
+    console.warn(
+      `[lst] the admin key is not a vault operator, so this run inherits the deployed rate ` +
+        `(${state.apyBps.toFixed(1)}bps APY) instead of the configured ${ctx.config.lstApyBps}bps`,
+    );
+  }
+
+  // Fail fast on a market that does not track redemption. |discount| is used rather than the
+  // signed value: a large premium is the same breakage seen from the other side.
+  const absDiscount = Math.abs(state.discountBps);
+  if (absDiscount > LST_STARTUP_FAIL_BPS) {
+    throw new Error(
+      `lst no-arbitrage check failed at startup: the LST/WETH market sits ${state.discountBps.toFixed(1)}bps ` +
+        `off the vault's redemption rate (limit ${LST_STARTUP_FAIL_BPS}bps). The usual cause is the pool's ` +
+        "rate oracle not being wired to stEthPerToken, which leaves a permanent risk-free arb for everyone.",
+    );
+  }
+  if (absDiscount > LST_STARTUP_WARN_BPS) {
+    console.warn(
+      `[lst] the LST/WETH market opens ${state.discountBps.toFixed(1)}bps off redemption ` +
+        `(warn above ${LST_STARTUP_WARN_BPS}bps)`,
+    );
+  }
+
+  if (state.rewardReserveWei === 0n) {
+    logger.event({
+      type: "lst_reward_reserve_empty",
+      note: "the vault has no funded rewards left, so the redemption rate will not rise this run",
+    });
+  }
+
+  return {
+    vault: LST.vault,
+    canConfigure,
+    rewardRatePerBlockRay: targetRate,
+  };
+}
+
+/// Advance the vault's clock one block. Accrual is permissionless and its size is a pure function
+/// of blocks elapsed, so this only keeps the on-chain rate current -- it grants the environment
+/// nothing an agent could not do itself.
+export async function accrueLst(
+  ctx: SimContext,
+  runtime: LstRuntime,
+  opts: { priorityFeeWei: bigint },
+): Promise<Hex> {
+  return sendNoMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: runtime.vault,
+      data: encodeCall("accrueRewards", []),
+      gas: ACCRUE_GAS,
+    },
+    opts.priorityFeeWei,
+  );
+}
+
+// The vault also exposes `slash`, gated to the same operator. Nothing calls it yet: a slashing
+// event belongs to the stress overlay, which is phase 2 of issue #38. It lives in the contract
+// rather than waiting for that phase because the vault is baked into the state dump, and adding a
+// function later would mean rebuilding the dump.
+
+/// Per-block telemetry: how far the market is from redemption, and whether the reserve is running
+/// out. Cheap (one readState the coordinator already needs) and the primary post-run source for
+/// whether the venue behaved.
+export function lstBlockEvent(
+  state: Awaited<ReturnType<typeof getLstState>>,
+  blockNumber: number,
+): Record<string, unknown> {
+  return {
+    type: "lst_block",
+    blockNumber,
+    redemptionRateWeth: state.redemptionRateWeth,
+    marketPriceWeth: state.midPriceWeth,
+    discountBps: state.discountBps,
+    queueLength: state.queueLength,
+    rewardReserveWei: state.rewardReserveWei.toString(),
+  };
+}
+
+function encodeCall(
+  functionName: "setRewardRate" | "setWithdrawalDelayBlocks" | "accrueRewards",
+  args: readonly unknown[],
+): Hex {
+  return encodeFunctionData({
+    abi: lstVaultAbi,
+    functionName,
+    args: args as never,
+  });
+}

--- a/core/src/realtime/lst.ts
+++ b/core/src/realtime/lst.ts
@@ -14,11 +14,16 @@ import { accountAddress, sendAndMine, sendNoMine } from "@eris/sdk/chain.js";
 import { LST } from "@eris/sdk/constants.js";
 import { getLstState, rewardRatePerBlockRay } from "@eris/sdk/protocols/lst.js";
 import type { SimContext } from "@eris/sdk/protocols/types.js";
+import { Rng } from "@eris/sdk/rng.js";
 import type { RunLogger } from "../logger.js";
 
 // accrueRewards touches a handful of slots. Pinning the gas skips viem's eth_estimateGas (an extra
 // EVM execution) on a tx the environment sends every block.
 const ACCRUE_GAS = 200_000n;
+
+// Salt for the APY Rng, so resampling the yield never disturbs the price path's or the flow's
+// consumption sequence (same discipline as the stress overlay's STRS salt).
+const LST_SEED_SALT = 0x4c_53_54_59; // "LSTY"
 
 // A discount this large right after setup means the pool is not tracking the vault's redemption
 // rate -- almost always an unwired rate oracle, which hands every agent the same risk-free arb
@@ -32,7 +37,48 @@ export type LstRuntime = {
   // rate baked in at deploy time, which is legitimate -- it just cannot be retuned per run.
   canConfigure: boolean;
   rewardRatePerBlockRay: bigint;
+  // Phase 2: the seed-derived APY path, if the run asked for a varying one.
+  apySchedule: ApySchedule | null;
 };
+
+/// Seed-driven APY variation (issue #38 phase 2).
+///
+/// A constant yield makes the venue trivial -- "stake everything at block 0" is optimal and stays
+/// optimal. Resampling it from a range on a fixed cadence means holding LST has a changing
+/// opportunity cost against the pool's discount, so the allocation is a decision rather than a
+/// setup step. Deterministic in the seed, from an Rng of its own so the price path is untouched.
+export class ApySchedule {
+  private readonly rng: Rng;
+  private readonly range: [number, number];
+  readonly stepBlocks: number;
+  private currentBps: number;
+
+  constructor(
+    seed: number,
+    range: [number, number],
+    stepBlocks: number,
+    initialBps: number,
+  ) {
+    this.rng = new Rng((seed ^ LST_SEED_SALT) >>> 0);
+    this.range = range;
+    this.stepBlocks = Math.max(1, stepBlocks);
+    this.currentBps = initialBps;
+  }
+
+  /// The APY for this block, or null when it has not changed and no write is needed.
+  nextAt(blockIndex: number): number | null {
+    if (blockIndex % this.stepBlocks !== 0) return null;
+    const [lo, hi] = this.range;
+    const sampled = Math.round(lo + (hi - lo) * this.rng.next());
+    if (sampled === this.currentBps) return null;
+    this.currentBps = sampled;
+    return sampled;
+  }
+
+  get apyBps(): number {
+    return this.currentBps;
+  }
+}
 
 /// Align the deployed vault with this run's economic clock, and refuse to start on a market that
 /// is not tracking the redemption rate.
@@ -83,6 +129,20 @@ export async function setupLst(
         },
       );
     }
+    if (ctx.config.lstQueueThroughputWeiPerBlock > 0n) {
+      await sendAndMine(
+        ctx.publicClient,
+        ctx.walletClient,
+        ctx.chain,
+        ctx.adminPk,
+        {
+          to: LST.vault,
+          data: encodeCall("setQueueThroughput", [
+            ctx.config.lstQueueThroughputWeiPerBlock,
+          ]),
+        },
+      );
+    }
   }
 
   const state = await getLstState(ctx);
@@ -101,6 +161,10 @@ export async function setupLst(
     redemptionRateWeth: state.redemptionRateWeth,
     marketPriceWeth: state.midPriceWeth,
     discountBps: state.discountBps,
+    // Phase 2 knobs, so a run's variation is visible in the log rather than only in its effects.
+    apyRangeBps: ctx.config.lstApyRangeBps,
+    apyStepBlocks: ctx.config.lstApyRangeBps ? ctx.config.lstApyStepBlocks : 0,
+    queueThroughputWeiPerBlock: state.queueThroughputWeiPerBlock.toString(),
   });
   if (!canConfigure) {
     console.warn(
@@ -133,11 +197,99 @@ export async function setupLst(
     });
   }
 
+  // Varying the yield needs operator rights (it is a setRewardRate per step). Without them the run
+  // keeps the deployed rate, which is a real limitation rather than a silent downgrade.
+  const apySchedule =
+    canConfigure && ctx.config.lstApyRangeBps
+      ? new ApySchedule(
+          ctx.config.seed,
+          ctx.config.lstApyRangeBps,
+          ctx.config.lstApyStepBlocks,
+          ctx.config.lstApyBps,
+        )
+      : null;
+  if (ctx.config.lstApyRangeBps && !canConfigure) {
+    console.warn(
+      "[lst] lst.apyRangeBps was set but the admin key is not a vault operator, so the yield stays fixed",
+    );
+  }
+
   return {
     vault: LST.vault,
     canConfigure,
     rewardRatePerBlockRay: targetRate,
+    apySchedule,
   };
+}
+
+/// Resample the APY for this block if the schedule says so (issue #38 phase 2). Returns the new
+/// value when it changed, so the caller can log it.
+export async function stepLstApy(
+  ctx: SimContext,
+  runtime: LstRuntime,
+  blockIndex: number,
+  priorityFeeWei: bigint,
+): Promise<number | null> {
+  const next = runtime.apySchedule?.nextAt(blockIndex);
+  if (next === null || next === undefined) return null;
+  const rate = rewardRatePerBlockRay(
+    next,
+    ctx.config.lstSimulatedSecondsPerBlock,
+  );
+  await sendNoMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: runtime.vault,
+      data: encodeCall("setRewardRate", [rate]),
+      gas: ACCRUE_GAS,
+    },
+    priorityFeeWei,
+  );
+  return next;
+}
+
+/// Apply a staking penalty (the stress overlay's lstSlash, issue #38 phase 2). The vault settles
+/// accrued rewards first, so the cut lands on the current pool rather than on a stale one.
+export async function slashLst(
+  ctx: SimContext,
+  runtime: LstRuntime,
+  magnitude: number,
+  logger: RunLogger,
+): Promise<void> {
+  const bps = BigInt(Math.round(magnitude * 10_000));
+  if (bps <= 0n) return;
+  if (!runtime.canConfigure) {
+    logger.event({
+      type: "lst_slash_skipped",
+      reason: "the admin key is not a vault operator",
+      bps: Number(bps),
+    });
+    return;
+  }
+  const before = await getLstState(ctx);
+  await sendAndMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: runtime.vault,
+      data: encodeCall("slash", [bps]),
+    },
+  );
+  const after = await getLstState(ctx);
+  logger.event({
+    type: "lst_slash",
+    bps: Number(bps),
+    redemptionRateBefore: before.redemptionRateWeth,
+    redemptionRateAfter: after.redemptionRateWeth,
+    // The market has not repriced yet: the gap this opens is the opportunity the event creates.
+    marketPriceWeth: after.midPriceWeth,
+    discountBps: after.discountBps,
+  });
 }
 
 /// Advance the vault's clock one block. Accrual is permissionless and its size is a pure function
@@ -186,7 +338,12 @@ export function lstBlockEvent(
 }
 
 function encodeCall(
-  functionName: "setRewardRate" | "setWithdrawalDelayBlocks" | "accrueRewards",
+  functionName:
+    | "setRewardRate"
+    | "setWithdrawalDelayBlocks"
+    | "setQueueThroughput"
+    | "accrueRewards"
+    | "slash",
   args: readonly unknown[],
 ): Hex {
   return encodeFunctionData({

--- a/core/src/realtime/lst.ts
+++ b/core/src/realtime/lst.ts
@@ -52,6 +52,7 @@ export class ApySchedule {
   private readonly range: [number, number];
   readonly stepBlocks: number;
   private currentBps: number;
+  private stepsTaken = 0;
 
   constructor(
     seed: number,
@@ -65,11 +66,23 @@ export class ApySchedule {
     this.currentBps = initialBps;
   }
 
-  /// The APY for this block, or null when it has not changed and no write is needed.
+  /// The APY as of `blockIndex`, or null when nothing changed and no write is needed.
+  ///
+  /// Driven by "how many steps should have happened by now" rather than by an exact modulo, because
+  /// the coordinator drops block notifications while it is busy. A missed index used to skip both
+  /// the resample *and* its Rng draw, so every later step drew a different value than the same
+  /// seed produced elsewhere -- destroying the reproducibility the salted Rng exists to give.
   nextAt(blockIndex: number): number | null {
-    if (blockIndex % this.stepBlocks !== 0) return null;
+    const dueSteps = Math.floor(blockIndex / this.stepBlocks) + 1;
+    if (dueSteps <= this.stepsTaken) return null;
     const [lo, hi] = this.range;
-    const sampled = Math.round(lo + (hi - lo) * this.rng.next());
+    let sampled = this.currentBps;
+    // Consume every draw the seed owes, so a dropped block costs a block of staleness and nothing
+    // more. The path stays a pure function of (seed, blockIndex).
+    while (this.stepsTaken < dueSteps) {
+      sampled = Math.round(lo + (hi - lo) * this.rng.next());
+      this.stepsTaken += 1;
+    }
     if (sampled === this.currentBps) return null;
     this.currentBps = sampled;
     return sampled;
@@ -174,7 +187,15 @@ export async function setupLst(
   }
 
   // Fail fast on a market that does not track redemption. |discount| is used rather than the
-  // signed value: a large premium is the same breakage seen from the other side.
+  // signed value: a large premium is the same breakage seen from the other side. A pool that did
+  // not quote at all is a different failure and gets its own message rather than being reported
+  // as a 10000bps oracle fault.
+  if (!state.marketQuoted) {
+    throw new Error(
+      "the LST/WETH pool did not quote at startup: it reverted or has no liquidity at probe size. " +
+        "Check that the deploy seeded it (deployer/src/protocols/lst.ts), or drop lst from run.protocols.",
+    );
+  }
   const absDiscount = Math.abs(state.discountBps);
   if (absDiscount > LST_STARTUP_FAIL_BPS) {
     throw new Error(
@@ -258,6 +279,7 @@ export async function slashLst(
   runtime: LstRuntime,
   magnitude: number,
   logger: RunLogger,
+  priorityFeeWei: bigint,
 ): Promise<void> {
   const bps = BigInt(Math.round(magnitude * 10_000));
   if (bps <= 0n) return;

--- a/core/src/realtime/reconstruct.ts
+++ b/core/src/realtime/reconstruct.ts
@@ -56,6 +56,10 @@ export type ReconstructionMeta = {
   alphaRefFairUsdcPerWeth: number;
   // agent -> α (= value at the fixed reference fair, toBlock − fromBlock; β-removed trade-derived PnL).
   alphaByAgent: Record<string, number>;
+  // agent -> realizable value at the run's last cross-section, for the agents where it differs
+  // from the mark (issue #38: a redemption still in the queue when the run ends). Absent entries
+  // mean the two agreed, which is the normal case.
+  liquidatableValueByAgent: Record<string, number>;
   // Holdings excluded from the value series because they could not be priced (issue #41) or could not
   // be read (issue #44).
   unpricedHoldings: UnpricedHolding[];
@@ -124,6 +128,11 @@ export type AgentValueSnapshot = {
   id: string;
   valueUsdc: number;
   alphaValueUsdc: number;
+  // What the agent could actually realize at this cross-section: free inventory plus each venue's
+  // exit value rather than its face mark. Equal to valueUsdc for every venue that exits at par,
+  // which is all of them except the LST queue (issue #38) -- so past runs compare unchanged, and
+  // the two only separate where a position genuinely cannot be liquidated for its mark.
+  liquidatableValueUsdc: number;
 };
 
 // A holding excluded from an agent's value: the scorer cannot price it, nothing sums it (issue #41),
@@ -206,6 +215,10 @@ export async function readValueSnapshotAtBlock(opts: {
   activeStables: Address[];
   priceFeed: Address;
   blockNumber: number;
+  // Last block of the run window. Venues whose exit takes time mark against it: an LST redemption
+  // queued at this cross-section is only worth par if it finalizes before the run ends (issue #38).
+  // Defaults to blockNumber, i.e. "nothing further is reachable" -- the conservative reading.
+  horizonBlock?: number;
   // Fixed reference fair for α evaluation (base symbol -> USD). If unspecified, α = total value.
   refFairByBase?: Record<string, number>;
 }): Promise<ValueSnapshot> {
@@ -302,6 +315,7 @@ export async function readValueSnapshotAtBlock(opts: {
   const ctx: ValuationContext = {
     publicClient,
     blockNumber: opts.blockNumber,
+    horizonBlock: opts.horizonBlock ?? opts.blockNumber,
     agents,
     activeStables,
     fairByBase: () => fairByBase,
@@ -396,12 +410,16 @@ export async function readValueSnapshotAtBlock(opts: {
     // Evaluate free inventory two ways: at live fair (β-inclusive) and at the fixed reference fair (β-removed).
     let total = valueUsdc(balance, fairByBase);
     let alphaTotal = valueUsdc(balance, refFairByBase);
+    // Free inventory is realizable by definition, so the liquidatable series starts from the same
+    // live mark and only the venues diverge.
+    let liquidatableTotal = valueUsdc(balance, fairByBase);
     // Protocol positions are a live mark in both evaluations (β removal applies to free inventory only).
     for (const [id, byAgent] of protocolValues) {
       const value = byAgent[agent.id];
       if (!value) continue;
       total += value.valueUsdc;
       alphaTotal += value.valueUsdc;
+      liquidatableTotal += value.liquidatableValueUsdc;
       for (const holding of value.unpriced) {
         unpriced.push({
           ...holding,
@@ -410,7 +428,12 @@ export async function readValueSnapshotAtBlock(opts: {
         });
       }
     }
-    values.push({ id: agent.id, valueUsdc: total, alphaValueUsdc: alphaTotal });
+    values.push({
+      id: agent.id,
+      valueUsdc: total,
+      alphaValueUsdc: alphaTotal,
+      liquidatableValueUsdc: liquidatableTotal,
+    });
   });
 
   return {
@@ -573,6 +596,7 @@ export async function reconstructValueSeries(opts: {
     activeStables,
     priceFeed,
     blockNumber: toBlock,
+    horizonBlock: toBlock,
   });
   failedReads += refSnapshot.failedReads;
   mergeFailedReads(failedReadTargets, refSnapshot.failedReadTargets);
@@ -588,6 +612,10 @@ export async function reconstructValueSeries(opts: {
 
   const alphaFirst = new Map<string, number>();
   const alphaLast = new Map<string, number>();
+  // Realizable value at the run's last cross-section, and the mark from that same cross-section to
+  // compare it against (issue #38). Reported alongside the mark rather than replacing it.
+  const liquidatableLast = new Map<string, number>();
+  const markedLast = new Map<string, number>();
   // Holdings the scorer could not price (issue #41) or could not read (issue #44). Deduplicated
   // across the run window (they persist block to block) and emitted once at the end, so a zero in
   // summary.json is never mistaken for a trading loss. amountRaw is the last one seen.
@@ -604,14 +632,22 @@ export async function reconstructValueSeries(opts: {
       activeStables,
       priceFeed,
       blockNumber: b,
+      horizonBlock: toBlock,
       refFairByBase,
     });
     failedReads += snapshot.failedReads;
     mergeFailedReads(failedReadTargets, snapshot.failedReadTargets);
     for (const h of snapshot.unpriced) unpriced.set(unpricedKey(h), h);
-    for (const { id, valueUsdc: total, alphaValueUsdc } of snapshot.values) {
+    for (const {
+      id,
+      valueUsdc: total,
+      alphaValueUsdc,
+      liquidatableValueUsdc,
+    } of snapshot.values) {
       if (!alphaFirst.has(id)) alphaFirst.set(id, alphaValueUsdc);
       alphaLast.set(id, alphaValueUsdc);
+      liquidatableLast.set(id, liquidatableValueUsdc);
+      markedLast.set(id, total);
       // The observation shape readPerRoundValues reads (inventory.valueUsdc = total value).
       // Do not include protocols (avoids double-counting perRoundValueUsdc). alphaValueUsdc is
       // the fixed-reference fair evaluation (β-removed) and can also be read as a per-round α series.
@@ -627,7 +663,14 @@ export async function reconstructValueSeries(opts: {
           ...(snapshot.poolPriceUsdcPerWeth !== null
             ? { poolPriceUsdcPerWeth: snapshot.poolPriceUsdcPerWeth }
             : {}),
-          inventory: { valueUsdc: total, alphaValueUsdc },
+          inventory: {
+            valueUsdc: total,
+            alphaValueUsdc,
+            // Only worth a field when it says something the mark does not.
+            ...(liquidatableValueUsdc !== total
+              ? { liquidatableValueUsdc }
+              : {}),
+          },
         },
       });
     }
@@ -636,6 +679,21 @@ export async function reconstructValueSeries(opts: {
   const alphaByAgent: Record<string, number> = {};
   for (const { id } of agents)
     alphaByAgent[id] = (alphaLast.get(id) ?? 0) - (alphaFirst.get(id) ?? 0);
+  // Only agents whose realizable value actually diverged from the mark. Comparing against the
+  // mark from the *same* cross-section matters: the coordinator's end-of-run PnL is computed at a
+  // different block by a different path, so comparing against that would flag every agent.
+  const liquidatableValueByAgent: Record<string, number> = {};
+  for (const { id } of agents) {
+    const liquidatable = liquidatableLast.get(id);
+    const marked = markedLast.get(id);
+    if (
+      liquidatable !== undefined &&
+      marked !== undefined &&
+      Math.abs(liquidatable - marked) > 1e-9
+    ) {
+      liquidatableValueByAgent[id] = liquidatable;
+    }
+  }
 
   // Issue #41: tokens outside the accounted set are invisible to the per-block cross-section (they
   // cannot be enumerated), so they are discovered once from the run window's Transfer logs.
@@ -683,6 +741,7 @@ export async function reconstructValueSeries(opts: {
     elapsedMs: Date.now() - started,
     alphaRefFairUsdcPerWeth: refFairByBase.WETH,
     alphaByAgent,
+    liquidatableValueByAgent,
     unpricedHoldings,
   };
 }

--- a/deployer/contracts/MockLSTVault.sol
+++ b/deployer/contracts/MockLSTVault.sol
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+/// @notice Minimal WETH/ERC20 surface the vault needs from its underlying asset.
+interface IVaultAsset {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+/// @title MockLSTVault
+/// @notice A self-contained liquid-staking vault in the style of wstETH: a **non-rebasing** share
+///         token whose redemption rate rises as staking yield accrues, plus a Lido-style
+///         request -> finalize -> claim withdrawal queue.
+///
+/// Why not fork Lido or Rocket Pool (issue #38): their cores drag in Aragon / StakingRouter /
+/// AccountingOracle (or RocketStorage) and beacon-chain assumptions, and the yield would still have
+/// to be mocked -- a large deploy whose economic content is a mock anyway, paid for in state-dump
+/// size and deploy time. So the *interface* is forked, not the implementation: ERC-4626
+/// (`asset` / `totalAssets` / `convertToAssets` / `previewRedeem` / `deposit` / `redeem`) plus the
+/// wstETH aliases (`stEthPerToken` / `getStETHByWstETH` / ...), so an agent can rely on prior
+/// knowledge of those names.
+///
+/// Deliberate deviations from ERC-4626, both because a real LST has no instant at-par exit:
+///   - `redeem` / `withdraw` **enqueue** a withdrawal instead of paying out; `claimWithdraw` pays.
+///     `previewRedeem` therefore reports what the queue will eventually pay, not what you get now.
+///     The instant exit is the LST/WETH secondary market, at whatever discount it is trading.
+///   - `maxWithdraw` / `previewWithdraw` are omitted rather than given a misleading answer.
+///
+/// Two properties matter because agents here are adversarial:
+///   - `totalPooledWeth` is internal accounting and is **never** `asset.balanceOf(address(this))`.
+///     A direct WETH transfer to this contract is a donation to nobody: it cannot move the
+///     exchange rate, so it cannot be used to grief or to inflate a share price.
+///   - The first deposit is floored and burns a slice of shares to address(0xdead), so the classic
+///     first-depositor share-inflation round-off is not available either.
+contract MockLSTVault {
+    // -----------------------------------------------------------------------
+    // ERC-20 (the share token). Non-rebasing: balances never change on their own -- the exchange
+    // rate does. A rebasing balance would break pool/LP accounting and historical scoring.
+    // -----------------------------------------------------------------------
+    string public constant name = "Eris Liquid Staked ETH";
+    string public constant symbol = "ERLST";
+    uint8 public constant decimals = 18;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    // -----------------------------------------------------------------------
+    // Vault state
+    // -----------------------------------------------------------------------
+
+    /// @notice ERC-4626 underlying asset (WETH).
+    address public immutable asset;
+
+    /// @notice WETH backing the outstanding shares. Internal accounting on purpose (see above).
+    uint256 public totalPooledWeth;
+
+    /// @notice Pre-funded, not-yet-distributed staking rewards. Yield is paid out of this rather
+    ///         than minted, so a run can never accrue more than the environment funded.
+    uint256 public rewardReserve;
+
+    /// @notice WETH already earmarked for queued withdrawals. Held for claimants, not for stakers.
+    uint256 public pendingWithdrawalWeth;
+
+    /// @notice Per-block reward rate as a ray (1e27) fraction of `totalPooledWeth`. The environment
+    ///         sets this from its economic clock (simulated seconds per block x target APY).
+    uint256 public rewardRatePerBlockRay;
+
+    /// @notice Block at which rewards were last accrued.
+    uint256 public lastAccrualBlock;
+
+    /// @notice Blocks between a withdrawal request and it becoming claimable (the queue's time cost).
+    uint256 public withdrawalDelayBlocks;
+
+    /// @notice Accounts allowed to reconfigure the vault (rate / delay) and to slash. Accrual itself
+    ///         is permissionless -- see `accrueRewards`.
+    mapping(address => bool) public operators;
+
+    uint256 private constant RAY = 1e27;
+    /// @notice Floor on the very first deposit, so the initial exchange rate cannot be set by dust.
+    uint256 public constant MIN_INITIAL_DEPOSIT = 1e15;
+    /// @notice Shares burnt on the first deposit so the supply can never return to (near) zero.
+    uint256 public constant BOOTSTRAP_BURN_SHARES = 1e6;
+    address private constant BURN_ADDRESS = 0x000000000000000000000000000000000000dEaD;
+
+    struct WithdrawalRequest {
+        address owner;
+        uint256 shares;
+        /// @notice WETH locked in at request time. The queue pays par: later yield or slashing does
+        ///         not move an already-queued request (Lido finalizes at the request-time rate).
+        uint256 assets;
+        uint256 claimableAt;
+        bool claimed;
+    }
+
+    WithdrawalRequest[] public withdrawalRequests;
+    mapping(address => uint256[]) private _requestIdsOf;
+    /// @notice Requests that exist but have not been claimed (the queue's length).
+    uint256 public openRequestCount;
+
+    event Deposited(address indexed caller, address indexed receiver, uint256 assets, uint256 shares);
+    event WithdrawalRequested(
+        address indexed owner, uint256 indexed requestId, uint256 shares, uint256 assets, uint256 claimableAt
+    );
+    event WithdrawalClaimed(address indexed owner, uint256 indexed requestId, uint256 assets);
+    event RewardsAccrued(uint256 assets, uint256 totalPooledWeth, uint256 rewardReserve);
+    event RewardsFunded(address indexed from, uint256 assets, uint256 rewardReserve);
+    event Slashed(uint256 assets, uint256 totalPooledWeth);
+    event RewardRateSet(uint256 rewardRatePerBlockRay);
+    event WithdrawalDelaySet(uint256 withdrawalDelayBlocks);
+    event OperatorSet(address indexed account, bool allowed);
+
+    modifier onlyOperator() {
+        require(operators[msg.sender], "LST: not operator");
+        _;
+    }
+
+    /// @param _asset          underlying WETH
+    /// @param _envOperator    a second operator besides the deployer (the simulation's admin key),
+    ///                        so the environment can retune the clock without redeploying
+    /// @param _rewardRatePerBlockRay initial per-block reward rate (ray)
+    /// @param _withdrawalDelayBlocks initial queue delay
+    constructor(
+        address _asset,
+        address _envOperator,
+        uint256 _rewardRatePerBlockRay,
+        uint256 _withdrawalDelayBlocks
+    ) {
+        require(_asset != address(0), "LST: asset required");
+        asset = _asset;
+        operators[msg.sender] = true;
+        emit OperatorSet(msg.sender, true);
+        if (_envOperator != address(0) && _envOperator != msg.sender) {
+            operators[_envOperator] = true;
+            emit OperatorSet(_envOperator, true);
+        }
+        rewardRatePerBlockRay = _rewardRatePerBlockRay;
+        withdrawalDelayBlocks = _withdrawalDelayBlocks;
+        lastAccrualBlock = block.number;
+        emit RewardRateSet(_rewardRatePerBlockRay);
+        emit WithdrawalDelaySet(_withdrawalDelayBlocks);
+    }
+
+    // -----------------------------------------------------------------------
+    // ERC-4626 style views
+    // -----------------------------------------------------------------------
+
+    function totalAssets() public view returns (uint256) {
+        return totalPooledWeth;
+    }
+
+    function convertToShares(uint256 assets) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        if (supply == 0 || totalPooledWeth == 0) return assets;
+        return (assets * supply) / totalPooledWeth;
+    }
+
+    function convertToAssets(uint256 shares) public view returns (uint256) {
+        uint256 supply = totalSupply;
+        if (supply == 0 || totalPooledWeth == 0) return shares;
+        return (shares * totalPooledWeth) / supply;
+    }
+
+    function previewDeposit(uint256 assets) external view returns (uint256) {
+        return convertToShares(assets);
+    }
+
+    /// @notice What the withdrawal queue would eventually pay for `shares`. NOT an instant quote:
+    ///         redeeming enqueues, and the payout lands `withdrawalDelayBlocks` later.
+    function previewRedeem(uint256 shares) external view returns (uint256) {
+        return convertToAssets(shares);
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxRedeem(address owner) external view returns (uint256) {
+        return balanceOf[owner];
+    }
+
+    // ---- wstETH aliases (so prior knowledge of the real thing transfers) ----
+
+    /// @notice WETH per 1e18 shares -- the redemption rate. This is the function the Curve
+    ///         stableswap-ng pool is wired to call as its rate oracle.
+    function stEthPerToken() public view returns (uint256) {
+        return convertToAssets(1e18);
+    }
+
+    function tokensPerStEth() external view returns (uint256) {
+        return convertToShares(1e18);
+    }
+
+    function getStETHByWstETH(uint256 shares) external view returns (uint256) {
+        return convertToAssets(shares);
+    }
+
+    function getWstETHByStETH(uint256 assets) external view returns (uint256) {
+        return convertToShares(assets);
+    }
+
+    // -----------------------------------------------------------------------
+    // Staking
+    // -----------------------------------------------------------------------
+
+    function deposit(uint256 assets, address receiver) public returns (uint256 shares) {
+        require(assets > 0, "LST: zero assets");
+        require(receiver != address(0), "LST: zero receiver");
+        bool bootstrap = totalSupply == 0;
+        if (bootstrap) require(assets >= MIN_INITIAL_DEPOSIT, "LST: initial deposit too small");
+        shares = convertToShares(assets);
+        require(shares > 0, "LST: zero shares");
+        require(IVaultAsset(asset).transferFrom(msg.sender, address(this), assets), "LST: transfer failed");
+        totalPooledWeth += assets;
+        if (bootstrap) {
+            // Lock a slice of the first mint away so the supply cannot be squeezed back down to a
+            // handful of wei, which is what makes share-price round-off exploitable.
+            require(shares > BOOTSTRAP_BURN_SHARES, "LST: initial deposit too small");
+            shares -= BOOTSTRAP_BURN_SHARES;
+            _mint(BURN_ADDRESS, BOOTSTRAP_BURN_SHARES);
+        }
+        _mint(receiver, shares);
+        emit Deposited(msg.sender, receiver, assets, shares);
+    }
+
+    function deposit(uint256 assets) external returns (uint256) {
+        return deposit(assets, msg.sender);
+    }
+
+    // -----------------------------------------------------------------------
+    // Withdrawal queue (request -> finalize -> claim)
+    // -----------------------------------------------------------------------
+
+    /// @notice Burn `shares` and join the withdrawal queue at today's rate. Claimable after
+    ///         `withdrawalDelayBlocks`; the alternative is selling into the secondary market now,
+    ///         at whatever discount it quotes.
+    function requestWithdraw(uint256 shares) public returns (uint256 requestId) {
+        require(shares > 0, "LST: zero shares");
+        uint256 assets = convertToAssets(shares);
+        require(assets > 0, "LST: zero assets");
+        require(assets <= totalPooledWeth, "LST: insufficient pool");
+        _burn(msg.sender, shares);
+        totalPooledWeth -= assets;
+        pendingWithdrawalWeth += assets;
+        requestId = withdrawalRequests.length;
+        uint256 claimableAt = block.number + withdrawalDelayBlocks;
+        withdrawalRequests.push(
+            WithdrawalRequest({
+                owner: msg.sender,
+                shares: shares,
+                assets: assets,
+                claimableAt: claimableAt,
+                claimed: false
+            })
+        );
+        _requestIdsOf[msg.sender].push(requestId);
+        openRequestCount += 1;
+        emit WithdrawalRequested(msg.sender, requestId, shares, assets, claimableAt);
+    }
+
+    /// @notice ERC-4626 shaped, but this vault has no instant exit: it enqueues like
+    ///         `requestWithdraw` and returns the assets the queue will pay.
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets) {
+        require(receiver == msg.sender && owner == msg.sender, "LST: only self redeem");
+        uint256 requestId = requestWithdraw(shares);
+        return withdrawalRequests[requestId].assets;
+    }
+
+    /// @notice ERC-4626 shaped withdraw-by-assets. Also enqueues.
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares) {
+        require(receiver == msg.sender && owner == msg.sender, "LST: only self withdraw");
+        shares = convertToShares(assets);
+        require(shares > 0, "LST: zero shares");
+        requestWithdraw(shares);
+    }
+
+    function claimWithdraw(uint256 requestId) public returns (uint256 assets) {
+        require(requestId < withdrawalRequests.length, "LST: no such request");
+        WithdrawalRequest storage request = withdrawalRequests[requestId];
+        require(request.owner == msg.sender, "LST: not request owner");
+        require(!request.claimed, "LST: already claimed");
+        require(block.number >= request.claimableAt, "LST: not finalized");
+        request.claimed = true;
+        assets = request.assets;
+        pendingWithdrawalWeth -= assets;
+        openRequestCount -= 1;
+        require(IVaultAsset(asset).transfer(msg.sender, assets), "LST: transfer failed");
+        emit WithdrawalClaimed(msg.sender, requestId, assets);
+    }
+
+    /// @notice Claim every finalized request of the caller. Convenient for an agent that queued a
+    ///         few exits and just wants whatever is ready.
+    function claimAllWithdrawals() external returns (uint256 assets) {
+        uint256[] storage ids = _requestIdsOf[msg.sender];
+        for (uint256 i = 0; i < ids.length; i++) {
+            WithdrawalRequest storage request = withdrawalRequests[ids[i]];
+            if (request.claimed || block.number < request.claimableAt) continue;
+            assets += claimWithdraw(ids[i]);
+        }
+    }
+
+    // ---- queue views ----
+
+    function requestIdsOf(address owner) external view returns (uint256[] memory) {
+        return _requestIdsOf[owner];
+    }
+
+    function withdrawalRequestCount() external view returns (uint256) {
+        return withdrawalRequests.length;
+    }
+
+    /// @notice One-read summary of an account's LST position, so observation and post-run scoring
+    ///         can both take it in a single batched call.
+    /// @return shares            share balance
+    /// @return shareAssets       what those shares redeem for at the current rate
+    /// @return pendingAssets     queued WETH not yet claimable
+    /// @return claimableAssets   queued WETH claimable right now
+    /// @return nextClaimableAt   block at which the earliest unclaimable request finalizes (0 if none)
+    /// @return openRequests      unclaimed requests belonging to this account
+    function accountSummary(address owner)
+        external
+        view
+        returns (
+            uint256 shares,
+            uint256 shareAssets,
+            uint256 pendingAssets,
+            uint256 claimableAssets,
+            uint256 nextClaimableAt,
+            uint256 openRequests
+        )
+    {
+        shares = balanceOf[owner];
+        shareAssets = convertToAssets(shares);
+        uint256[] storage ids = _requestIdsOf[owner];
+        for (uint256 i = 0; i < ids.length; i++) {
+            WithdrawalRequest storage request = withdrawalRequests[ids[i]];
+            if (request.claimed) continue;
+            openRequests += 1;
+            if (block.number >= request.claimableAt) {
+                claimableAssets += request.assets;
+            } else {
+                pendingAssets += request.assets;
+                if (nextClaimableAt == 0 || request.claimableAt < nextClaimableAt) {
+                    nextClaimableAt = request.claimableAt;
+                }
+            }
+        }
+    }
+
+    /// @notice Like `accountSummary`, but splits the queued-but-unclaimable WETH by whether it
+    ///         finalizes at or before `horizonBlock`.
+    ///
+    /// Post-run scoring marks an LST position at what it could actually realize, and a redemption
+    /// that finalizes after the run ends cannot be realized inside it. Doing that split on-chain
+    /// keeps it to one batched read per agent per block instead of walking the queue off-chain.
+    function accountSummaryAt(address owner, uint256 horizonBlock)
+        external
+        view
+        returns (
+            uint256 shares,
+            uint256 shareAssets,
+            uint256 claimableAssets,
+            uint256 reachableAssets,
+            uint256 unreachableAssets,
+            uint256 openRequests
+        )
+    {
+        shares = balanceOf[owner];
+        shareAssets = convertToAssets(shares);
+        uint256[] storage ids = _requestIdsOf[owner];
+        for (uint256 i = 0; i < ids.length; i++) {
+            WithdrawalRequest storage request = withdrawalRequests[ids[i]];
+            if (request.claimed) continue;
+            openRequests += 1;
+            if (block.number >= request.claimableAt) {
+                claimableAssets += request.assets;
+            } else if (request.claimableAt <= horizonBlock) {
+                reachableAssets += request.assets;
+            } else {
+                unreachableAssets += request.assets;
+            }
+        }
+    }
+
+    /// @notice Every unclaimed request of an account, in one read (for the agent's observation).
+    function openRequestsOf(address owner)
+        external
+        view
+        returns (uint256[] memory ids, uint256[] memory assets, uint256[] memory claimableAt)
+    {
+        uint256[] storage all = _requestIdsOf[owner];
+        uint256 open = 0;
+        for (uint256 i = 0; i < all.length; i++) {
+            if (!withdrawalRequests[all[i]].claimed) open += 1;
+        }
+        ids = new uint256[](open);
+        assets = new uint256[](open);
+        claimableAt = new uint256[](open);
+        uint256 k = 0;
+        for (uint256 i = 0; i < all.length; i++) {
+            WithdrawalRequest storage request = withdrawalRequests[all[i]];
+            if (request.claimed) continue;
+            ids[k] = all[i];
+            assets[k] = request.assets;
+            claimableAt[k] = request.claimableAt;
+            k += 1;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Yield
+    // -----------------------------------------------------------------------
+
+    /// @notice Move funded rewards into the pool for the blocks elapsed since the last accrual.
+    ///
+    /// Permissionless on purpose: the amount is a pure function of blocks elapsed and the
+    /// configured rate, so no caller can manufacture yield by calling it more often, and an agent
+    /// poking it does not gain anything over one that waits. The environment calls it every block
+    /// so the rate an observation reports is never stale.
+    function accrueRewards() public returns (uint256 accrued) {
+        uint256 elapsed = block.number - lastAccrualBlock;
+        if (elapsed == 0) return 0;
+        lastAccrualBlock = block.number;
+        if (totalSupply == 0 || rewardRatePerBlockRay == 0 || rewardReserve == 0) return 0;
+        accrued = (totalPooledWeth * rewardRatePerBlockRay * elapsed) / RAY;
+        if (accrued > rewardReserve) accrued = rewardReserve;
+        if (accrued == 0) return 0;
+        rewardReserve -= accrued;
+        totalPooledWeth += accrued;
+        emit RewardsAccrued(accrued, totalPooledWeth, rewardReserve);
+    }
+
+    /// @notice Fund the reward reserve. Pulls WETH in explicitly: a bare `transfer` to this
+    ///         contract is not funding, and does not move the exchange rate.
+    function fundRewards(uint256 assets) external {
+        require(assets > 0, "LST: zero assets");
+        require(IVaultAsset(asset).transferFrom(msg.sender, address(this), assets), "LST: transfer failed");
+        rewardReserve += assets;
+        emit RewardsFunded(msg.sender, assets, rewardReserve);
+    }
+
+    /// @notice Cut the pool by `bps` (a staking penalty; the stress overlay's LST event in phase 2).
+    ///         The WETH returns to the reward reserve rather than leaving, so the vault stays
+    ///         solvent against its outstanding shares and queued claims.
+    function slash(uint256 bps) external onlyOperator returns (uint256 slashed) {
+        require(bps <= 10_000, "LST: bps out of range");
+        accrueRewards();
+        slashed = (totalPooledWeth * bps) / 10_000;
+        if (slashed == 0) return 0;
+        totalPooledWeth -= slashed;
+        rewardReserve += slashed;
+        emit Slashed(slashed, totalPooledWeth);
+    }
+
+    // -----------------------------------------------------------------------
+    // Configuration
+    // -----------------------------------------------------------------------
+
+    function setRewardRate(uint256 ratePerBlockRay) external onlyOperator {
+        // Settle at the old rate first, otherwise the new rate would retroactively reprice blocks
+        // that already elapsed.
+        accrueRewards();
+        rewardRatePerBlockRay = ratePerBlockRay;
+        emit RewardRateSet(ratePerBlockRay);
+    }
+
+    function setWithdrawalDelayBlocks(uint256 delayBlocks) external onlyOperator {
+        withdrawalDelayBlocks = delayBlocks;
+        emit WithdrawalDelaySet(delayBlocks);
+    }
+
+    function setOperator(address account, bool allowed) external onlyOperator {
+        operators[account] = allowed;
+        emit OperatorSet(account, allowed);
+    }
+
+    /// @notice Everything the environment and an agent need about the vault, in one read.
+    function vaultSummary()
+        external
+        view
+        returns (
+            uint256 pooledWeth,
+            uint256 shareSupply,
+            uint256 redemptionRate,
+            uint256 reserve,
+            uint256 queuedWeth,
+            uint256 queueLength,
+            uint256 delayBlocks,
+            uint256 ratePerBlockRay
+        )
+    {
+        return (
+            totalPooledWeth,
+            totalSupply,
+            stEthPerToken(),
+            rewardReserve,
+            pendingWithdrawalWeth,
+            openRequestCount,
+            withdrawalDelayBlocks,
+            rewardRatePerBlockRay
+        );
+    }
+
+    /// @notice WETH held minus every obligation. Must never be negative; exposed so a run can
+    ///         assert it rather than trust it.
+    function surplusWeth() external view returns (uint256) {
+        uint256 held = IVaultAsset(asset).balanceOf(address(this));
+        uint256 owed = totalPooledWeth + pendingWithdrawalWeth + rewardReserve;
+        return held > owed ? held - owed : 0;
+    }
+
+    // -----------------------------------------------------------------------
+    // ERC-20 internals
+    // -----------------------------------------------------------------------
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= amount, "LST: insufficient allowance");
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "LST: zero receiver");
+        require(balanceOf[from] >= amount, "LST: insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burn(address from, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "LST: insufficient balance");
+        balanceOf[from] -= amount;
+        totalSupply -= amount;
+        emit Transfer(from, address(0), amount);
+    }
+}

--- a/deployer/contracts/MockLSTVault.sol
+++ b/deployer/contracts/MockLSTVault.sol
@@ -73,8 +73,21 @@ contract MockLSTVault {
     /// @notice Block at which rewards were last accrued.
     uint256 public lastAccrualBlock;
 
-    /// @notice Blocks between a withdrawal request and it becoming claimable (the queue's time cost).
+    /// @notice Floor on how long a withdrawal request waits before it can be claimed.
     uint256 public withdrawalDelayBlocks;
+
+    /// @notice How much queued WETH the protocol can finalize per block. 0 disables the limit, in
+    ///         which case every request simply waits `withdrawalDelayBlocks` (phase 1 behaviour).
+    ///
+    /// A real withdrawal queue is rate-limited by how fast the protocol can free capital, and it
+    /// finalizes in order. That makes the wait depend on two things a staker has to reason about:
+    /// how much is already queued ahead of them, and how large their own exit is. Without it the
+    /// queue is a fixed toll and the exit decision has no size to it (issue #38 phase 2).
+    uint256 public queueThroughputWeiPerBlock;
+
+    /// @notice The block the queue is currently booked out to. Requests stack after it, so a large
+    ///         exit pushes back everyone who queues later -- including its own owner next time.
+    uint256 public queueDrainBlock;
 
     /// @notice Accounts allowed to reconfigure the vault (rate / delay) and to slash. Accrual itself
     ///         is permissionless -- see `accrueRewards`.
@@ -112,6 +125,7 @@ contract MockLSTVault {
     event Slashed(uint256 assets, uint256 totalPooledWeth);
     event RewardRateSet(uint256 rewardRatePerBlockRay);
     event WithdrawalDelaySet(uint256 withdrawalDelayBlocks);
+    event QueueThroughputSet(uint256 queueThroughputWeiPerBlock);
     event OperatorSet(address indexed account, bool allowed);
 
     modifier onlyOperator() {
@@ -235,9 +249,28 @@ contract MockLSTVault {
     // Withdrawal queue (request -> finalize -> claim)
     // -----------------------------------------------------------------------
 
-    /// @notice Burn `shares` and join the withdrawal queue at today's rate. Claimable after
-    ///         `withdrawalDelayBlocks`; the alternative is selling into the secondary market now,
-    ///         at whatever discount it quotes.
+    /// @notice When a redemption of `assets` requested right now would become claimable.
+    ///
+    /// The floor is `withdrawalDelayBlocks`, but once a throughput limit is set the request also
+    /// has to wait for whatever is queued ahead of it and then for its own size to drain. Exposed
+    /// so an agent can price the wait before committing to it, rather than discovering it after.
+    function estimateClaimableAt(uint256 assets) public view returns (uint256) {
+        uint256 floorBlock = block.number + withdrawalDelayBlocks;
+        uint256 throughput = queueThroughputWeiPerBlock;
+        if (throughput == 0) return floorBlock;
+        uint256 start = queueDrainBlock > floorBlock ? queueDrainBlock : floorBlock;
+        // Round up: a partial block of draining still costs a block.
+        return start + (assets + throughput - 1) / throughput;
+    }
+
+    /// @notice Blocks a redemption of `assets` would wait if requested now.
+    function estimateDelayBlocks(uint256 assets) external view returns (uint256) {
+        return estimateClaimableAt(assets) - block.number;
+    }
+
+    /// @notice Burn `shares` and join the withdrawal queue at today's rate. Claimable once the
+    ///         queue reaches it (see `estimateClaimableAt`); the alternative is selling into the
+    ///         secondary market now, at whatever discount it quotes.
     function requestWithdraw(uint256 shares) public returns (uint256 requestId) {
         require(shares > 0, "LST: zero shares");
         uint256 assets = convertToAssets(shares);
@@ -247,7 +280,8 @@ contract MockLSTVault {
         totalPooledWeth -= assets;
         pendingWithdrawalWeth += assets;
         requestId = withdrawalRequests.length;
-        uint256 claimableAt = block.number + withdrawalDelayBlocks;
+        uint256 claimableAt = estimateClaimableAt(assets);
+        if (queueThroughputWeiPerBlock > 0) queueDrainBlock = claimableAt;
         withdrawalRequests.push(
             WithdrawalRequest({
                 owner: msg.sender,
@@ -473,6 +507,11 @@ contract MockLSTVault {
         emit WithdrawalDelaySet(delayBlocks);
     }
 
+    function setQueueThroughput(uint256 weiPerBlock) external onlyOperator {
+        queueThroughputWeiPerBlock = weiPerBlock;
+        emit QueueThroughputSet(weiPerBlock);
+    }
+
     function setOperator(address account, bool allowed) external onlyOperator {
         operators[account] = allowed;
         emit OperatorSet(account, allowed);
@@ -490,7 +529,9 @@ contract MockLSTVault {
             uint256 queuedWeth,
             uint256 queueLength,
             uint256 delayBlocks,
-            uint256 ratePerBlockRay
+            uint256 ratePerBlockRay,
+            uint256 throughputWeiPerBlock,
+            uint256 drainBlock
         )
     {
         return (
@@ -501,7 +542,9 @@ contract MockLSTVault {
             pendingWithdrawalWeth,
             openRequestCount,
             withdrawalDelayBlocks,
-            rewardRatePerBlockRay
+            rewardRatePerBlockRay,
+            queueThroughputWeiPerBlock,
+            queueDrainBlock
         );
     }
 

--- a/deployer/contracts/MockLSTVault.sol
+++ b/deployer/contracts/MockLSTVault.sol
@@ -477,16 +477,20 @@ contract MockLSTVault {
         emit RewardsFunded(msg.sender, assets, rewardReserve);
     }
 
-    /// @notice Cut the pool by `bps` (a staking penalty; the stress overlay's LST event in phase 2).
-    ///         The WETH returns to the reward reserve rather than leaving, so the vault stays
-    ///         solvent against its outstanding shares and queued claims.
+    /// @notice Cut the pool by `bps` (a staking penalty; the stress overlay's LST event).
+    ///
+    /// The WETH leaves the vault. An earlier version moved it into the reward reserve, which kept
+    /// the books tidy but made a slash a transfer rather than a loss: accrual paid the same WETH
+    /// back out as future yield, so the redemption rate recovered and the reserve was silently
+    /// topped up past what the environment funded. Burning it keeps "a slash is permanent" true
+    /// and keeps the reserve bound honest.
     function slash(uint256 bps) external onlyOperator returns (uint256 slashed) {
-        require(bps <= 10_000, "LST: bps out of range");
+        require(bps < 10_000, "LST: bps out of range");
         accrueRewards();
         slashed = (totalPooledWeth * bps) / 10_000;
         if (slashed == 0) return 0;
         totalPooledWeth -= slashed;
-        rewardReserve += slashed;
+        require(IVaultAsset(asset).transfer(BURN_ADDRESS, slashed), "LST: transfer failed");
         emit Slashed(slashed, totalPooledWeth);
     }
 

--- a/deployer/src/index.ts
+++ b/deployer/src/index.ts
@@ -11,11 +11,20 @@ import { deployBalancerV2 } from "./protocols/balancer-v2.js";
 import { deployAaveV3 } from "./protocols/aave-v3.js";
 import { deployCurve } from "./protocols/curve.js";
 import { deployGmxV2 } from "./protocols/gmx-v2.js";
+import { deployLst } from "./protocols/lst.js";
 
-type ProtocolName = "uniswap" | "balancer" | "aave" | "gmx" | "curve";
+type ProtocolName = "uniswap" | "balancer" | "aave" | "gmx" | "curve" | "lst";
 
-// gmx takes several minutes via hardhat-deploy, so put it last in ALL
-const ALL: ProtocolName[] = ["uniswap", "balancer", "aave", "curve", "gmx"];
+// gmx takes several minutes via hardhat-deploy, so put it last in ALL.
+// lst reuses the stableswap-ng factory for its secondary market, so it comes after curve.
+const ALL: ProtocolName[] = [
+  "uniswap",
+  "balancer",
+  "aave",
+  "curve",
+  "lst",
+  "gmx",
+];
 
 const DEPLOYERS: Record<
   ProtocolName,
@@ -25,6 +34,7 @@ const DEPLOYERS: Record<
   balancer: deployBalancerV2,
   aave: deployAaveV3,
   curve: deployCurve,
+  lst: deployLst,
   gmx: deployGmxV2,
 };
 

--- a/deployer/src/protocols/aave-v3.ts
+++ b/deployer/src/protocols/aave-v3.ts
@@ -19,6 +19,13 @@ function readDeployment(name: string): { address: Address; abi: Abi } {
   return { address: j.address as Address, abi: j.abi as Abi };
 }
 
+function readArtifact(name: string): { abi: Abi; bytecode: `0x${string}` } {
+  const j = JSON.parse(
+    readFileSync(resolve(DEPLOYMENTS, `${name}.json`), "utf8"),
+  );
+  return { abi: j.abi as Abi, bytecode: j.bytecode as `0x${string}` };
+}
+
 // Target tokens (Aave test token keys)
 const TOKEN_KEYS = ["WETH", "USDC", "WBTC", "USDT", "DAI"] as const;
 
@@ -274,6 +281,162 @@ async function registerSharedReserves() {
     "shared reserve registration",
     SHARED_RESERVE_KEYS.filter((k) => reg.tokens[k]).join(", "),
   );
+}
+
+// ---------------------------------------------------------------------------
+// LST as a reserve (issue #38 phase 3)
+// ---------------------------------------------------------------------------
+
+// Aave's own reserves supply the risk parameters for the shared tokens above by cloning a
+// same-named market. An LST has no such source, so its parameters are stated here instead. These
+// sit a notch below Arbitrum's real wstETH market (LTV 78.5% / LT 81%): the vault can be slashed
+// and the secondary market is thin, both of which argue for less leverage, and a conservative
+// number makes the liquidation cascade a tail event rather than the default outcome.
+const LST_LTV = 7000n; // 70%
+const LST_LIQUIDATION_THRESHOLD = 7500n; // 75%
+const LST_LIQUIDATION_BONUS = 10_750n; // 7.5% bonus (Aave encodes it as 100% + bonus)
+const LST_RESERVE_FACTOR = 1500n; // 15%
+
+/// Register the LST vault's share token as an Aave reserve: collateral only, no borrowing.
+///
+/// Collateral-only mirrors how liquid staking tokens are actually listed (nobody borrows wstETH
+/// meaningfully; the point is borrowing ETH *against* it), and it keeps the leverage loop to the
+/// one the venue is about — stake, post as collateral, borrow WETH, stake again.
+///
+/// The price source is a MockAggregator of its own rather than a borrowed one, because the LST is
+/// not worth the same as WETH: it is worth WETH x the vault's redemption rate, and that rate rises
+/// with yield and falls with a slash. The environment writes it every block, so the oracle lags
+/// the vault by exactly one block — the same lag every other price in this simulation has, and the
+/// thing that makes a slash reach health factors a block after it reaches the vault.
+export async function registerLstReserve(
+  lstToken: Address,
+  initialPriceUsd8: bigint,
+): Promise<{
+  aggregator: Address;
+  aToken: Address;
+  variableDebtToken: Address;
+}> {
+  info("Aave V3: registering the LST reserve (collateral only)");
+  const configuratorAddr = readDeployment(
+    "PoolConfigurator-Proxy-Aave",
+  ).address;
+  const configuratorAbi = readDeployment("PoolConfigurator-Implementation").abi;
+  const oracle = readDeployment("AaveOracle-Aave");
+  const poolAbi = poolImplAbi();
+  const pdpAddr = readDeployment("PoolDataProvider-Aave").address;
+  const pdpAbi = readDeployment("PoolDataProvider-Aave").abi;
+  const { pool, tokens } = aave();
+
+  // Its own aggregator, deployed from Aave's own MockAggregator so the storage layout matches what
+  // the environment writes to (the answer in slot 0).
+  const aggArtifact = readArtifact("WETH-TestnetPriceAggregator-Aave");
+  const aggHash = await deployerWallet.deployContract({
+    abi: aggArtifact.abi,
+    bytecode: aggArtifact.bytecode,
+    args: [initialPriceUsd8],
+    account: dep,
+    chain: anvilChain,
+  });
+  const aggregator = (await waitTx(aggHash)).contractAddress as Address;
+  ok("LST price aggregator", aggregator);
+
+  const existing = (await publicClient.readContract({
+    address: pool,
+    abi: poolAbi,
+    functionName: "getReserveData",
+    args: [lstToken],
+  })) as { aTokenAddress: Address };
+  if (!existing.aTokenAddress || existing.aTokenAddress === ZERO_ADDRESS) {
+    // The interest rate strategy is cloned from WETH: nothing is borrowable here, so the curve only
+    // ever prices supply, and WETH's is the closest thing to an ETH-denominated asset's.
+    const wethReserve = (await publicClient.readContract({
+      address: pool,
+      abi: poolAbi,
+      functionName: "getReserveData",
+      args: [tokens.WETH],
+    })) as { interestRateStrategyAddress: Address };
+
+    let h = await deployerWallet.writeContract({
+      address: oracle.address,
+      abi: oracle.abi,
+      functionName: "setAssetSources",
+      args: [[lstToken], [aggregator]],
+      account: dep,
+      chain: anvilChain,
+    });
+    await waitTx(h);
+
+    h = await deployerWallet.writeContract({
+      address: configuratorAddr,
+      abi: configuratorAbi,
+      functionName: "initReserves",
+      args: [
+        [
+          {
+            aTokenImpl: readDeployment("AToken-Aave").address,
+            stableDebtTokenImpl: readDeployment("StableDebtToken-Aave").address,
+            variableDebtTokenImpl: readDeployment("VariableDebtToken-Aave")
+              .address,
+            underlyingAssetDecimals: 18,
+            interestRateStrategyAddress:
+              wethReserve.interestRateStrategyAddress,
+            underlyingAsset: lstToken,
+            treasury: readDeployment("TreasuryProxy").address,
+            incentivesController: readDeployment("IncentivesProxy").address,
+            aTokenName: "Aave Eris LST",
+            aTokenSymbol: "aErLST",
+            variableDebtTokenName: "Aave Variable Debt Eris LST",
+            variableDebtTokenSymbol: "variableDebtErLST",
+            stableDebtTokenName: "Aave Stable Debt Eris LST",
+            stableDebtTokenSymbol: "stableDebtErLST",
+            params: "0x10",
+          },
+        ],
+      ],
+      account: dep,
+      chain: anvilChain,
+    });
+    await waitTx(h);
+
+    h = await deployerWallet.writeContract({
+      address: configuratorAddr,
+      abi: configuratorAbi,
+      functionName: "configureReserveAsCollateral",
+      args: [
+        lstToken,
+        LST_LTV,
+        LST_LIQUIDATION_THRESHOLD,
+        LST_LIQUIDATION_BONUS,
+      ],
+      account: dep,
+      chain: anvilChain,
+    });
+    await waitTx(h);
+    h = await deployerWallet.writeContract({
+      address: configuratorAddr,
+      abi: configuratorAbi,
+      functionName: "setReserveFactor",
+      args: [lstToken, LST_RESERVE_FACTOR],
+      account: dep,
+      chain: anvilChain,
+    });
+    await waitTx(h);
+    // Deliberately not calling setReserveBorrowing: the LST is collateral, not something to borrow.
+  } else {
+    ok("LST reserve", "already exists, reusing");
+  }
+
+  const toks = (await publicClient.readContract({
+    address: pdpAddr,
+    abi: pdpAbi,
+    functionName: "getReserveTokensAddresses",
+    args: [lstToken],
+  })) as readonly [Address, Address, Address];
+  ok(
+    "LST reserve",
+    `LTV ${Number(LST_LTV) / 100}% / LT ${Number(LST_LIQUIDATION_THRESHOLD) / 100}% / collateral only`,
+  );
+  return { aggregator, aToken: toks[0], variableDebtToken: toks[2] };
 }
 
 /** Mint test tokens to the deployer via the Faucet */

--- a/deployer/src/protocols/aave-v3.ts
+++ b/deployer/src/protocols/aave-v3.ts
@@ -310,7 +310,7 @@ const LST_RESERVE_FACTOR = 1500n; // 15%
 /// thing that makes a slash reach health factors a block after it reaches the vault.
 export async function registerLstReserve(
   lstToken: Address,
-  initialPriceUsd8: bigint,
+  redemptionRateWad: bigint,
 ): Promise<{
   aggregator: Address;
   aToken: Address;
@@ -327,18 +327,18 @@ export async function registerLstReserve(
   const pdpAbi = readDeployment("PoolDataProvider-Aave").abi;
   const { pool, tokens } = aave();
 
-  // Its own aggregator, deployed from Aave's own MockAggregator so the storage layout matches what
-  // the environment writes to (the answer in slot 0).
-  const aggArtifact = readArtifact("WETH-TestnetPriceAggregator-Aave");
-  const aggHash = await deployerWallet.deployContract({
-    abi: aggArtifact.abi,
-    bytecode: aggArtifact.bytecode,
-    args: [initialPriceUsd8],
-    account: dep,
-    chain: anvilChain,
-  });
-  const aggregator = (await waitTx(aggHash)).contractAddress as Address;
-  ok("LST price aggregator", aggregator);
+  // The opening price has to be WETH x the redemption rate *at Aave's own WETH price*, not at the
+  // price the spot venues were seeded with. Those differ (Aave's testnet WETH aggregator says
+  // $4000, the pools are seeded at $3000), and using the seed price listed the LST 25% below its
+  // collateral value until the environment's first per-block write corrected it -- a window in
+  // which health factors were wrong.
+  const wethPriceUsd8 = (await publicClient.readContract({
+    address: oracle.address,
+    abi: oracle.abi,
+    functionName: "getAssetPrice",
+    args: [tokens.WETH],
+  })) as bigint;
+  const initialPriceUsd8 = (wethPriceUsd8 * redemptionRateWad) / 10n ** 18n;
 
   const existing = (await publicClient.readContract({
     address: pool,
@@ -346,7 +346,38 @@ export async function registerLstReserve(
     functionName: "getReserveData",
     args: [lstToken],
   })) as { aTokenAddress: Address };
-  if (!existing.aTokenAddress || existing.aTokenAddress === ZERO_ADDRESS) {
+  const fresh =
+    !existing.aTokenAddress || existing.aTokenAddress === ZERO_ADDRESS;
+
+  // The aggregator is deployed only when it will actually be wired. Deploying it first meant a
+  // re-run on an existing reserve returned a brand new contract that setAssetSources never pointed
+  // at, which then went into deployments.json and constants as "the LST's price source" while
+  // nothing read it -- and burned a CREATE, shifting every later address on a nominal no-op.
+  let aggregator: Address;
+  if (fresh) {
+    // From Aave's own MockAggregator, so the storage layout matches what the environment writes to
+    // (the answer in slot 0).
+    const aggArtifact = readArtifact("WETH-TestnetPriceAggregator-Aave");
+    const aggHash = await deployerWallet.deployContract({
+      abi: aggArtifact.abi,
+      bytecode: aggArtifact.bytecode,
+      args: [initialPriceUsd8],
+      account: dep,
+      chain: anvilChain,
+    });
+    aggregator = (await waitTx(aggHash)).contractAddress as Address;
+    ok("LST price aggregator", aggregator);
+  } else {
+    aggregator = (await publicClient.readContract({
+      address: oracle.address,
+      abi: oracle.abi,
+      functionName: "getSourceOfAsset",
+      args: [lstToken],
+    })) as Address;
+    ok("LST price aggregator", `${aggregator} (existing)`);
+  }
+
+  if (fresh) {
     // The interest rate strategy is cloned from WETH: nothing is borrowable here, so the curve only
     // ever prices supply, and WETH's is the closest thing to an ETH-denominated asset's.
     const wethReserve = (await publicClient.readContract({

--- a/deployer/src/protocols/lst.ts
+++ b/deployer/src/protocols/lst.ts
@@ -36,10 +36,16 @@ const SIMULATED_SECONDS_PER_BLOCK = 3600n; // one block == one hour of staking
 const SECONDS_PER_YEAR = 31_536_000n;
 const RAY = 10n ** 27n;
 
-/// Blocks between requesting a withdrawal and being able to claim it. On the economic clock above
-/// this is a day, against Lido's real one-to-five days -- long enough that queueing is a real cost
-/// against selling into the pool, short enough to complete inside a few-hundred-block run.
+/// Floor on how long a withdrawal waits. On the economic clock above this is a day, against Lido's
+/// real one-to-five days -- long enough that queueing is a real cost against selling into the pool,
+/// short enough to complete inside a few-hundred-block run.
 const WITHDRAWAL_DELAY_BLOCKS = 24n;
+
+/// How much queued WETH the vault finalizes per block (issue #38 phase 2). With the per-round trade
+/// cap around 1 WETH, this makes an ordinary exit cost a block or two on top of the floor while a
+/// ten-WETH exit costs ten -- so size and congestion both show up in the wait instead of the queue
+/// being a flat toll. 0 would disable the limit entirely.
+const QUEUE_THROUGHPUT_WEI_PER_BLOCK = parseUnits("1", 18);
 
 /// Secondary-market depth. Far smaller than the $3M spot venues on purpose: an LST book is thin,
 /// and a book an agent cannot move is a book with no exit decision in it. Calibrated against the
@@ -124,6 +130,17 @@ export async function deployLst({ seed }: { seed: boolean }) {
   const vault = (await waitTx(deployHash)).contractAddress as Address;
   ok("MockLSTVault", vault);
 
+  const throughputHash = await deployerWallet.writeContract({
+    address: vault,
+    abi: vaultArtifact.abi,
+    functionName: "setQueueThroughput",
+    args: [QUEUE_THROUGHPUT_WEI_PER_BLOCK],
+    account: dep,
+    chain: anvilChain,
+  });
+  await waitTx(throughputHash);
+  ok("queue throughput", `${QUEUE_THROUGHPUT_WEI_PER_BLOCK} wei/block`);
+
   setProtocol("lst", {
     vault,
     lstToken: vault, // the vault is its own share token (wstETH model)
@@ -132,6 +149,7 @@ export async function deployLst({ seed }: { seed: boolean }) {
     simulatedSecondsPerBlock: Number(SIMULATED_SECONDS_PER_BLOCK),
     targetApyBps: Number(TARGET_APY_BPS),
     withdrawalDelayBlocks: Number(WITHDRAWAL_DELAY_BLOCKS),
+    queueThroughputWeiPerBlock: QUEUE_THROUGHPUT_WEI_PER_BLOCK.toString(),
   });
 
   if (!seed) return;

--- a/deployer/src/protocols/lst.ts
+++ b/deployer/src/protocols/lst.ts
@@ -1,0 +1,280 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  keccak256,
+  parseUnits,
+  toBytes,
+  toFunctionSelector,
+  type Abi,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { accounts, deployerWallet, publicClient } from "../clients.js";
+import { anvilChain } from "../config.js";
+import { approve } from "../erc20.js";
+import { getRegistry, setProtocol, token } from "../registry.js";
+import { wrapWeth } from "../tokens.js";
+import { ROOT, assert, info, loadForgeArtifact, ok, waitTx } from "../util.js";
+
+const dep = accounts.deployer;
+const ZERO = "0x0000000000000000000000000000000000000000" as Address;
+
+// ---------------------------------------------------------------------------
+// Calibration (issue #38)
+//
+// The vault runs on a compressed *economic* clock rather than EVM time: one block stands for
+// SIMULATED_SECONDS_PER_BLOCK seconds of staking. These are the deploy-time defaults baked into the
+// state dump; a run can retune them through the lst section of its config (the simulation's admin
+// key is registered as a second operator for exactly that).
+//
+// The APY is deliberately the same order as Aave's WETH supply rate. A 1000x-speed LST would make
+// every other venue irrelevant -- the point of the venue is a yield/exit tradeoff, not free money.
+// ---------------------------------------------------------------------------
+const TARGET_APY_BPS = 300n; // 3%/yr, ~ Aave WETH supply
+const SIMULATED_SECONDS_PER_BLOCK = 3600n; // one block == one hour of staking
+const SECONDS_PER_YEAR = 31_536_000n;
+const RAY = 10n ** 27n;
+
+/// Blocks between requesting a withdrawal and being able to claim it. On the economic clock above
+/// this is a day, against Lido's real one-to-five days -- long enough that queueing is a real cost
+/// against selling into the pool, short enough to complete inside a few-hundred-block run.
+const WITHDRAWAL_DELAY_BLOCKS = 24n;
+
+/// Secondary-market depth. Far smaller than the $3M spot venues on purpose: an LST book is thin,
+/// and a book an agent cannot move is a book with no exit decision in it. Calibrated against the
+/// per-round trade cap (~1 WETH): at 100 WETH a side that is 1% of the book, so ordinary trading
+/// shifts the discount by single-digit bps and a large exit visibly costs more per unit. At the
+/// 400 WETH first tried, dumping 12% of the book moved it 9bps — nothing an agent could work with.
+const POOL_WETH = parseUnits("100", 18);
+/// Rewards the environment pre-funds. Bounded by construction: a run can never accrue more than
+/// this, so a misconfigured clock overpays a little rather than minting forever.
+const REWARD_RESERVE = parseUnits("50", 18);
+
+// Curve stableswap-ng plain-pool parameters. Modelled on the real wstETH/ETH ng pool: a low fee and
+// a soft A, so the curve holds the peg over ordinary size and gives way (the cliff) on a large
+// one-sided exit. Much lower than the USDC/DAI pool's 2000 because an LST is not a hard peg — at
+// 500 the curve was so flat that no trade an agent is allowed to make registered at all.
+const POOL_A = 100n;
+const POOL_FEE = 4_000_000n; // 0.04%
+const POOL_OFFPEG_FEE_MULTIPLIER = 20_000_000_000n;
+const POOL_MA_EXP_TIME = 866n;
+
+// The pool reads the redemption rate from the vault itself, exactly as the real wstETH/ETH ng pool
+// reads stEthPerToken. Without this the pool would treat LST/WETH as 1:1, and a rising exchange
+// rate would open a permanent risk-free arb for everyone -- a beta-style freebie that destroys
+// discrimination (ADR 0007).
+const RATE_ORACLE_SELECTOR = toFunctionSelector(
+  "function stEthPerToken() view returns (uint256)",
+);
+
+const CURVE_VENDOR = resolve(ROOT, "vendor", "curve");
+
+function curveArtifact(name: string): { abi: Abi; bytecode: Hex } {
+  const json = JSON.parse(
+    readFileSync(resolve(CURVE_VENDOR, `${name}.json`), "utf8"),
+  );
+  return {
+    abi: json.abi as Abi,
+    bytecode: (json.bytecode ?? json.blueprintBytecode) as Hex,
+  };
+}
+
+/// Per-block reward rate as a ray fraction of the pooled WETH.
+export function rewardRatePerBlockRay(
+  apyBps: bigint,
+  simulatedSecondsPerBlock: bigint,
+): bigint {
+  return (
+    (apyBps * simulatedSecondsPerBlock * RAY) / (10_000n * SECONDS_PER_YEAR)
+  );
+}
+
+/// The simulation's admin account, derived the same way sdk/src/config.ts derives it
+/// (`keccak256("eris-role:admin")`). Registering it as an operator lets the environment retune the
+/// economic clock per run without redeploying or holding the deployer key.
+function envOperatorAddress(): Address {
+  return privateKeyToAccount(keccak256(toBytes("eris-role:admin"))).address;
+}
+
+export async function deployLst({ seed }: { seed: boolean }) {
+  info(
+    "Deploying the LST venue (wstETH-style vault + LST/WETH secondary market)",
+  );
+
+  const weth = token("WETH");
+  const vaultArtifact = loadForgeArtifact("MockLSTVault", "MockLSTVault");
+  const ratePerBlockRay = rewardRatePerBlockRay(
+    TARGET_APY_BPS,
+    SIMULATED_SECONDS_PER_BLOCK,
+  );
+
+  const deployHash = await deployerWallet.deployContract({
+    abi: vaultArtifact.abi,
+    bytecode: vaultArtifact.bytecode,
+    args: [
+      weth,
+      envOperatorAddress(),
+      ratePerBlockRay,
+      WITHDRAWAL_DELAY_BLOCKS,
+    ],
+    account: dep,
+    chain: anvilChain,
+  });
+  const vault = (await waitTx(deployHash)).contractAddress as Address;
+  ok("MockLSTVault", vault);
+
+  setProtocol("lst", {
+    vault,
+    lstToken: vault, // the vault is its own share token (wstETH model)
+    asset: weth,
+    rewardRatePerBlockRay: ratePerBlockRay.toString(),
+    simulatedSecondsPerBlock: Number(SIMULATED_SECONDS_PER_BLOCK),
+    targetApyBps: Number(TARGET_APY_BPS),
+    withdrawalDelayBlocks: Number(WITHDRAWAL_DELAY_BLOCKS),
+  });
+
+  if (!seed) return;
+
+  // The deployer's WETH is already spread across the other venues by the time we get here, so top
+  // it up from its (effectively unlimited) anvil ETH rather than assuming a balance.
+  await wrapWeth(weth, POOL_WETH * 2n + REWARD_RESERVE + parseUnits("10", 18));
+
+  // ---- stake, so the pool has LST to hold and the exchange rate is well-defined ----
+  const stakeAssets = POOL_WETH;
+  await approve(weth, vault, stakeAssets + REWARD_RESERVE);
+  const stakeHash = await deployerWallet.writeContract({
+    address: vault,
+    abi: vaultArtifact.abi,
+    functionName: "deposit",
+    args: [stakeAssets, dep.address],
+    account: dep,
+    chain: anvilChain,
+  });
+  await waitTx(stakeHash);
+  const lstBalance = (await publicClient.readContract({
+    address: vault,
+    abi: vaultArtifact.abi,
+    functionName: "balanceOf",
+    args: [dep.address],
+  })) as bigint;
+  ok("staked", `${stakeAssets} WETH -> ${lstBalance} LST`);
+
+  const fundHash = await deployerWallet.writeContract({
+    address: vault,
+    abi: vaultArtifact.abi,
+    functionName: "fundRewards",
+    args: [REWARD_RESERVE],
+    account: dep,
+    chain: anvilChain,
+  });
+  await waitTx(fundHash);
+  ok("reward reserve funded", `${REWARD_RESERVE} WETH`);
+
+  await seedSecondaryMarket(vault, weth, lstBalance);
+}
+
+/// Create the LST/WETH stableswap-ng plain pool on the factory Curve already deployed, wire the
+/// rate oracle, and seed it balanced (at par, since the vault starts at a 1:1 rate).
+async function seedSecondaryMarket(
+  vault: Address,
+  weth: Address,
+  lstBalance: bigint,
+) {
+  const curve = getRegistry().protocols.curve as
+    { factory?: string } | undefined;
+  if (!curve?.factory) {
+    throw new Error(
+      "lst: the Curve stableswap-ng factory is not in deployments.json — deploy curve before lst",
+    );
+  }
+  const factory = curve.factory as Address;
+  const factoryAbi = curveArtifact("CurveStableSwapFactoryNG").abi;
+  const poolAbi = curveArtifact("CurveStableSwapNG").abi;
+
+  info("LST: creating the LST/WETH stableswap-ng pool and seeding liquidity");
+  // coin0 = WETH (the numeraire), coin1 = LST. Asset type 1 = "has a rate oracle": the pool calls
+  // stEthPerToken on the vault, so a rising redemption rate shifts the curve instead of leaving a
+  // free arb behind.
+  const coins = [weth, vault] as Address[];
+  const deployHash = await deployerWallet.writeContract({
+    address: factory,
+    abi: factoryAbi,
+    functionName: "deploy_plain_pool",
+    args: [
+      "Eris LST/WETH",
+      "ERLSTWETH",
+      coins,
+      POOL_A,
+      POOL_FEE,
+      POOL_OFFPEG_FEE_MULTIPLIER,
+      POOL_MA_EXP_TIME,
+      0n, // implementation_idx
+      [0, 1], // asset_types: [Standard, Oracle]
+      ["0x00000000", RATE_ORACLE_SELECTOR], // method_ids
+      [ZERO, vault], // oracles
+    ],
+    account: dep,
+    chain: anvilChain,
+  });
+  await waitTx(deployHash);
+
+  const count = (await publicClient.readContract({
+    address: factory,
+    abi: factoryAbi,
+    functionName: "pool_count",
+    args: [],
+  })) as bigint;
+  const pool = (await publicClient.readContract({
+    address: factory,
+    abi: factoryAbi,
+    functionName: "pool_list",
+    args: [count - 1n],
+  })) as Address;
+  assert(pool !== ZERO, "LST/WETH pool was not created");
+  ok("LST/WETH pool created", pool);
+
+  // Fail fast if the oracle did not take: with a 1:1 rate the two are indistinguishable today, but
+  // the moment yield accrues an unwired pool prices LST at par and hands everyone free money.
+  const storedRates = (await publicClient.readContract({
+    address: pool,
+    abi: poolAbi,
+    functionName: "stored_rates",
+    args: [],
+  })) as readonly bigint[];
+  const vaultRate = (await publicClient.readContract({
+    address: vault,
+    abi: loadForgeArtifact("MockLSTVault", "MockLSTVault").abi,
+    functionName: "stEthPerToken",
+    args: [],
+  })) as bigint;
+  assert(
+    storedRates.length === 2 && storedRates[1] === vaultRate,
+    `LST rate oracle is not wired: stored_rates=${storedRates.join(",")} vault rate=${vaultRate}`,
+  );
+  ok("rate oracle wired", `stEthPerToken=${vaultRate}`);
+
+  // Balanced at the current rate: equal *rate-adjusted* value on both legs, which at a 1:1 start
+  // means equal amounts. Seeding it off-peg would hand the first agent to look a free carry.
+  const lstAmount = lstBalance < POOL_WETH ? lstBalance : POOL_WETH;
+  await approve(weth, pool, POOL_WETH);
+  await approve(vault, pool, lstAmount);
+  const addHash = await deployerWallet.writeContract({
+    address: pool,
+    abi: poolAbi,
+    functionName: "add_liquidity",
+    args: [[POOL_WETH, lstAmount], 0n, dep.address],
+    account: dep,
+    chain: anvilChain,
+  });
+  await waitTx(addHash);
+  ok("add_liquidity", `${POOL_WETH} WETH / ${lstAmount} LST (at par)`);
+
+  setProtocol("lst", {
+    pool,
+    poolWethIndex: 0,
+    poolLstIndex: 1,
+    poolFee: Number(POOL_FEE),
+    poolA: Number(POOL_A),
+  });
+}

--- a/deployer/src/protocols/lst.ts
+++ b/deployer/src/protocols/lst.ts
@@ -14,6 +14,7 @@ import { accounts, deployerWallet, publicClient } from "../clients.js";
 import { anvilChain } from "../config.js";
 import { approve } from "../erc20.js";
 import { getRegistry, setProtocol, token } from "../registry.js";
+import { registerLstReserve } from "./aave-v3.js";
 import { wrapWeth } from "../tokens.js";
 import { ROOT, assert, info, loadForgeArtifact, ok, waitTx } from "../util.js";
 
@@ -73,6 +74,10 @@ const POOL_MA_EXP_TIME = 866n;
 const RATE_ORACLE_SELECTOR = toFunctionSelector(
   "function stEthPerToken() view returns (uint256)",
 );
+
+/// The WETH price the other venues are seeded at ($3000). Only used for the LST's opening Aave
+/// oracle value; the environment rewrites it from the run's fair price every block.
+const INITIAL_WETH_PRICE_USD = 3000;
 
 const CURVE_VENDOR = resolve(ROOT, "vendor", "curve");
 
@@ -294,5 +299,33 @@ async function seedSecondaryMarket(
     poolLstIndex: 1,
     poolFee: Number(POOL_FEE),
     poolA: Number(POOL_A),
+  });
+
+  await listAsAaveCollateral(vault);
+}
+
+/// Issue #38 phase 3: list the LST as Aave collateral so it can be levered.
+///
+/// Skipped when Aave is not in this deploy — the venue works without it, leverage is the layer on
+/// top. Registered here rather than inside the Aave deploy because the vault does not exist yet at
+/// that point (Aave runs before Curve, which the secondary market needs).
+async function listAsAaveCollateral(vault: Address) {
+  const aave = getRegistry().protocols.aaveV3 as
+    { pool?: string; tokens?: Record<string, string> } | undefined;
+  if (!aave?.pool) {
+    info("LST: skipping the Aave listing (aave is not in this deploy)");
+    return;
+  }
+  // The LST opens at the vault's redemption rate against WETH, which the pool was just seeded at.
+  // The environment overwrites this every block; it only has to be sane at block 0.
+  const initialPriceUsd8 = BigInt(Math.round(INITIAL_WETH_PRICE_USD * 1e8));
+  const { aggregator, aToken, variableDebtToken } = await registerLstReserve(
+    vault,
+    initialPriceUsd8,
+  );
+  setProtocol("lst", {
+    aaveAggregator: aggregator,
+    aaveAToken: aToken,
+    aaveVariableDebtToken: variableDebtToken,
   });
 }

--- a/deployer/src/protocols/lst.ts
+++ b/deployer/src/protocols/lst.ts
@@ -75,10 +75,6 @@ const RATE_ORACLE_SELECTOR = toFunctionSelector(
   "function stEthPerToken() view returns (uint256)",
 );
 
-/// The WETH price the other venues are seeded at ($3000). Only used for the LST's opening Aave
-/// oracle value; the environment rewrites it from the run's fair price every block.
-const INITIAL_WETH_PRICE_USD = 3000;
-
 const CURVE_VENDOR = resolve(ROOT, "vendor", "curve");
 
 function curveArtifact(name: string): { abi: Abi; bytecode: Hex } {
@@ -316,12 +312,16 @@ async function listAsAaveCollateral(vault: Address) {
     info("LST: skipping the Aave listing (aave is not in this deploy)");
     return;
   }
-  // The LST opens at the vault's redemption rate against WETH, which the pool was just seeded at.
-  // The environment overwrites this every block; it only has to be sane at block 0.
-  const initialPriceUsd8 = BigInt(Math.round(INITIAL_WETH_PRICE_USD * 1e8));
+  // Priced at Aave's own WETH price times the vault's rate; registerLstReserve reads the former.
+  // The environment overwrites this every block, but it has to be right at block 0 too.
+  const redemptionRateWad = (await publicClient.readContract({
+    address: vault,
+    abi: loadForgeArtifact("MockLSTVault", "MockLSTVault").abi,
+    functionName: "stEthPerToken",
+  })) as bigint;
   const { aggregator, aToken, variableDebtToken } = await registerLstReserve(
     vault,
-    initialPriceUsd8,
+    redemptionRateWad,
   );
   setProtocol("lst", {
     aaveAggregator: aggregator,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,7 +14,9 @@ npm run sim:realtime -- --config config/vuln-test.yaml    # specify a different 
 - **Do not write secrets into the YAML.** Put RPC URLs, private keys, and API keys in `.env.local` (`ARB_RPC_URL` / `*_PRIVATE_KEY` / `ANTHROPIC_API_KEY` / `OLLAMA_API_KEY`). `config/local.yaml` is gitignored; `config/example.yaml` is the committed template.
 - One-shot overrides go via CLI flags (`--seed` / `--blocks` / `--protocols` etc.). Each agent's `env` is a strategy parameter passed to the agent process and is written under `agents[].env`.
 
-Committed templates in `config/`: `example.yaml` (minimal roster) / `vuln-test.yaml` (vulnerability events) / `regimes/` (official regimes = market scenarios for [Backtest](backtest.md); this YAML follows the same schema).
+- `example.yaml` ships with **`run.localDeploy: true`**, matching the README Quick Start and the official regimes: every venue is deployed onto a bare anvil by the bundled `deployer/`, so no fork RPC is involved and `npm run sim:realtime` needs no flags. To use an Arbitrum fork, set `localDeploy: false`, drop `lst` from `run.protocols` (its vault is ours and has no Arbitrum counterpart), and start `npm run anvil` with `ARB_RPC_URL` set.
+
+Committed templates in `config/`: `example.yaml` (the default roster) / `lst.yaml` (the liquid-staking venue on its own) / `vuln-test.yaml` (vulnerability events) / `regimes/` (official regimes = market scenarios for [Backtest](backtest.md); this YAML follows the same schema).
 
 ## Main sections
 

--- a/docs/guide/protocols-and-actions.md
+++ b/docs/guide/protocols-and-actions.md
@@ -11,6 +11,14 @@ Each adapter (`sdk/src/protocols/<name>.ts`) implements parse/validate, calldata
 | Curve | `curveSwap` | fork: tricrypto WETH↔USDT / local: twocrypto-ng WETH/USDC |
 | Aave v3 | `aaveSupply`, `aaveWithdraw`, `aaveBorrow`, `aaveRepay` | native USDC / WETH reserves |
 | GMX v2 | `gmxIncrease`, `gmxDecrease` | ETH/USD perp market |
+| LST | `lstDeposit`, `lstSwap`, `lstRequestWithdraw`, `lstClaimWithdraw` | **local only**: a wstETH-style vault plus its LST/WETH stableswap-ng market |
+
+The LST venue (issue #38) is the one venue with no fork counterpart — the vault is deployed by
+`deployer/`, so a fork run that lists `lst` fails fast at startup. It is also the one venue where an
+asset has two prices at once: `protocols.lst` reports the vault's `redemptionRateWeth` (reachable
+only through a withdrawal queue that takes `withdrawalDelayBlocks`) and the pool's
+`marketPriceWeth` (instant, at whatever discount it trades) separately, and scoring marks the
+position at whichever exit it could actually realize before the run ends.
 
 The table shows the default WETH markets. If a WBTC leg (`MARKET_LEGS`) is deployed in the local deploy, add `base: "WBTC"` to the same actions to also trade the WBTC/USDC spot, GMX WBTC market, and Aave WBTC reserve (multi-asset; ADR 0013).
 

--- a/example/agents/lst-carry/agent.ts
+++ b/example/agents/lst-carry/agent.ts
@@ -55,8 +55,31 @@ const MIN_STAKE_APY_BPS = Number(
   process.env.ERIS_LST_MIN_STAKE_APY_BPS ?? "200",
 );
 const SLIPPAGE_BPS = Number(process.env.ERIS_LST_SLIPPAGE_BPS ?? "50");
+// Leveraged staking (issue #38 phase 3): post LST as Aave collateral, borrow WETH against it, stake
+// that too. Off by default -- it multiplies the yield and the slashing exposure in equal measure,
+// and the LST's Aave price follows the vault a block late, so a slash reaches the health factor
+// after it reaches the position. Opt in with ERIS_LST_LEVERAGE_TARGET_HF.
+const LEVERAGE_TARGET_HF = Number(
+  process.env.ERIS_LST_LEVERAGE_TARGET_HF ?? "0",
+);
+// Never borrow the health factor below this, whatever the target says: liquidation costs the
+// bonus (7.5%) on the seized collateral, which is worth many runs of yield.
+const LEVERAGE_MIN_HF = Number(process.env.ERIS_LST_LEVERAGE_MIN_HF ?? "1.6");
+// Only borrow when the health factor is this multiple above the target, so one turn of the loop
+// does not immediately need undoing.
+const LEVERAGE_BORROW_BAND = Number(
+  process.env.ERIS_LST_LEVERAGE_BORROW_BAND ?? "1.25",
+);
 // Dust floor: below this, an action costs more in gas than it can earn.
 const MIN_ACTION_WEI = 10n ** 15n; // 0.001 WETH
+
+/// Aave's health factor as a readable number, or -1 when there is no debt (it reports a sentinel
+/// near uint256 max, which does not survive a plain Number()).
+function hfForLog(raw: string | undefined): number {
+  if (raw === undefined) return -1;
+  const hf = BigInt(raw);
+  return hf > 10n ** 30n ? -1 : Number(hf / 10n ** 14n) / 1e4;
+}
 
 function minBI(a: bigint, b: bigint): bigint {
   return a < b ? a : b;
@@ -121,7 +144,78 @@ export type CarryDecision =
   | { kind: "queue"; lstIn: bigint }
   | { kind: "harvest"; lstIn: bigint }
   | { kind: "stake"; wethIn: bigint }
+  // Phase 3 leverage: post LST as collateral, borrow WETH against it, unwind when the health
+  // factor gets close.
+  | { kind: "collateralize"; lstIn: bigint }
+  | { kind: "borrow"; wethOut: bigint }
+  | { kind: "deleverage"; wethIn: bigint }
   | { kind: "hold"; reason: string };
+
+/// The leverage leg (issue #38 phase 3), kept separate because it is opt-in and reads a different
+/// part of the observation -- Aave's account state -- from everything else here.
+///
+/// The loop is stake -> post -> borrow -> stake. Each turn buys more yield and more slashing
+/// exposure, so it is bounded by a target health factor rather than run to the LTV ceiling.
+/// Unwinding comes first and unconditionally: a health factor under the floor is worth more than
+/// any yield, because liquidation hands over the bonus on top of the debt.
+export function decideLeverage(input: {
+  lst: LstObservation;
+  aave:
+    | {
+        healthFactor: string;
+        availableBorrowsBase: string;
+        totalDebtBase: string;
+      }
+    | undefined;
+  wethBalanceWei: bigint;
+  fairPriceUsd: number;
+}): CarryDecision | null {
+  if (LEVERAGE_TARGET_HF <= 0) return null; // opt-in
+  if (!input.lst.aaveCollateral || !input.aave) return null;
+  const lstBalance = BigInt(input.lst.lstBalanceWei);
+  const hfRaw = BigInt(input.aave.healthFactor);
+  // Aave reports a sentinel near uint256 max when there is no debt at all.
+  const hasDebt = hfRaw < 10n ** 30n;
+  const hf = hasDebt
+    ? Number(hfRaw) / Number(10n ** 18n)
+    : Number.POSITIVE_INFINITY;
+
+  // 1. Too close to liquidation: repay before anything else.
+  if (hf < LEVERAGE_MIN_HF && input.wethBalanceWei >= MIN_ACTION_WEI) {
+    return { kind: "deleverage", wethIn: input.wethBalanceWei };
+  }
+  // 2. Unposted LST earns yield but supports no borrowing. Post it.
+  if (lstBalance >= MIN_ACTION_WEI) {
+    return { kind: "collateralize", lstIn: lstBalance };
+  }
+  // 3. Borrowed WETH is not leverage until it is staked and posted again. Hand back to the spot
+  //    decisions while there is WETH in hand: borrowing on top of an unstaked balance piles debt
+  //    against collateral that never grew (measured as 38 borrows against 18 forced repayments,
+  //    oscillating 1.16 <-> 2.14).
+  if (input.wethBalanceWei >= MIN_ACTION_WEI) return null;
+  // 4. Borrow against what is posted, sized to land *on* the target rather than past it.
+  //
+  //    Health factor is collateral x LT / debt, so scaling the existing debt by hf/target puts the
+  //    position exactly at the target. Sizing off the headroom instead overshoots: measured as 24
+  //    borrows against 22 forced repayments, oscillating 2.89 <-> 1.56, because each borrow blew
+  //    straight through the target and the floor beneath it. With no debt yet there is nothing to
+  //    scale from, so the first turn takes half the headroom and the next turn corrects.
+  if (
+    hf > LEVERAGE_TARGET_HF * LEVERAGE_BORROW_BAND &&
+    input.fairPriceUsd > 0
+  ) {
+    const availableUsd = Number(BigInt(input.aave.availableBorrowsBase)) / 1e8;
+    const debtUsd = Number(BigInt(input.aave.totalDebtBase)) / 1e8;
+    const borrowUsd = hasDebt
+      ? Math.min(debtUsd * (hf / LEVERAGE_TARGET_HF - 1), availableUsd)
+      : availableUsd * 0.5;
+    const wethOut = BigInt(
+      Math.floor((borrowUsd / input.fairPriceUsd) * 1e18),
+    );
+    if (wethOut >= MIN_ACTION_WEI) return { kind: "borrow", wethOut };
+  }
+  return null;
+}
 
 export function decideCarry(input: {
   lst: LstObservation;
@@ -200,7 +294,13 @@ export function decideCarry(input: {
       BigInt(lst.lstRedemptionValueWethWei) +
       BigInt(lst.pendingWithdrawalWethWei);
     const book = input.wethBalanceWei + staked;
-    const target = fraction(book, STAKE_TARGET_BPS);
+    // With the leverage loop on, holding a WETH buffer defeats the point: the loop only turns when
+    // borrowed WETH is staked and re-posted. Measured with the 70% target: ten stake/post pairs
+    // and not a single borrow.
+    const target = fraction(
+      book,
+      LEVERAGE_TARGET_HF > 0 ? 10_000 : STAKE_TARGET_BPS,
+    );
     if (target > staked + fraction(book, STAKE_REBALANCE_BAND_BPS)) {
       const size = minBI(
         minBI(target - staked, input.maxStakeWei),
@@ -239,9 +339,26 @@ export function decide(
     return { type: "noop", reason: "the lst venue is not enabled this run" };
   }
   const wethBalanceWei = BigInt(obs.balances.wethWei || "0");
-  if (wethBalanceWei === 0n && BigInt(lst.lstBalanceWei) === 0n) {
+  // Empty hands are only a dead end if there is nothing posted either. A levered position holds
+  // its whole book as Aave collateral, so checking the wallet alone reads that as "this venue is
+  // unusable" -- and because this return happens before the decision log, a run doing exactly that
+  // looks like an agent that stopped responding. It cost an afternoon of misdiagnosis.
+  const collateralBase = BigInt(obs.protocols.aave?.totalCollateralBase ?? "0");
+  const queued =
+    BigInt(lst.pendingWithdrawalWethWei) +
+    BigInt(lst.claimableWithdrawalWethWei);
+  if (
+    wethBalanceWei === 0n &&
+    BigInt(lst.lstBalanceWei) === 0n &&
+    collateralBase === 0n &&
+    queued === 0n
+  ) {
     // This venue is denominated in WETH. A USDC-only funding profile leaves nothing to work with,
     // which is a configuration mismatch rather than a market judgement -- say so plainly.
+    ctx?.log({
+      round: obs.round,
+      reason: "no WETH, no LST, nothing posted or queued",
+    });
     return {
       type: "noop",
       reason:
@@ -249,14 +366,23 @@ export function decide(
     };
   }
 
-  const decision = decideCarry({
-    lst,
-    wethBalanceWei,
-    maxStakeWei:
-      BigInt(obs.limits.maxLstDepositWethWei ?? "0") || wethBalanceWei,
-    maxSwapWei: BigInt(obs.limits.maxWethInWei) || wethBalanceWei,
-    blocksRemaining: obs.blocksRemaining,
-  });
+  // Leverage first when it is switched on: an unhealthy borrow outranks any trade, and posting
+  // collateral is what makes the loop turn. Falls through to the spot decisions otherwise.
+  const decision =
+    decideLeverage({
+      lst,
+      aave: obs.protocols.aave,
+      wethBalanceWei,
+      fairPriceUsd: obs.fairPriceUsdcPerWeth,
+    }) ??
+    decideCarry({
+      lst,
+      wethBalanceWei,
+      maxStakeWei:
+        BigInt(obs.limits.maxLstDepositWethWei ?? "0") || wethBalanceWei,
+      maxSwapWei: BigInt(obs.limits.maxWethInWei) || wethBalanceWei,
+      blocksRemaining: obs.blocksRemaining,
+    });
   const fee = obs.limits.defaultPriorityFeePerGasWei;
 
   // Record why, every cycle. A rule agent's noop leaves no trace on chain and none in the mempool
@@ -270,6 +396,8 @@ export function decide(
       apyBps: Number(lst.apyBps.toFixed(0)),
       queueDelayBlocks: lst.estimatedQueueDelayBlocks,
       blocksRemaining: obs.blocksRemaining ?? -1,
+      // 1e18 fixed point; Aave's no-debt sentinel is astronomically large, so it is reported as -1.
+      healthFactor: hfForLog(obs.protocols.aave?.healthFactor),
     },
   });
 
@@ -302,6 +430,27 @@ export function decide(
       return {
         type: "lstDeposit",
         amountWethWei: decision.wethIn.toString(),
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "collateralize":
+      return {
+        type: "aaveSupply",
+        asset: "LST",
+        amount: decision.lstIn.toString(),
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "borrow":
+      return {
+        type: "aaveBorrow",
+        asset: "WETH",
+        amount: decision.wethOut.toString(),
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "deleverage":
+      return {
+        type: "aaveRepay",
+        asset: "WETH",
+        amount: decision.wethIn.toString(),
         maxPriorityFeePerGasWei: fee,
       };
     default:

--- a/example/agents/lst-carry/agent.ts
+++ b/example/agents/lst-carry/agent.ts
@@ -17,7 +17,12 @@
  * The last one matters more than it looks. Scoring marks an LST position at what it could realize,
  * so a panicked end-of-run exit converts a mark into the same number minus fees.
  */
-import type { AgentAction, AgentObservation, LstObservation } from "@eris/sdk";
+import type {
+  AgentAction,
+  AgentContext,
+  AgentObservation,
+  LstObservation,
+} from "@eris/sdk";
 
 // Round-trip cost of touching the pool (its fee plus the impact of a real-size order), in bps.
 // The carry has to clear this before it is worth doing.
@@ -42,6 +47,13 @@ const STAKE_REBALANCE_BAND_BPS = Number(
 const CARRY_FRACTION_BPS = Number(
   process.env.ERIS_LST_CARRY_FRACTION_BPS ?? "5000",
 );
+// Below this APY, staking is not worth the risk of holding LST: the yield stops covering the
+// slashing exposure and the cost of eventually exiting. The yield varies during the run (issue #38
+// phase 2), so this is a live decision rather than a one-time one -- an agent that ignores it
+// simply stakes through the lean stretches and collects the downside for nothing.
+const MIN_STAKE_APY_BPS = Number(
+  process.env.ERIS_LST_MIN_STAKE_APY_BPS ?? "200",
+);
 const SLIPPAGE_BPS = Number(process.env.ERIS_LST_SLIPPAGE_BPS ?? "50");
 // Dust floor: below this, an action costs more in gas than it can earn.
 const MIN_ACTION_WEI = 10n ** 15n; // 0.001 WETH
@@ -56,12 +68,49 @@ function fraction(amount: bigint, bps: number): bigint {
 
 /// Whether a redemption queued now would finalize with room to spare before the run ends. When the
 /// run has no block limit the queue is always reachable.
+///
+/// Takes the *effective* wait, not the vault's floor: once the queue is rate-limited (issue #38
+/// phase 2) the wait grows with what is already queued ahead and with the size being redeemed, so
+/// a decision made against the floor would queue exits that cannot finish.
 export function queueFitsInRun(
   blocksRemaining: number | undefined,
-  withdrawalDelayBlocks: number,
+  queueDelayBlocks: number,
 ): boolean {
   if (blocksRemaining === undefined) return true;
-  return blocksRemaining > withdrawalDelayBlocks + QUEUE_MARGIN_BLOCKS;
+  return blocksRemaining > queueDelayBlocks + QUEUE_MARGIN_BLOCKS;
+}
+
+/// How much of a share balance is worth queueing right now.
+///
+/// The queue drains at a fixed rate, so a large position cannot all finalize before the run ends
+/// even when a small one could. Queueing the whole thing anyway leaves the overflow stranded (it
+/// scores as unrealizable), and refusing to queue at all forfeits the part that would have made it.
+/// So take the slice that fits: partial exits are what a real staker does against a busy queue.
+export function queueableShares(
+  input: {
+    lst: LstObservation;
+    blocksRemaining: number | undefined;
+  },
+  shares: bigint,
+): bigint {
+  const throughput = BigInt(input.lst.queueThroughputWeiPerBlock ?? "0");
+  const redemptionValue = BigInt(input.lst.lstRedemptionValueWethWei);
+  if (
+    throughput <= 0n ||
+    input.blocksRemaining === undefined ||
+    redemptionValue <= 0n
+  ) {
+    return shares;
+  }
+  // Blocks left for draining once the floor and the safety margin are paid for.
+  const drainBlocks =
+    input.blocksRemaining -
+    input.lst.withdrawalDelayBlocks -
+    QUEUE_MARGIN_BLOCKS;
+  if (drainBlocks <= 0) return 0n;
+  const affordableAssets = BigInt(drainBlocks) * throughput;
+  if (affordableAssets >= redemptionValue) return shares;
+  return (shares * affordableAssets) / redemptionValue;
 }
 
 /// The decision, split out from the observation plumbing so it can be reasoned about (and tested)
@@ -88,10 +137,13 @@ export function decideCarry(input: {
   // 1. Anything already finalized is free to take, and leaving it queued earns nothing.
   if (claimable > 0n) return { kind: "claim" };
 
-  const canQueue = queueFitsInRun(
-    input.blocksRemaining,
-    lst.withdrawalDelayBlocks,
-  );
+  // Is the queue open at all? Judged on a *marginal* exit rather than on liquidating the whole
+  // position: how much of the position fits is a sizing question, handled by queueableShares. The
+  // two differ once a balance grows past what the queue can drain in the time left, and conflating
+  // them shuts the venue down early -- measured as the last 38 blocks of a run spent holding.
+  const queueDelay = lst.estimatedQueueDelayBlocks ?? lst.withdrawalDelayBlocks;
+  const marginalDelay = lst.queueDelayPerWethBlocks ?? queueDelay;
+  const canQueue = queueFitsInRun(input.blocksRemaining, marginalDelay);
   const edgeBps = lst.discountBps - POOL_COST_BPS - SAFETY_BPS;
 
   // 2. Close out what you already hold before buying more. The carry is buy-then-redeem, and it is
@@ -104,7 +156,8 @@ export function decideCarry(input: {
   //    run became stake -> queue -> stake churn and left 14 WETH in a queue that outlived the run.
   //    Below this level, holding and earning the yield is the better trade.
   if (canQueue && lstBalance >= MIN_ACTION_WEI && edgeBps > 0) {
-    return { kind: "queue", lstIn: lstBalance };
+    const lstIn = queueableShares(input, lstBalance);
+    if (lstIn >= MIN_ACTION_WEI) return { kind: "queue", lstIn };
   }
 
   // 3. The market is cheap enough to buy and redeem at par -- the carry this agent is named for.
@@ -130,10 +183,17 @@ export function decideCarry(input: {
     if (size >= MIN_ACTION_WEI) return { kind: "harvest", lstIn: size };
   }
 
-  // 5. No dislocation to trade, so just earn the yield -- but only if an exit can still be queued.
-  //    Staking into the last blocks of a run buys yield you cannot collect and an exit that has to
-  //    pay the pool's discount.
-  if (canQueue && input.wethBalanceWei > 0n && lst.yieldPerBlockBps > 0) {
+  // 5. No dislocation to trade, so earn the yield -- if it is worth earning, and if an exit can
+  //    still be queued. Staking into the last blocks of a run buys yield you cannot collect and an
+  //    exit that has to pay the pool's discount; staking through a lean stretch collects the
+  //    slashing exposure without being paid for it.
+  const yieldWorthIt = lst.apyBps >= MIN_STAKE_APY_BPS;
+  if (
+    canQueue &&
+    yieldWorthIt &&
+    input.wethBalanceWei > 0n &&
+    lst.yieldPerBlockBps > 0
+  ) {
     // Measured against the whole WETH-denominated book, so once the target is reached this stops
     // firing instead of nibbling at the remaining balance forever.
     const staked =
@@ -155,7 +215,13 @@ export function decideCarry(input: {
     // would pay, so an exit here just donates the fee.
     return {
       kind: "hold",
-      reason: `queue no longer fits in the run (${input.blocksRemaining ?? "?"} blocks left, needs ${lst.withdrawalDelayBlocks + QUEUE_MARGIN_BLOCKS}); holding, since selling only pays the pool fee`,
+      reason: `queue no longer fits in the run (${input.blocksRemaining ?? "?"} blocks left, a marginal exit needs ${marginalDelay + QUEUE_MARGIN_BLOCKS} at the current congestion, this whole position ${queueDelay}); holding, since selling only pays the pool fee`,
+    };
+  }
+  if (!yieldWorthIt && input.wethBalanceWei > 0n) {
+    return {
+      kind: "hold",
+      reason: `yield ${lst.apyBps.toFixed(0)}bps is below the ${MIN_STAKE_APY_BPS}bps floor; holding WETH rather than taking slashing exposure for it`,
     };
   }
   return {
@@ -166,6 +232,7 @@ export function decideCarry(input: {
 
 export function decide(
   obs: AgentObservation,
+  ctx?: AgentContext,
 ): AgentAction | Record<string, unknown> | null {
   const lst = obs.protocols.lst;
   if (!lst) {
@@ -191,6 +258,20 @@ export function decide(
     blocksRemaining: obs.blocksRemaining,
   });
   const fee = obs.limits.defaultPriorityFeePerGasWei;
+
+  // Record why, every cycle. A rule agent's noop leaves no trace on chain and none in the mempool
+  // log, so without this a run where the agent correctly sat out is indistinguishable from one
+  // where it was broken -- and phase 2 is full of reasons to correctly sit out.
+  ctx?.log({
+    round: obs.round,
+    reason: decision.kind === "hold" ? decision.reason : decision.kind,
+    signals: {
+      discountBps: Number(lst.discountBps.toFixed(2)),
+      apyBps: Number(lst.apyBps.toFixed(0)),
+      queueDelayBlocks: lst.estimatedQueueDelayBlocks,
+      blocksRemaining: obs.blocksRemaining ?? -1,
+    },
+  });
 
   switch (decision.kind) {
     case "claim":

--- a/example/agents/lst-carry/agent.ts
+++ b/example/agents/lst-carry/agent.ts
@@ -1,0 +1,229 @@
+/**
+ * lst-carry: works the liquid-staking venue's whole decision surface (issue #38).
+ *
+ * An LST has two prices at once. The vault owes `redemptionRateWeth` per share, but only through a
+ * withdrawal queue that takes `withdrawalDelayBlocks`; the secondary market pays `marketPriceWeth`
+ * immediately, at whatever discount it happens to be trading. Every decision here is about which
+ * of those two you want, and whether the run lasts long enough to still have the choice:
+ *
+ *   claim    a finalized redemption is free money sitting on the table
+ *   carry    the market is discounted below redemption -> buy it and queue the redemption at par,
+ *            but only while the queue still fits inside the run
+ *   harvest  the market is at a premium -> sell shares into it rather than redeem at par
+ *   stake    neither, so just earn the yield -- provided you can still queue an exit later
+ *   hold     late in the run, do nothing: selling only pays the pool's fee, and scoring already
+ *            marks the position at what the pool would pay
+ *
+ * The last one matters more than it looks. Scoring marks an LST position at what it could realize,
+ * so a panicked end-of-run exit converts a mark into the same number minus fees.
+ */
+import type { AgentAction, AgentObservation, LstObservation } from "@eris/sdk";
+
+// Round-trip cost of touching the pool (its fee plus the impact of a real-size order), in bps.
+// The carry has to clear this before it is worth doing.
+const POOL_COST_BPS = Number(process.env.ERIS_LST_POOL_COST_BPS ?? "12");
+// Extra edge demanded on top of cost, so noise around par does not trigger trades.
+const SAFETY_BPS = Number(process.env.ERIS_LST_SAFETY_BPS ?? "15");
+// Blocks of slack left after the queue delay before trusting a queued exit to finalize in time.
+const QUEUE_MARGIN_BLOCKS = Number(
+  process.env.ERIS_LST_QUEUE_MARGIN_BLOCKS ?? "4",
+);
+// How much of the WETH-denominated book to hold as LST once there is nothing better to do, in bps.
+// A *target*, not a per-cycle fraction: staking a fixed slice of the remaining balance every block
+// converges on the same allocation but pays gas twenty-five times to get there (measured in a live
+// run, where it was the whole of the agent's loss).
+const STAKE_TARGET_BPS = Number(
+  process.env.ERIS_LST_STAKE_TARGET_BPS ?? "7000",
+);
+// Don't top up for a gap smaller than this share of the book: rebalancing dust is pure gas.
+const STAKE_REBALANCE_BAND_BPS = Number(
+  process.env.ERIS_LST_STAKE_BAND_BPS ?? "500",
+);
+const CARRY_FRACTION_BPS = Number(
+  process.env.ERIS_LST_CARRY_FRACTION_BPS ?? "5000",
+);
+const SLIPPAGE_BPS = Number(process.env.ERIS_LST_SLIPPAGE_BPS ?? "50");
+// Dust floor: below this, an action costs more in gas than it can earn.
+const MIN_ACTION_WEI = 10n ** 15n; // 0.001 WETH
+
+function minBI(a: bigint, b: bigint): bigint {
+  return a < b ? a : b;
+}
+
+function fraction(amount: bigint, bps: number): bigint {
+  return (amount * BigInt(Math.max(0, Math.round(bps)))) / 10_000n;
+}
+
+/// Whether a redemption queued now would finalize with room to spare before the run ends. When the
+/// run has no block limit the queue is always reachable.
+export function queueFitsInRun(
+  blocksRemaining: number | undefined,
+  withdrawalDelayBlocks: number,
+): boolean {
+  if (blocksRemaining === undefined) return true;
+  return blocksRemaining > withdrawalDelayBlocks + QUEUE_MARGIN_BLOCKS;
+}
+
+/// The decision, split out from the observation plumbing so it can be reasoned about (and tested)
+/// on its own.
+export type CarryDecision =
+  | { kind: "claim" }
+  | { kind: "carry"; wethIn: bigint }
+  | { kind: "queue"; lstIn: bigint }
+  | { kind: "harvest"; lstIn: bigint }
+  | { kind: "stake"; wethIn: bigint }
+  | { kind: "hold"; reason: string };
+
+export function decideCarry(input: {
+  lst: LstObservation;
+  wethBalanceWei: bigint;
+  maxStakeWei: bigint;
+  maxSwapWei: bigint;
+  blocksRemaining: number | undefined;
+}): CarryDecision {
+  const { lst } = input;
+  const lstBalance = BigInt(lst.lstBalanceWei);
+  const claimable = BigInt(lst.claimableWithdrawalWethWei);
+
+  // 1. Anything already finalized is free to take, and leaving it queued earns nothing.
+  if (claimable > 0n) return { kind: "claim" };
+
+  const canQueue = queueFitsInRun(
+    input.blocksRemaining,
+    lst.withdrawalDelayBlocks,
+  );
+  const edgeBps = lst.discountBps - POOL_COST_BPS - SAFETY_BPS;
+
+  // 2. Close out what you already hold before buying more. The carry is buy-then-redeem, and it is
+  //    the redemption that turns the discount into WETH you can trade again -- so queueing comes
+  //    first, otherwise the agent just keeps buying until the discount closes and never collects
+  //    (measured: five buys, no redemption, the whole edge left on the table as an open position).
+  //
+  //    Gated on the *same* edge as the buy, not a looser one. With a looser gate the agent also
+  //    queues its staked position the moment the market drifts below par at all -- which in a live
+  //    run became stake -> queue -> stake churn and left 14 WETH in a queue that outlived the run.
+  //    Below this level, holding and earning the yield is the better trade.
+  if (canQueue && lstBalance >= MIN_ACTION_WEI && edgeBps > 0) {
+    return { kind: "queue", lstIn: lstBalance };
+  }
+
+  // 3. The market is cheap enough to buy and redeem at par -- the carry this agent is named for.
+  //    Only while the queue still fits: past that point the discount is not recoverable.
+  if (canQueue && edgeBps > 0 && input.wethBalanceWei > 0n) {
+    const size = minBI(
+      minBI(
+        fraction(input.wethBalanceWei, CARRY_FRACTION_BPS),
+        input.maxSwapWei,
+      ),
+      input.wethBalanceWei,
+    );
+    if (size >= MIN_ACTION_WEI) return { kind: "carry", wethIn: size };
+  }
+
+  // 4. The mirror image: the market is paying above redemption, so sell into it instead of
+  //    queueing. (discountBps < 0 is a premium.)
+  if (
+    lstBalance >= MIN_ACTION_WEI &&
+    -lst.discountBps > POOL_COST_BPS + SAFETY_BPS
+  ) {
+    const size = minBI(lstBalance, input.maxSwapWei);
+    if (size >= MIN_ACTION_WEI) return { kind: "harvest", lstIn: size };
+  }
+
+  // 5. No dislocation to trade, so just earn the yield -- but only if an exit can still be queued.
+  //    Staking into the last blocks of a run buys yield you cannot collect and an exit that has to
+  //    pay the pool's discount.
+  if (canQueue && input.wethBalanceWei > 0n && lst.yieldPerBlockBps > 0) {
+    // Measured against the whole WETH-denominated book, so once the target is reached this stops
+    // firing instead of nibbling at the remaining balance forever.
+    const staked =
+      BigInt(lst.lstRedemptionValueWethWei) +
+      BigInt(lst.pendingWithdrawalWethWei);
+    const book = input.wethBalanceWei + staked;
+    const target = fraction(book, STAKE_TARGET_BPS);
+    if (target > staked + fraction(book, STAKE_REBALANCE_BAND_BPS)) {
+      const size = minBI(
+        minBI(target - staked, input.maxStakeWei),
+        input.wethBalanceWei,
+      );
+      if (size >= MIN_ACTION_WEI) return { kind: "stake", wethIn: size };
+    }
+  }
+
+  if (!canQueue && lstBalance > 0n) {
+    // Late in the run, holding beats selling: scoring already marks the shares at what the pool
+    // would pay, so an exit here just donates the fee.
+    return {
+      kind: "hold",
+      reason: `queue no longer fits in the run (${input.blocksRemaining ?? "?"} blocks left, needs ${lst.withdrawalDelayBlocks + QUEUE_MARGIN_BLOCKS}); holding, since selling only pays the pool fee`,
+    };
+  }
+  return {
+    kind: "hold",
+    reason: `discount ${lst.discountBps.toFixed(1)}bps does not clear cost ${POOL_COST_BPS + SAFETY_BPS}bps`,
+  };
+}
+
+export function decide(
+  obs: AgentObservation,
+): AgentAction | Record<string, unknown> | null {
+  const lst = obs.protocols.lst;
+  if (!lst) {
+    return { type: "noop", reason: "the lst venue is not enabled this run" };
+  }
+  const wethBalanceWei = BigInt(obs.balances.wethWei || "0");
+  if (wethBalanceWei === 0n && BigInt(lst.lstBalanceWei) === 0n) {
+    // This venue is denominated in WETH. A USDC-only funding profile leaves nothing to work with,
+    // which is a configuration mismatch rather than a market judgement -- say so plainly.
+    return {
+      type: "noop",
+      reason:
+        "no WETH and no LST: the lst venue is WETH-denominated, so this run needs funding.wethWei > 0",
+    };
+  }
+
+  const decision = decideCarry({
+    lst,
+    wethBalanceWei,
+    maxStakeWei:
+      BigInt(obs.limits.maxLstDepositWethWei ?? "0") || wethBalanceWei,
+    maxSwapWei: BigInt(obs.limits.maxWethInWei) || wethBalanceWei,
+    blocksRemaining: obs.blocksRemaining,
+  });
+  const fee = obs.limits.defaultPriorityFeePerGasWei;
+
+  switch (decision.kind) {
+    case "claim":
+      return { type: "lstClaimWithdraw", maxPriorityFeePerGasWei: fee };
+    case "carry":
+      return {
+        type: "lstSwap",
+        tokenIn: "WETH",
+        amountIn: decision.wethIn.toString(),
+        slippageBps: SLIPPAGE_BPS,
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "queue":
+      return {
+        type: "lstRequestWithdraw",
+        amountLstWei: decision.lstIn.toString(),
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "harvest":
+      return {
+        type: "lstSwap",
+        tokenIn: "LST",
+        amountIn: decision.lstIn.toString(),
+        slippageBps: SLIPPAGE_BPS,
+        maxPriorityFeePerGasWei: fee,
+      };
+    case "stake":
+      return {
+        type: "lstDeposit",
+        amountWethWei: decision.wethIn.toString(),
+        maxPriorityFeePerGasWei: fee,
+      };
+    default:
+      return { type: "noop", reason: decision.reason };
+  }
+}

--- a/example/agents/lst-carry/agent.ts
+++ b/example/agents/lst-carry/agent.ts
@@ -125,11 +125,15 @@ export function queueableShares(
   ) {
     return shares;
   }
-  // Blocks left for draining once the floor and the safety margin are paid for.
+  // Blocks left for draining once the wait *and* the safety margin are paid for. The wait has to
+  // be the marginal one the vault is quoting right now (floor plus whatever is booked ahead), not
+  // the advertised floor: with the queue already booked out, sizing off the floor queues more than
+  // can finalize -- precisely the stranded-WETH loss this function exists to prevent. decideCarry
+  // already uses the quoted wait for the fit check; the two must not disagree.
+  const marginalWait =
+    input.lst.queueDelayPerWethBlocks ?? input.lst.withdrawalDelayBlocks;
   const drainBlocks =
-    input.blocksRemaining -
-    input.lst.withdrawalDelayBlocks -
-    QUEUE_MARGIN_BLOCKS;
+    input.blocksRemaining - marginalWait - QUEUE_MARGIN_BLOCKS;
   if (drainBlocks <= 0) return 0n;
   const affordableAssets = BigInt(drainBlocks) * throughput;
   if (affordableAssets >= redemptionValue) return shares;
@@ -160,6 +164,8 @@ export type CarryDecision =
 /// any yield, because liquidation hands over the bonus on top of the debt.
 export function decideLeverage(input: {
   lst: LstObservation;
+  // Whether the spot path has a premium worth selling into; leverage yields to it.
+  premiumWorthHarvesting?: boolean;
   aave:
     | {
         healthFactor: string;
@@ -172,6 +178,12 @@ export function decideLeverage(input: {
 }): CarryDecision | null {
   if (LEVERAGE_TARGET_HF <= 0) return null; // opt-in
   if (!input.lst.aaveCollateral || !input.aave) return null;
+  // Finalized WETH in the queue and a market paying above par are both free, and neither has
+  // anything to do with the loop. Posting collateral unconditionally in front of them made them
+  // unreachable for a levered agent, which holds LST continuously by construction: claimable WETH
+  // sat in the queue untouched for the rest of the run.
+  if (BigInt(input.lst.claimableWithdrawalWethWei) > 0n) return null;
+  if (input.premiumWorthHarvesting) return null;
   const lstBalance = BigInt(input.lst.lstBalanceWei);
   const hfRaw = BigInt(input.aave.healthFactor);
   // Aave reports a sentinel near uint256 max when there is no debt at all.
@@ -238,7 +250,12 @@ export function decideCarry(input: {
   const queueDelay = lst.estimatedQueueDelayBlocks ?? lst.withdrawalDelayBlocks;
   const marginalDelay = lst.queueDelayPerWethBlocks ?? queueDelay;
   const canQueue = queueFitsInRun(input.blocksRemaining, marginalDelay);
-  const edgeBps = lst.discountBps - POOL_COST_BPS - SAFETY_BPS;
+  // No quote means no tradable market, whatever discountBps says. Every branch below that touches
+  // the pool is gated on this.
+  const quoted = lst.marketQuoted !== false;
+  const edgeBps = quoted
+    ? lst.discountBps - POOL_COST_BPS - SAFETY_BPS
+    : Number.NEGATIVE_INFINITY;
 
   // 2. Close out what you already hold before buying more. The carry is buy-then-redeem, and it is
   //    the redemption that turns the discount into WETH you can trade again -- so queueing comes
@@ -270,6 +287,7 @@ export function decideCarry(input: {
   // 4. The mirror image: the market is paying above redemption, so sell into it instead of
   //    queueing. (discountBps < 0 is a premium.)
   if (
+    quoted &&
     lstBalance >= MIN_ACTION_WEI &&
     -lst.discountBps > POOL_COST_BPS + SAFETY_BPS
   ) {
@@ -374,6 +392,10 @@ export function decide(
       aave: obs.protocols.aave,
       wethBalanceWei,
       fairPriceUsd: obs.fairPriceUsdcPerWeth,
+      premiumWorthHarvesting:
+        lst.marketQuoted !== false &&
+        BigInt(lst.lstBalanceWei) >= MIN_ACTION_WEI &&
+        -lst.discountBps > POOL_COST_BPS + SAFETY_BPS,
     }) ??
     decideCarry({
       lst,

--- a/example/agents/lst-carry/prompt.md
+++ b/example/agents/lst-carry/prompt.md
@@ -1,0 +1,109 @@
+---
+name: lst-carry
+description: Liquid staking - stake for yield, or trade the gap between the market price and the redemption rate
+---
+# Mission
+
+You trade the **LST venue**: a liquid staking token whose value can be reached
+two different ways, at two different prices. Your job is to pick the right one
+each cycle, and to notice when the run is too short for the slow one.
+
+## The two prices
+
+`observation.protocols.lst` reports both. They are not the same number, and the
+gap between them is the entire game:
+
+- `redemptionRateWeth` — WETH the vault owes per 1 LST. **Full value, but slow**:
+  reaching it means queueing a redemption with `lstRequestWithdraw`, waiting
+  `withdrawalDelayBlocks`, then `lstClaimWithdraw`.
+- `marketPriceWeth` — WETH the LST/WETH pool pays per 1 LST **right now**, fee
+  and impact included. Instant, but only worth what the pool quotes.
+- `discountBps` — how far the market sits below redemption.
+  **Positive = LST is trading cheap.** Negative = it is at a premium.
+
+Two more fields size the decision:
+
+- `yieldPerBlockBps` — what staked LST earns per block (`apyBps` is the same
+  thing annualised on the run's compressed clock). This is the reward for simply
+  holding.
+- `blocksRemaining` (top level, not under `lst`) — how much run is left.
+
+Your own position: `lstBalanceWei`, `lstRedemptionValueWethWei` (what your shares
+redeem for at par), `instantExitWethWei` (what the pool would actually pay for
+**your** size, which is worse than `marketPriceWeth` x balance if you are large),
+`pendingWithdrawals`, `claimableWithdrawalWethWei`.
+
+## The rule that decides most cycles
+
+**A queued redemption is only worth par if it finalizes before the run ends.**
+You are scored on what you could realize, not on face value. So before choosing
+the slow path, check:
+
+```
+blocksRemaining > withdrawalDelayBlocks + 4
+```
+
+If that fails, the queue is closed to you: the only exit left is the pool, at
+its discount.
+
+## Decision procedure (every cycle)
+
+1. **Claim first.** If `claimableWithdrawalWethWei > 0`, emit
+   `{"type":"lstClaimWithdraw"}`. Finalized WETH sitting in the queue earns
+   nothing and costs nothing to take.
+2. **Redeem what you hold, before buying more.** If `discountBps > 27` (pool cost
+   ~12bps + 15bps safety), the queue check passes, and you hold LST, queue it:
+   `{"type":"lstRequestWithdraw","amountLstWei":"<lstBalanceWei>"}`. Redemption
+   is what turns the discount into WETH you can trade again — buy first and you
+   just keep buying until the discount closes, then hold an open position instead
+   of a realised profit.
+   Do **not** queue on a smaller discount. Queueing whenever the market is a
+   little below par drags your staked position into the queue too; in a live run
+   that became stake → queue → stake churn and stranded 14 WETH in a queue that
+   outlived the run. Below 27bps, holding and earning the yield is better.
+3. **Then carry, when the market is cheap and the queue still fits.** Same 27bps
+   gate, with WETH free to spend:
+   `{"type":"lstSwap","tokenIn":"WETH","amountIn":"<~50% of balances.wethWei>","slippageBps":50}`.
+   Your own buying closes the discount, so expect this to stop firing after a
+   few rounds — that is the trade working, not a failure.
+4. **Harvest a premium.** If `discountBps < -27` (the pool is paying *above*
+   redemption) and you hold LST, sell into it instead of queueing:
+   `{"type":"lstSwap","tokenIn":"LST","amountIn":"<lstBalanceWei>","slippageBps":50}`.
+5. **Otherwise stake toward a target, then stop.** While the queue check passes,
+   hold about **70% of your WETH-denominated book** as LST, where the book is
+   `balances.wethWei + lstRedemptionValueWethWei + pendingWithdrawalWethWei`.
+   Stake the shortfall with
+   `{"type":"lstDeposit","amountWethWei":"<target - already staked>"}` and then
+   **stop**: do not top up for a gap under ~5% of the book. Staking a slice of the
+   remaining balance every cycle reaches the same allocation while paying gas
+   every time — in a live run that was the agent's entire loss.
+6. **Late in the run, hold.** Once the queue no longer fits, do **not** dump your
+   LST into the pool. Your position is already marked at what the pool would pay,
+   so selling converts that mark into the same number minus the fee. Emit noop.
+
+## Sizing and units
+
+- Every amount is a decimal integer string in wei (LST and WETH are both
+  18-decimal). Never floats, never scientific notation.
+- `lstDeposit.amountWethWei` must be <= `limits.maxLstDepositWethWei` and <=
+  `balances.wethWei`.
+- `lstSwap` with `tokenIn: "WETH"` must be <= `limits.maxWethInWei` and <=
+  `balances.wethWei`; with `tokenIn: "LST"` it must be <= `lstBalanceWei`.
+- Check `instantExitWethWei` against `lstRedemptionValueWethWei` before selling
+  size: if the pool pays much less than `marketPriceWeth x balance` suggests, you
+  are too big for the book and should split the exit or queue instead.
+
+## Explicit noop criteria
+
+- `discountBps` inside +/-27bps and no free WETH: nothing to do.
+- Queue no longer fits and you already hold LST: hold, do not sell.
+- No WETH and no LST at all: this venue is WETH-denominated, so say so
+  (`funding.wethWei` is zero) rather than trying to trade.
+
+## Revision invariants (for self-improvement)
+
+- **Never queue a redemption that cannot finalize before the run ends.** That
+  converts a good position into an unrealizable one.
+- **Never panic-sell late.** Holding is already marked at the pool price.
+- Tunable: the discount thresholds, sizing fractions, how much slack to leave on
+  the queue check.

--- a/example/agents/lst-carry/prompt.md
+++ b/example/agents/lst-carry/prompt.md
@@ -14,18 +14,24 @@ each cycle, and to notice when the run is too short for the slow one.
 gap between them is the entire game:
 
 - `redemptionRateWeth` — WETH the vault owes per 1 LST. **Full value, but slow**:
-  reaching it means queueing a redemption with `lstRequestWithdraw`, waiting
-  `withdrawalDelayBlocks`, then `lstClaimWithdraw`.
+  reaching it means queueing a redemption with `lstRequestWithdraw`, waiting for
+  the queue, then `lstClaimWithdraw`.
 - `marketPriceWeth` — WETH the LST/WETH pool pays per 1 LST **right now**, fee
   and impact included. Instant, but only worth what the pool quotes.
 - `discountBps` — how far the market sits below redemption.
   **Positive = LST is trading cheap.** Negative = it is at a premium.
 
-Two more fields size the decision:
+Three more fields size the decision:
 
 - `yieldPerBlockBps` — what staked LST earns per block (`apyBps` is the same
   thing annualised on the run's compressed clock). This is the reward for simply
-  holding.
+  holding. **It changes during the run**, so a stake that was worth holding
+  earlier may not be, and vice versa — re-read it, do not assume it.
+- `estimatedQueueDelayBlocks` — how many blocks a redemption of **your** size
+  would actually wait right now. The queue is rate-limited, so this is larger
+  than `withdrawalDelayBlocks` when the queue is busy or your position is big.
+  Use this one, never the floor. `queueDelayPerWethBlocks` is the same figure
+  for a one-WETH exit, i.e. the congestion with your own size taken out.
 - `blocksRemaining` (top level, not under `lst`) — how much run is left.
 
 Your own position: `lstBalanceWei`, `lstRedemptionValueWethWei` (what your shares
@@ -40,11 +46,17 @@ You are scored on what you could realize, not on face value. So before choosing
 the slow path, check:
 
 ```
-blocksRemaining > withdrawalDelayBlocks + 4
+blocksRemaining > estimatedQueueDelayBlocks + 4
 ```
 
+Note this can flip against you without you doing anything: if others queue large
+redemptions ahead of you, your wait grows. Re-check it every cycle.
+
 If that fails, the queue is closed to you: the only exit left is the pool, at
-its discount.
+its discount. Note `estimatedQueueDelayBlocks` is quoted for your *whole*
+balance; `queueDelayPerWethBlocks` is the same for a marginal one-WETH exit. A
+big position can be too large to redeem in full while a slice of it still fits —
+that is a sizing problem, not a closed queue.
 
 ## Decision procedure (every cycle)
 
@@ -53,7 +65,13 @@ its discount.
    nothing and costs nothing to take.
 2. **Redeem what you hold, before buying more.** If `discountBps > 27` (pool cost
    ~12bps + 15bps safety), the queue check passes, and you hold LST, queue it:
-   `{"type":"lstRequestWithdraw","amountLstWei":"<lstBalanceWei>"}`. Redemption
+   `{"type":"lstRequestWithdraw","amountLstWei":"<the slice that fits>"}`.
+   **Size it to what can actually finalize.** With `queueThroughputWeiPerBlock`
+   set, the queue drains that much WETH per block, so only
+   `(blocksRemaining - withdrawalDelayBlocks - 4) x throughput` of value can
+   still land. Queue more than that and the overflow is stranded past the run and
+   scores as nothing; queue none of it and you forfeit the part that would have
+   made it. Take the slice, and queue the rest later if the queue frees up. Redemption
    is what turns the discount into WETH you can trade again — buy first and you
    just keep buying until the discount closes, then hold an open position instead
    of a realised profit.
@@ -69,7 +87,12 @@ its discount.
 4. **Harvest a premium.** If `discountBps < -27` (the pool is paying *above*
    redemption) and you hold LST, sell into it instead of queueing:
    `{"type":"lstSwap","tokenIn":"LST","amountIn":"<lstBalanceWei>","slippageBps":50}`.
-5. **Otherwise stake toward a target, then stop.** While the queue check passes,
+5. **Otherwise stake toward a target — if the yield is worth it — then stop.**
+   Skip staking entirely while `apyBps` is under ~200: below that the yield stops
+   paying for the risk of holding LST (a slash can cut the redemption rate mid-run)
+   and for the cost of eventually exiting. `apyBps` **moves during the run**, so
+   this flips both ways: check it every cycle rather than deciding once.
+   Otherwise, while the queue check passes,
    hold about **70% of your WETH-denominated book** as LST, where the book is
    `balances.wethWei + lstRedemptionValueWethWei + pendingWithdrawalWethWei`.
    Stake the shortfall with
@@ -96,6 +119,7 @@ its discount.
 ## Explicit noop criteria
 
 - `discountBps` inside +/-27bps and no free WETH: nothing to do.
+- `apyBps` below ~200 and no dislocation: hold WETH, do not stake.
 - Queue no longer fits and you already hold LST: hold, do not sell.
 - No WETH and no LST at all: this venue is WETH-denominated, so say so
   (`funding.wethWei` is zero) rather than trying to trade.
@@ -103,7 +127,11 @@ its discount.
 ## Revision invariants (for self-improvement)
 
 - **Never queue a redemption that cannot finalize before the run ends.** That
-  converts a good position into an unrealizable one.
+  converts a good position into an unrealizable one. Judge it on
+  `estimatedQueueDelayBlocks`, never on `withdrawalDelayBlocks`.
+- **A slash can cut the redemption rate mid-run.** It lands on one block and the
+  pool has not repriced yet, so the discount jumps: that is an opportunity to
+  buy, not a reason to panic-sell.
 - **Never panic-sell late.** Holding is already marked at the pool price.
 - Tunable: the discount thresholds, sizing fractions, how much slack to leave on
   the queue check.

--- a/example/agents/lst-carry/prompt.md
+++ b/example/agents/lst-carry/prompt.md
@@ -116,6 +116,16 @@ that is a sizing problem, not a closed queue.
   size: if the pool pays much less than `marketPriceWeth x balance` suggests, you
   are too big for the book and should split the exit or queue instead.
 
+## Leverage is not your job here
+
+`protocols.lst.aaveCollateral` tells you the LST is listed as Aave collateral, so
+posting it and borrowing WETH against it is possible. **This prompt does not do
+that.** Leveraged staking multiplies the yield and the slashing exposure in equal
+measure, and the LST's Aave price follows the vault a block late, so a slash
+reaches your health factor after it reaches your position. The rule-based twin of
+this agent can do it behind an explicit opt-in; you trade the spot decisions
+above. If you find yourself reaching for `aaveSupply`, don't.
+
 ## Explicit noop criteria
 
 - `discountBps` inside +/-27bps and no free WETH: nothing to do.

--- a/example/agents/runtime/prompt.ts
+++ b/example/agents/runtime/prompt.ts
@@ -73,8 +73,8 @@ export function loadPromptAgent(agentDir: string): PromptAgent {
 const ENV_RULES = `# Environment rules
 
 You are one trading agent among several competing on a simulated DeFi market
-(Uniswap v3 / Balancer / Curve spot, GMX perp, Aave v3 lending — only the venues
-listed in observation.enabledProtocols are live this run).
+(Uniswap v3 / Balancer / Curve spot, GMX perp, Aave v3 lending, LST liquid staking —
+only the venues listed in observation.enabledProtocols are live this run).
 
 ## Observation (the user message contains the latest one as JSON)
 - fairPriceUsdcPerWeth: the environment's fair price for WETH in USDC. Venue prices
@@ -87,6 +87,14 @@ listed in observation.enabledProtocols are live this run).
   before reaching the chain (the cycle is wasted).
 - competition: priority-fee auction feedback (maxCompetitorPriorityFeeWei etc.).
   Blocks order transactions by priority fee, descending.
+- blocksRemaining: blocks left before the run ends. Anything that takes longer than
+  this to unwind cannot be unwound, and is scored at whatever you could exit it for.
+- protocols.lst (when the lst venue is live): a liquid staking token with TWO prices.
+  redemptionRateWeth is what the vault owes per LST, reachable only through a
+  withdrawal queue that takes withdrawalDelayBlocks. marketPriceWeth is what the
+  LST/WETH pool pays right now. discountBps is how far the market sits below
+  redemption (positive = LST is cheap). You are scored on what you could realize, so
+  a queued redemption only counts if it finalizes while blocksRemaining lasts.
 
 ## Action rules
 - Output exactly ONE action object per decision cycle, as JSON matching the schema.

--- a/example/agents/runtime/read.ts
+++ b/example/agents/runtime/read.ts
@@ -39,6 +39,10 @@ export class Reader {
   // begins, so it does not exist yet. Everyone starts observing at the same point, so deriving it
   // here costs at most a block or two of accuracy and gives no one an advantage.
   private firstBlock: number | null = null;
+  // When this process started, and when it first managed to observe a block. The gap between them
+  // is startup lag the run has already spent.
+  private readonly startedAtMs = Date.now();
+  private firstSeenAtMs: number | null = null;
 
   constructor(opts: {
     ctx: SimContext;
@@ -111,16 +115,40 @@ export class Reader {
       this.enabledIds,
     );
     this.firstBlock ??= bn;
+    this.firstSeenAtMs ??= Date.now();
     // The environment passes its resolved block budget, which is what a CLI --blocks override
     // changed; the YAML the child reloads still says whatever the file says.
     const runBlocks = Number(
       process.env.ERIS_RUN_BLOCKS ?? this.ctx.config.runBlocks,
     );
+    const budgets: number[] = [];
     if (runBlocks > 0) {
-      observation.blocksRemaining = Math.max(
+      // Counting from the first block *this* agent saw overstates the remaining run by however
+      // long the process took to boot -- and an agent told the run is longer than it is starts
+      // exits it cannot finish. Charge the startup lag against the budget.
+      const startupLagBlocks = Math.max(
         0,
-        runBlocks - (bn - this.firstBlock),
+        Math.round(
+          (this.firstSeenAtMs - this.startedAtMs) /
+            1000 /
+            Math.max(1, this.ctx.config.blockTimeSec),
+        ),
       );
+      budgets.push(runBlocks - startupLagBlocks - (bn - this.firstBlock));
+    }
+    // A run without a block limit still ends on the wall clock, and nothing above accounts for it.
+    const runSeconds = this.ctx.config.runSeconds;
+    if (runSeconds > 0) {
+      const elapsedSec = (Date.now() - this.startedAtMs) / 1000;
+      budgets.push(
+        Math.floor(
+          (runSeconds - elapsedSec) / Math.max(1, this.ctx.config.blockTimeSec),
+        ),
+      );
+    }
+    if (budgets.length > 0) {
+      // Whichever terminator comes first is the one that ends the run.
+      observation.blocksRemaining = Math.max(0, Math.min(...budgets));
     }
     return { observation, balances, stateById, fairPrice };
   }

--- a/example/agents/runtime/read.ts
+++ b/example/agents/runtime/read.ts
@@ -34,6 +34,11 @@ export class Reader {
   private readonly runId: string;
   private readonly extraBaseSymbols: string[];
   private readonly history: AgentObservation["history"] = [];
+  // The first block this agent saw, used to estimate how much of the run is left. The environment
+  // cannot pass the run's start block in env: agent processes are spawned before interval mining
+  // begins, so it does not exist yet. Everyone starts observing at the same point, so deriving it
+  // here costs at most a block or two of accuracy and gives no one an advantage.
+  private firstBlock: number | null = null;
 
   constructor(opts: {
     ctx: SimContext;
@@ -105,6 +110,18 @@ export class Reader {
       this.ctx.config,
       this.enabledIds,
     );
+    this.firstBlock ??= bn;
+    // The environment passes its resolved block budget, which is what a CLI --blocks override
+    // changed; the YAML the child reloads still says whatever the file says.
+    const runBlocks = Number(
+      process.env.ERIS_RUN_BLOCKS ?? this.ctx.config.runBlocks,
+    );
+    if (runBlocks > 0) {
+      observation.blocksRemaining = Math.max(
+        0,
+        runBlocks - (bn - this.firstBlock),
+      );
+    }
     return { observation, balances, stateById, fairPrice };
   }
 }

--- a/scripts/genLocalConstants.ts
+++ b/scripts/genLocalConstants.ts
@@ -59,6 +59,9 @@ type LstInfo = {
   simulatedSecondsPerBlock: number;
   targetApyBps: number;
   withdrawalDelayBlocks: number;
+  aaveAggregator?: Address;
+  aaveAToken?: Address;
+  aaveVariableDebtToken?: Address;
 };
 
 function readLst(
@@ -75,6 +78,16 @@ function readLst(
     simulatedSecondsPerBlock: Number(lst.simulatedSecondsPerBlock ?? 0),
     targetApyBps: Number(lst.targetApyBps ?? 0),
     withdrawalDelayBlocks: Number(lst.withdrawalDelayBlocks ?? 0),
+    // Phase 3: only present when the deploy also had Aave to list it on.
+    ...(lst.aaveAToken
+      ? {
+          aaveAggregator: getAddress(String(lst.aaveAggregator)),
+          aaveAToken: getAddress(String(lst.aaveAToken)),
+          aaveVariableDebtToken: getAddress(
+            String(lst.aaveVariableDebtToken),
+          ),
+        }
+      : {}),
   };
 }
 
@@ -324,7 +337,14 @@ function render(d: {
     poolWethIndex: ${d.lst.poolWethIndex},
     simulatedSecondsPerBlock: ${d.lst.simulatedSecondsPerBlock},
     targetApyBps: ${d.lst.targetApyBps},
-    withdrawalDelayBlocks: ${d.lst.withdrawalDelayBlocks},
+    withdrawalDelayBlocks: ${d.lst.withdrawalDelayBlocks},${
+      d.lst.aaveAToken
+        ? `
+    aaveAggregator: ${a(d.lst.aaveAggregator!)},
+    aaveAToken: ${a(d.lst.aaveAToken!)},
+    aaveVariableDebtToken: ${a(d.lst.aaveVariableDebtToken!)},`
+        : ""
+    }
   },`
     : "";
 
@@ -432,6 +452,9 @@ export type LocalDeployment = {
     simulatedSecondsPerBlock: number;
     targetApyBps: number;
     withdrawalDelayBlocks: number;
+    aaveAggregator?: Address;
+    aaveAToken?: Address;
+    aaveVariableDebtToken?: Address;
   };
 };
 

--- a/scripts/genLocalConstants.ts
+++ b/scripts/genLocalConstants.ts
@@ -43,8 +43,40 @@ type Deployments = {
       }[];
     };
     aaveV3?: Record<string, unknown>;
+    lst?: Record<string, string | number>;
   };
 };
+
+// Issue #38: the LST venue exists only locally (there is no Arbitrum contract to point at), and a
+// partial deploy may omit it, so every field is checked before a block is emitted.
+type LstInfo = {
+  vault: Address;
+  lstToken: Address;
+  asset: Address;
+  pool: Address;
+  poolLstIndex: number;
+  poolWethIndex: number;
+  simulatedSecondsPerBlock: number;
+  targetApyBps: number;
+  withdrawalDelayBlocks: number;
+};
+
+function readLst(
+  lst: Record<string, string | number> | undefined,
+): LstInfo | undefined {
+  if (!lst?.vault || !lst?.pool) return undefined;
+  return {
+    vault: getAddress(String(lst.vault)),
+    lstToken: getAddress(String(lst.lstToken ?? lst.vault)),
+    asset: getAddress(String(need(lst.asset, "lst.asset"))),
+    pool: getAddress(String(lst.pool)),
+    poolLstIndex: Number(need(lst.poolLstIndex, "lst.poolLstIndex")),
+    poolWethIndex: Number(need(lst.poolWethIndex, "lst.poolWethIndex")),
+    simulatedSecondsPerBlock: Number(lst.simulatedSecondsPerBlock ?? 0),
+    targetApyBps: Number(lst.targetApyBps ?? 0),
+    withdrawalDelayBlocks: Number(lst.withdrawalDelayBlocks ?? 0),
+  };
+}
 
 type GmxMarketList = NonNullable<
   NonNullable<Deployments["protocols"]["gmxV2"]>["markets"]
@@ -229,6 +261,7 @@ export function generateLocalConstants(deploymentsPath?: string): {
       PoolDataProvider: ca(aave.poolDataProvider, "aaveV3.poolDataProvider"),
     },
     wbtc: wbtcInfo,
+    lst: readLst(p.lst),
   });
 
   const target = resolve(ROOT, "sdk", "src", "constants.local.ts");
@@ -244,6 +277,12 @@ export function generateLocalConstants(deploymentsPath?: string): {
   } else {
     console.log(`  WBTC: none (WETH only. MARKET_LEGS is WETH-only)`);
   }
+  const lstInfo = readLst(p.lst);
+  console.log(
+    lstInfo
+      ? `  LST=${lstInfo.vault} (pool=${lstInfo.pool} apy=${lstInfo.targetApyBps}bps clock=${lstInfo.simulatedSecondsPerBlock}s/block)`
+      : `  LST: none (the lst venue is unavailable in this deployment)`,
+  );
   console.log(`  local run: set ERIS_LOCAL_DEPLOY=1 to use`);
   return { target, deploymentsPath: path, fingerprint };
 }
@@ -269,9 +308,25 @@ function render(d: {
   ethUsdMarket: Address;
   aave: Record<string, Address>;
   wbtc?: WbtcInfo;
+  lst?: LstInfo;
 }): string {
   const a = (x: string) => `"${x}" as Address`;
   const w = d.wbtc;
+  const lstBlock = d.lst
+    ? `
+  // Issue #38: the LST venue (wstETH-style vault + LST/WETH stableswap-ng secondary market).
+  LST: {
+    vault: ${a(d.lst.vault)},
+    lstToken: ${a(d.lst.lstToken)},
+    asset: ${a(d.lst.asset)},
+    pool: ${a(d.lst.pool)},
+    poolLstIndex: ${d.lst.poolLstIndex},
+    poolWethIndex: ${d.lst.poolWethIndex},
+    simulatedSecondsPerBlock: ${d.lst.simulatedSecondsPerBlock},
+    targetApyBps: ${d.lst.targetApyBps},
+    withdrawalDelayBlocks: ${d.lst.withdrawalDelayBlocks},
+  },`
+    : "";
 
   // ---- TOKENS' WBTC entry (if any) ----
   const tokensWbtc = w
@@ -366,6 +421,18 @@ export type LocalDeployment = {
   };
   // ADR 0013: multi-asset market legs (WBTC etc.). Includes the WBTC leg if WBTC is in deployments.json.
   MARKET_LEGS?: MarketLegs;
+  // Issue #38: present only when the deploy included the lst venue.
+  LST?: {
+    vault: Address;
+    lstToken: Address;
+    asset: Address;
+    pool: Address;
+    poolLstIndex: number;
+    poolWethIndex: number;
+    simulatedSecondsPerBlock: number;
+    targetApyBps: number;
+    withdrawalDelayBlocks: number;
+  };
 };
 
 export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
@@ -429,7 +496,7 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     AclAdmin: ${a(d.aave.AclAdmin)},
     AclManager: ${a(d.aave.AclManager)},
     PoolDataProvider: ${a(d.aave.PoolDataProvider)},
-  },${marketLegs}
+  },${lstBlock}${marketLegs}
 };
 `;
 }

--- a/sdk/src/abis.ts
+++ b/sdk/src/abis.ts
@@ -114,7 +114,14 @@ export const lstVaultAbi = parseAbi([
   "function accountSummary(address owner) view returns (uint256 shares, uint256 shareAssets, uint256 pendingAssets, uint256 claimableAssets, uint256 nextClaimableAt, uint256 openRequests)",
   "function accountSummaryAt(address owner, uint256 horizonBlock) view returns (uint256 shares, uint256 shareAssets, uint256 claimableAssets, uint256 reachableAssets, uint256 unreachableAssets, uint256 openRequests)",
   "function openRequestsOf(address owner) view returns (uint256[] ids, uint256[] assets, uint256[] claimableAt)",
-  "function vaultSummary() view returns (uint256 pooledWeth, uint256 shareSupply, uint256 redemptionRate, uint256 reserve, uint256 queuedWeth, uint256 queueLength, uint256 delayBlocks, uint256 ratePerBlockRay)",
+  "function vaultSummary() view returns (uint256 pooledWeth, uint256 shareSupply, uint256 redemptionRate, uint256 reserve, uint256 queuedWeth, uint256 queueLength, uint256 delayBlocks, uint256 ratePerBlockRay, uint256 throughputWeiPerBlock, uint256 drainBlock)",
+  // Issue #38 phase 2: the queue is rate-limited, so the wait depends on your size and on what is
+  // already queued ahead of you. Quote it before committing rather than discovering it after.
+  "function estimateClaimableAt(uint256 assets) view returns (uint256)",
+  "function estimateDelayBlocks(uint256 assets) view returns (uint256)",
+  "function setQueueThroughput(uint256 weiPerBlock)",
+  "function queueThroughputWeiPerBlock() view returns (uint256)",
+  "function queueDrainBlock() view returns (uint256)",
   "function surplusWeth() view returns (uint256)",
 ]);
 

--- a/sdk/src/abis.ts
+++ b/sdk/src/abis.ts
@@ -68,6 +68,56 @@ export const balancerQueriesAbi = parseAbi([
   "function querySwap((bytes32 poolId, uint8 kind, address assetIn, address assetOut, uint256 amount, bytes userData) singleSwap, (address sender, bool fromInternalBalance, address recipient, bool toInternalBalance) funds) returns (uint256)",
 ]);
 
+// Curve StableSwap-NG (the LST/WETH secondary market, issue #38). Note the int128 coin indices --
+// stableswap and the crypto pools above disagree on that, so they cannot share an ABI.
+export const curveStableSwapNgAbi = parseAbi([
+  "function get_dy(int128 i, int128 j, uint256 dx) view returns (uint256)",
+  "function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) returns (uint256)",
+  "function coins(uint256 i) view returns (address)",
+  "function balances(uint256 i) view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+  // The rate the pool applies to each coin. For the LST leg this is the vault's redemption rate,
+  // which is what keeps a rising exchange rate from opening a free arb (issue #38).
+  "function stored_rates() view returns (uint256[])",
+  "function A() view returns (uint256)",
+  "function fee() view returns (uint256)",
+]);
+
+// MockLSTVault (issue #38): ERC-4626 shaped with wstETH aliases and a request/claim withdrawal
+// queue. `redeem` enqueues rather than paying out, so previewRedeem is the queue's eventual payout.
+export const lstVaultAbi = parseAbi([
+  "function asset() view returns (address)",
+  "function totalAssets() view returns (uint256)",
+  "function balanceOf(address owner) view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+  "function approve(address spender, uint256 amount) returns (bool)",
+  "function convertToShares(uint256 assets) view returns (uint256)",
+  "function convertToAssets(uint256 shares) view returns (uint256)",
+  "function previewDeposit(uint256 assets) view returns (uint256)",
+  "function previewRedeem(uint256 shares) view returns (uint256)",
+  "function stEthPerToken() view returns (uint256)",
+  "function deposit(uint256 assets, address receiver) returns (uint256)",
+  "function requestWithdraw(uint256 shares) returns (uint256)",
+  "function claimWithdraw(uint256 requestId) returns (uint256)",
+  "function claimAllWithdrawals() returns (uint256)",
+  "function accrueRewards() returns (uint256)",
+  "function fundRewards(uint256 assets)",
+  "function slash(uint256 bps) returns (uint256)",
+  "function setRewardRate(uint256 ratePerBlockRay)",
+  "function setWithdrawalDelayBlocks(uint256 delayBlocks)",
+  "function operators(address account) view returns (bool)",
+  "function rewardReserve() view returns (uint256)",
+  "function withdrawalDelayBlocks() view returns (uint256)",
+  "function rewardRatePerBlockRay() view returns (uint256)",
+  "function requestIdsOf(address owner) view returns (uint256[])",
+  "function withdrawalRequests(uint256 id) view returns (address owner, uint256 shares, uint256 assets, uint256 claimableAt, bool claimed)",
+  "function accountSummary(address owner) view returns (uint256 shares, uint256 shareAssets, uint256 pendingAssets, uint256 claimableAssets, uint256 nextClaimableAt, uint256 openRequests)",
+  "function accountSummaryAt(address owner, uint256 horizonBlock) view returns (uint256 shares, uint256 shareAssets, uint256 claimableAssets, uint256 reachableAssets, uint256 unreachableAssets, uint256 openRequests)",
+  "function openRequestsOf(address owner) view returns (uint256[] ids, uint256[] assets, uint256[] claimableAt)",
+  "function vaultSummary() view returns (uint256 pooledWeth, uint256 shareSupply, uint256 redemptionRate, uint256 reserve, uint256 queuedWeth, uint256 queueLength, uint256 delayBlocks, uint256 ratePerBlockRay)",
+  "function surplusWeth() view returns (uint256)",
+]);
+
 // Curve CryptoSwap (tricrypto v0.2.x): exchange / get_dy / coins / balances
 export const curveTricryptoAbi = parseAbi([
   "function get_dy(uint256 i, uint256 j, uint256 dx) view returns (uint256)",

--- a/sdk/src/action.ts
+++ b/sdk/src/action.ts
@@ -369,12 +369,14 @@ function applyLeafSpend(
       spendStable(BigInt(item.amountQuoteDesired ?? item.amountUsdcDesired));
       break;
     case "aaveSupply":
-      if (kindOf(item.asset) === "base")
-        spendBase(item.asset, BigInt(item.amount));
-      else spendStable(BigInt(item.amount));
+      // Anything that is not the settlement stable is deducted from the base side. An LST is
+      // neither (issue #38 phase 3) and is not in the bases map, so spendBase is a no-op for it --
+      // correct, since its balance is tracked by its own venue rather than here.
+      if (kindOf(item.asset) === "stable") spendStable(BigInt(item.amount));
+      else spendBase(item.asset, BigInt(item.amount));
       break;
     case "aaveRepay": {
-      const isBase = kindOf(item.asset) === "base";
+      const isBase = kindOf(item.asset) !== "stable";
       const amt =
         item.amount === "max"
           ? isBase

--- a/sdk/src/action.ts
+++ b/sdk/src/action.ts
@@ -368,6 +368,18 @@ function applyLeafSpend(
       );
       spendStable(BigInt(item.amountQuoteDesired ?? item.amountUsdcDesired));
       break;
+    // Issue #38: an lst leg is bundleable, so cumulative validation has to see what it consumes.
+    // Without these two cases both leaves of a {lstDeposit 10 WETH, lstSwap 10 WETH} bundle
+    // validated against the same untouched balance, the bundle was accepted, and the second leg
+    // reverted on chain at the agent's expense.
+    case "lstDeposit":
+      spendBase("WETH", BigInt(item.amountWethWei));
+      break;
+    case "lstSwap":
+      if (item.tokenIn === "WETH") spendBase("WETH", BigInt(item.amountIn));
+      // Selling LST credits WETH, but the LST side is not in the bases map (it is the venue's own
+      // accounting), so there is nothing to deduct and the credit is left to the on-chain result.
+      break;
     case "aaveSupply":
       // Anything that is not the settlement stable is deducted from the base side. An LST is
       // neither (issue #38 phase 3) and is not in the bases map, so spendBase is a no-op for it --

--- a/sdk/src/actionSchema.ts
+++ b/sdk/src/actionSchema.ts
@@ -154,6 +154,45 @@ export const gmxDecreaseSchema = z.object({
   ...priorityFee,
 });
 
+// LST venue (issue #38). The market is LST/WETH, so there is no `base` market selector here.
+export const lstDepositSchema = z.object({
+  type: z.literal("lstDeposit"),
+  amountWethWei: decimalString.describe(
+    "WETH to stake (wei). Mints LST at the vault's current redemption rate.",
+  ),
+  ...priorityFee,
+});
+
+export const lstSwapSchema = z.object({
+  type: z.literal("lstSwap"),
+  tokenIn: z
+    .enum(["WETH", "LST"])
+    .describe(
+      'the token you are sending: "WETH" buys LST from the secondary market, "LST" sells into it (the instant exit, at the pool\'s discount).',
+    ),
+  amountIn: decimalString.describe("wei of tokenIn (both are 18-decimal)"),
+  slippageBps: z.number().int().nonnegative().optional(),
+  ...priorityFee,
+});
+
+export const lstRequestWithdrawSchema = z.object({
+  type: z.literal("lstRequestWithdraw"),
+  amountLstWei: decimalString.describe(
+    "LST shares to queue for redemption at par (wei). Claimable after withdrawalDelayBlocks; this is the slow, full-value exit.",
+  ),
+  ...priorityFee,
+});
+
+export const lstClaimWithdrawSchema = z.object({
+  type: z.literal("lstClaimWithdraw"),
+  requestId: decimalString
+    .optional()
+    .describe(
+      "a specific queued request id. Omit to claim every request that has finalized.",
+    ),
+  ...priorityFee,
+});
+
 const rawTxSchema = z.object({
   to: hexString,
   data: hexString,
@@ -190,6 +229,12 @@ const LEAF_SCHEMAS_BY_PROTOCOL: Record<ProtocolId, z.ZodTypeAny[]> = {
     aaveRepaySchema,
   ],
   gmx: [gmxIncreaseSchema, gmxDecreaseSchema],
+  lst: [
+    lstDepositSchema,
+    lstSwapSchema,
+    lstRequestWithdrawSchema,
+    lstClaimWithdrawSchema,
+  ],
 };
 
 // GMX cannot be bundled because it requires keeper execution (same rule as bundleable in action.ts).
@@ -198,11 +243,19 @@ const BUNDLEABLE_PROTOCOLS: ProtocolId[] = [
   "balancer",
   "curve",
   "aave",
+  "lst",
 ];
 
 // AgentAction schema restricted to enabled venues (default is all venues).
 export function agentActionSchemaFor(
-  enabled: ProtocolId[] = ["uniswap", "balancer", "curve", "gmx", "aave"],
+  enabled: ProtocolId[] = [
+    "uniswap",
+    "balancer",
+    "curve",
+    "gmx",
+    "aave",
+    "lst",
+  ],
 ): z.ZodTypeAny {
   const leaves = enabled.flatMap((id) => LEAF_SCHEMAS_BY_PROTOCOL[id] ?? []);
   const bundleable = enabled

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -183,6 +183,16 @@ export type SimConfig = {
   // Target APY in bps on that clock. Kept the same order as the Aave WETH supply rate on purpose:
   // a 1000x-speed LST would make every other venue irrelevant.
   lstApyBps: number;
+  // Issue #38 phase 2: when set to a [min,max] bps pair, the APY is resampled from it every
+  // lstApyStepBlocks using a seed-derived Rng, instead of holding lstApyBps for the whole run.
+  // Without variation the optimum is "stake everything at block 0" and the venue has no decision
+  // in it. Empty (the default) keeps the fixed rate.
+  lstApyRangeBps: [number, number] | null;
+  lstApyStepBlocks: number;
+  // Queued WETH the vault can finalize per block. 0 leaves whatever the deploy baked in, and a
+  // deploy default of 0 means no limit -- every request waits exactly the delay. With a limit, the
+  // wait grows with your own size and with whatever is queued ahead of you.
+  lstQueueThroughputWeiPerBlock: bigint;
   // Blocks between requesting a redemption and being able to claim it (the queue's time cost).
   // 0 leaves whatever the deploy baked in.
   lstWithdrawalDelayBlocks: number;
@@ -394,6 +404,15 @@ export function loadConfig(env = process.env): SimConfig {
       intEnv(env.ERIS_LST_SIMULATED_SECONDS_PER_BLOCK, 3600),
     ),
     lstApyBps: Math.max(0, intEnv(env.ERIS_LST_APY_BPS, 300)),
+    lstApyRangeBps: parseBpsRange(
+      env.ERIS_LST_APY_RANGE_BPS,
+      "ERIS_LST_APY_RANGE_BPS",
+    ),
+    lstApyStepBlocks: Math.max(1, intEnv(env.ERIS_LST_APY_STEP_BLOCKS, 10)),
+    lstQueueThroughputWeiPerBlock: bigintEnv(
+      env.ERIS_LST_QUEUE_THROUGHPUT_WEI_PER_BLOCK,
+      0n,
+    ),
     lstWithdrawalDelayBlocks: Math.max(
       0,
       intEnv(env.ERIS_LST_WITHDRAWAL_DELAY_BLOCKS, 0),
@@ -470,6 +489,25 @@ function floatEnv(value: string | undefined, fallback: number): number {
 function bigintEnv(value: string | undefined, fallback: bigint): bigint {
   if (value === undefined || value === "") return fallback;
   return BigInt(value);
+}
+
+// A "[min, max]" bps pair, accepted as JSON or as a bare CSV so it survives the YAML→env encoding
+// (an array of numbers becomes "200,600"). Null when unset, which means "no variation".
+function parseBpsRange(
+  value: string | undefined,
+  label: string,
+): [number, number] | null {
+  if (value === undefined || value.trim() === "") return null;
+  const parts = value
+    .trim()
+    .replace(/^\[|\]$/g, "")
+    .split(",")
+    .map((s) => Number(s.trim()));
+  if (parts.length !== 2 || parts.some((n) => !Number.isFinite(n) || n < 0))
+    throw new Error(`${label} must be a [min, max] pair of non-negative bps`);
+  const [lo, hi] = parts;
+  if (lo > hi) throw new Error(`${label} must have min <= max`);
+  return [lo, hi];
 }
 
 // ADR 0013: unit suffix (derived from decimals) for a base symbol's "amount env".

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -13,6 +13,8 @@ import {
 import type { ProtocolId } from "./types.js";
 import { baseTokens } from "./markets.js";
 
+// The lst venue is deliberately not in the default set: it exists only under local deploy (issue
+// #38), so defaulting it on would break every fork run. Enable it explicitly via run.protocols.
 const ALL_PROTOCOLS: ProtocolId[] = [
   "uniswap",
   "balancer",
@@ -20,6 +22,9 @@ const ALL_PROTOCOLS: ProtocolId[] = [
   "gmx",
   "aave",
 ];
+
+// Protocols that can be named in run.protocols but are not in the default set.
+const OPT_IN_PROTOCOLS: ProtocolId[] = ["lst"];
 
 export type SimConfig = {
   rpcUrl: string;
@@ -170,6 +175,19 @@ export type SimConfig = {
   aaveFlowActorSizeSigma: number;
   // ADR 0013: per-leg AMM flow cap for non-WETH bases (base units). Empty/0 default = WBTC flow off.
   baseFlowMax: Record<string, bigint>;
+  // ---- LST venue (issue #38) ----
+  // Yield runs on a compressed *economic* clock rather than EVM time: one block stands for this
+  // many seconds of staking. EVM time is deliberately not warped for it (that would also move
+  // Aave's accrual and GMX funding).
+  lstSimulatedSecondsPerBlock: number;
+  // Target APY in bps on that clock. Kept the same order as the Aave WETH supply rate on purpose:
+  // a 1000x-speed LST would make every other venue irrelevant.
+  lstApyBps: number;
+  // Blocks between requesting a redemption and being able to claim it (the queue's time cost).
+  // 0 leaves whatever the deploy baked in.
+  lstWithdrawalDelayBlocks: number;
+  // Per-agent cap on a single stake, in wei. 0 = uncapped (bounded by balance).
+  lstMaxDepositWethWei: bigint;
   // Launch command and deterministic seed for the orderflow bot (a separate process).
   flowBotCommand: string;
   flowBotArgs: string[];
@@ -369,6 +387,21 @@ export function loadConfig(env = process.env): SimConfig {
     // (e.g. FLOW_MAX_WBTC_SATS). Default 0 = flow off for WBTC etc. → extraBases do not consume RNG = byte-compatible.
     // WETH flow keeps using uninformed/balancer/curve FlowMaxWethWei (not listed here).
     baseFlowMax: readBaseAmounts(env, "FLOW_MAX", { WETH: 0n }),
+    // LST venue (issue #38). The defaults mirror what the deployer bakes into the state dump, so a
+    // run that says nothing about lst behaves exactly as deployed.
+    lstSimulatedSecondsPerBlock: Math.max(
+      0,
+      intEnv(env.ERIS_LST_SIMULATED_SECONDS_PER_BLOCK, 3600),
+    ),
+    lstApyBps: Math.max(0, intEnv(env.ERIS_LST_APY_BPS, 300)),
+    lstWithdrawalDelayBlocks: Math.max(
+      0,
+      intEnv(env.ERIS_LST_WITHDRAWAL_DELAY_BLOCKS, 0),
+    ),
+    lstMaxDepositWethWei: bigintEnv(
+      env.ERIS_LST_MAX_DEPOSIT_WETH_WEI,
+      5_000_000_000_000_000_000n,
+    ),
     flowBotCommand: env.FLOW_BOT_COMMAND ?? "node",
     flowBotArgs:
       env.FLOW_BOT_ARGS && env.FLOW_BOT_ARGS.trim() !== ""
@@ -405,7 +438,8 @@ function parseEnabledProtocols(value: string | undefined): ProtocolId[] {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean) as ProtocolId[];
-  const invalid = ids.filter((id) => !ALL_PROTOCOLS.includes(id));
+  const known = [...ALL_PROTOCOLS, ...OPT_IN_PROTOCOLS];
+  const invalid = ids.filter((id) => !known.includes(id));
   if (invalid.length > 0)
     throw new Error(
       `unknown protocol in ENABLED_PROTOCOLS: ${invalid.join(", ")}`,

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -7,7 +7,7 @@ import type { MarketLegs } from "./types.js";
 
 // Canonical fingerprint of the source deployments.json (ADR 0016 §2). The backtest CLI
 // compares it against the state dump manifest and, on mismatch, regenerates from the manifest's bundled deployments.
-export const DEPLOYMENTS_FINGERPRINT = "sha256:409706837cde777e0b03a10c57a48b75fdd1c37a1d818fd3b5419499710e9f75";
+export const DEPLOYMENTS_FINGERPRINT = "sha256:b7d41bba15bd2c1ce520982367e50e6f30381de94390fb4033fda3ce26633d5a";
 
 export type LocalDeployment = {
   CHAIN_ID: number;

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -7,7 +7,7 @@ import type { MarketLegs } from "./types.js";
 
 // Canonical fingerprint of the source deployments.json (ADR 0016 §2). The backtest CLI
 // compares it against the state dump manifest and, on mismatch, regenerates from the manifest's bundled deployments.
-export const DEPLOYMENTS_FINGERPRINT = "sha256:0ea10b08653ec9ea09c4524268c56c2c3f3730326cccd5d87e3bc0d15fb501be";
+export const DEPLOYMENTS_FINGERPRINT = "sha256:df9a6a34d7dc09fc3220a0888ee5a42ab1e750f4158c0cebbd26c8e6e9cb31aa";
 
 export type LocalDeployment = {
   CHAIN_ID: number;
@@ -48,6 +48,18 @@ export type LocalDeployment = {
   };
   // ADR 0013: multi-asset market legs (WBTC etc.). Includes the WBTC leg if WBTC is in deployments.json.
   MARKET_LEGS?: MarketLegs;
+  // Issue #38: present only when the deploy included the lst venue.
+  LST?: {
+    vault: Address;
+    lstToken: Address;
+    asset: Address;
+    pool: Address;
+    poolLstIndex: number;
+    poolWethIndex: number;
+    simulatedSecondsPerBlock: number;
+    targetApyBps: number;
+    withdrawalDelayBlocks: number;
+  };
 };
 
 export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
@@ -92,19 +104,19 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     usdcToken: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address,
   },
   GMX: {
-    RoleStore: "0xD49a0e9A4CD5979aE36840f542D2d7f02C4817Be" as Address,
-    DataStore: "0x70bDA08DBe07363968e9EE53d899dFE48560605B" as Address,
-    Oracle: "0x54B8d8E2455946f2A5B8982283f2359812e815ce" as Address,
-    EventEmitter: "0x821f3361D454cc98b7555221A06Be563a7E2E0A6" as Address,
-    Router: "0x9BcC604D4381C5b0Ad12Ff3Bf32bEdE063416BC7" as Address,
-    ExchangeRouter: "0x3a622DB2db50f463dF562Dc5F341545A64C580fc" as Address,
-    OrderHandler: "0x0fe4223AD99dF788A6Dcad148eB4086E6389cEB6" as Address,
-    OrderVault: "0x3C15538ED063e688c8DF3d571Cb7a0062d2fB18D" as Address,
-    LiquidationHandler: "0xF6a8aD553b265405526030c2102fda2bDcdDC177" as Address,
-    Reader: "0xF85895D097B2C25946BB95C4d11E2F3c035F8f0C" as Address,
-    Config: "0xC66AB83418C20A65C3f8e83B3d11c8C3a6097b6F" as Address,
+    RoleStore: "0x0000000000000000000000000000000000000000" as Address,
+    DataStore: "0x0000000000000000000000000000000000000000" as Address,
+    Oracle: "0x0000000000000000000000000000000000000000" as Address,
+    EventEmitter: "0x0000000000000000000000000000000000000000" as Address,
+    Router: "0x0000000000000000000000000000000000000000" as Address,
+    ExchangeRouter: "0x0000000000000000000000000000000000000000" as Address,
+    OrderHandler: "0x0000000000000000000000000000000000000000" as Address,
+    OrderVault: "0x0000000000000000000000000000000000000000" as Address,
+    LiquidationHandler: "0x0000000000000000000000000000000000000000" as Address,
+    Reader: "0x0000000000000000000000000000000000000000" as Address,
+    Config: "0x0000000000000000000000000000000000000000" as Address,
   },
-  GMX_MARKETS: { ETH_USD: "0xE733b869384b78dB550a4D5aC903E96B936D9293" as Address },
+  GMX_MARKETS: { ETH_USD: "0x0000000000000000000000000000000000000000" as Address },
   AAVE: {
     PoolAddressesProvider: "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07" as Address,
     Pool: "0x7B6fCB97Fc1B74e16CBe577054a4426d3487837C" as Address,
@@ -112,6 +124,18 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     AclAdmin: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as Address,
     AclManager: "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B" as Address,
     PoolDataProvider: "0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f" as Address,
+  },
+  // Issue #38: the LST venue (wstETH-style vault + LST/WETH stableswap-ng secondary market).
+  LST: {
+    vault: "0xD49a0e9A4CD5979aE36840f542D2d7f02C4817Be" as Address,
+    lstToken: "0xD49a0e9A4CD5979aE36840f542D2d7f02C4817Be" as Address,
+    asset: "0x5FbDB2315678afecb367f032d93F642f64180aa3" as Address,
+    pool: "0x3d8bf8Fc25136DC4Bf6CF7c2ee688b9a66a480F3" as Address,
+    poolLstIndex: 1,
+    poolWethIndex: 0,
+    simulatedSecondsPerBlock: 3600,
+    targetApyBps: 300,
+    withdrawalDelayBlocks: 24,
   },
   MARKET_LEGS: {
     uniswap: {
@@ -127,8 +151,7 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
       WBTC: { pool: "0xF2AdAad89d56D49C697B9907C7D66ef27d96f859" as Address, baseIndex: 1, quoteIndex: 0, stable: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address },
     },
     gmx: {
-      WETH: { market: "0xE733b869384b78dB550a4D5aC903E96B936D9293" as Address },
-      WBTC: { market: "0x1aE4DB9915671B3E15fc265bAF3B9E509DC1f56e" as Address },
+      WETH: { market: "0x0000000000000000000000000000000000000000" as Address },
     },
     aave: {
       WETH: {},

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -7,7 +7,7 @@ import type { MarketLegs } from "./types.js";
 
 // Canonical fingerprint of the source deployments.json (ADR 0016 §2). The backtest CLI
 // compares it against the state dump manifest and, on mismatch, regenerates from the manifest's bundled deployments.
-export const DEPLOYMENTS_FINGERPRINT = "sha256:df9a6a34d7dc09fc3220a0888ee5a42ab1e750f4158c0cebbd26c8e6e9cb31aa";
+export const DEPLOYMENTS_FINGERPRINT = "sha256:667fd167cccfc4cd05b10d05cbfcd72819b4a9f922d75f628b3cbf29c017f1e6";
 
 export type LocalDeployment = {
   CHAIN_ID: number;

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -7,7 +7,7 @@ import type { MarketLegs } from "./types.js";
 
 // Canonical fingerprint of the source deployments.json (ADR 0016 §2). The backtest CLI
 // compares it against the state dump manifest and, on mismatch, regenerates from the manifest's bundled deployments.
-export const DEPLOYMENTS_FINGERPRINT = "sha256:179a47cf7017a30988c339a84057bf1dc97cc23b1b8bb84c0f7ec329bba1b3fe";
+export const DEPLOYMENTS_FINGERPRINT = "sha256:409706837cde777e0b03a10c57a48b75fdd1c37a1d818fd3b5419499710e9f75";
 
 export type LocalDeployment = {
   CHAIN_ID: number;
@@ -107,19 +107,19 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     usdcToken: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address,
   },
   GMX: {
-    RoleStore: "0x0000000000000000000000000000000000000000" as Address,
-    DataStore: "0x0000000000000000000000000000000000000000" as Address,
-    Oracle: "0x0000000000000000000000000000000000000000" as Address,
-    EventEmitter: "0x0000000000000000000000000000000000000000" as Address,
-    Router: "0x0000000000000000000000000000000000000000" as Address,
-    ExchangeRouter: "0x0000000000000000000000000000000000000000" as Address,
-    OrderHandler: "0x0000000000000000000000000000000000000000" as Address,
-    OrderVault: "0x0000000000000000000000000000000000000000" as Address,
-    LiquidationHandler: "0x0000000000000000000000000000000000000000" as Address,
-    Reader: "0x0000000000000000000000000000000000000000" as Address,
-    Config: "0x0000000000000000000000000000000000000000" as Address,
+    RoleStore: "0xB06c856C8eaBd1d8321b687E188204C1018BC4E5" as Address,
+    DataStore: "0x71089Ba41e478702e1904692385Be3972B2cBf9e" as Address,
+    Oracle: "0xD6b040736e948621c5b6E0a494473c47a6113eA8" as Address,
+    EventEmitter: "0xf090f16dEc8b6D24082Edd25B1C8D26f2bC86128" as Address,
+    Router: "0x3904b8f5b0F49cD206b7d5AABeE5D1F37eE15D8d" as Address,
+    ExchangeRouter: "0x9C85258d9A00C01d00ded98065ea3840dF06f09c" as Address,
+    OrderHandler: "0x0Dd99d9f56A14E9D53b2DdC62D9f0bAbe806647A" as Address,
+    OrderVault: "0x8fC8CFB7f7362E44E472c690A6e025B80E406458" as Address,
+    LiquidationHandler: "0xF5b81Fe0B6F378f9E6A3fb6A6cD1921FCeA11799" as Address,
+    Reader: "0x6B21b3ae41f818Fc91e322b53f8D0773d31eCB75" as Address,
+    Config: "0x071586BA1b380B00B793Cc336fe01106B0BFbE6D" as Address,
   },
-  GMX_MARKETS: { ETH_USD: "0x0000000000000000000000000000000000000000" as Address },
+  GMX_MARKETS: { ETH_USD: "0xA5ecC14E7c21e0E4Fc9B41092F3db87d7B3c9865" as Address },
   AAVE: {
     PoolAddressesProvider: "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07" as Address,
     Pool: "0x7B6fCB97Fc1B74e16CBe577054a4426d3487837C" as Address,
@@ -157,7 +157,8 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
       WBTC: { pool: "0xF2AdAad89d56D49C697B9907C7D66ef27d96f859" as Address, baseIndex: 1, quoteIndex: 0, stable: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as Address },
     },
     gmx: {
-      WETH: { market: "0x0000000000000000000000000000000000000000" as Address },
+      WETH: { market: "0xA5ecC14E7c21e0E4Fc9B41092F3db87d7B3c9865" as Address },
+      WBTC: { market: "0x2ffb9D923da1736ad51739B857cEf3a56EFD5f47" as Address },
     },
     aave: {
       WETH: {},

--- a/sdk/src/constants.local.ts
+++ b/sdk/src/constants.local.ts
@@ -7,7 +7,7 @@ import type { MarketLegs } from "./types.js";
 
 // Canonical fingerprint of the source deployments.json (ADR 0016 §2). The backtest CLI
 // compares it against the state dump manifest and, on mismatch, regenerates from the manifest's bundled deployments.
-export const DEPLOYMENTS_FINGERPRINT = "sha256:667fd167cccfc4cd05b10d05cbfcd72819b4a9f922d75f628b3cbf29c017f1e6";
+export const DEPLOYMENTS_FINGERPRINT = "sha256:179a47cf7017a30988c339a84057bf1dc97cc23b1b8bb84c0f7ec329bba1b3fe";
 
 export type LocalDeployment = {
   CHAIN_ID: number;
@@ -59,6 +59,9 @@ export type LocalDeployment = {
     simulatedSecondsPerBlock: number;
     targetApyBps: number;
     withdrawalDelayBlocks: number;
+    aaveAggregator?: Address;
+    aaveAToken?: Address;
+    aaveVariableDebtToken?: Address;
   };
 };
 
@@ -136,6 +139,9 @@ export const LOCAL_DEPLOYMENT: LocalDeployment | null = {
     simulatedSecondsPerBlock: 3600,
     targetApyBps: 300,
     withdrawalDelayBlocks: 24,
+    aaveAggregator: "0x70bDA08DBe07363968e9EE53d899dFE48560605B" as Address,
+    aaveAToken: "0xfB2C19FF34F419a02e4564e8Ce6A3448fAD93f8b" as Address,
+    aaveVariableDebtToken: "0x555a114B12884781a975Fa45bDb4d3cC9ba1d640" as Address,
   },
   MARKET_LEGS: {
     uniswap: {

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -184,6 +184,11 @@ export type LstDeployment = {
   simulatedSecondsPerBlock: number;
   targetApyBps: number;
   withdrawalDelayBlocks: number;
+  // Issue #38 phase 3: present when the LST is listed as Aave collateral. Absent when the deploy
+  // had no Aave, in which case the venue still works and only leverage is unavailable.
+  aaveAggregator?: Address;
+  aaveAToken?: Address;
+  aaveVariableDebtToken?: Address;
 };
 
 export const LST: LstDeployment | null = L?.LST ?? null;

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -165,6 +165,39 @@ export const AAVE = L?.AAVE ?? {
 };
 
 // ---------------------------------------------------------------------------
+// LST venue (issue #38). A wstETH-style vault plus its LST/WETH stableswap-ng secondary market.
+//
+// Unlike the other venues there is no Arbitrum counterpart to point at: the vault is ours, deployed
+// by the bundled deployer and baked into the ADR 0016 state dump. So this is null on a fork, and a
+// run that enables the lst protocol without local deploy fails fast rather than reading zeros.
+// ---------------------------------------------------------------------------
+export type LstDeployment = {
+  vault: Address;
+  // The vault is its own share token (non-rebasing wstETH model), so this equals `vault`. Kept
+  // separate because nothing else should have to know that.
+  lstToken: Address;
+  asset: Address; // WETH
+  pool: Address; // LST/WETH stableswap-ng
+  poolLstIndex: number;
+  poolWethIndex: number;
+  // Deploy-time economic clock, reported so a run can say what it inherited (a run may retune it).
+  simulatedSecondsPerBlock: number;
+  targetApyBps: number;
+  withdrawalDelayBlocks: number;
+};
+
+export const LST: LstDeployment | null = L?.LST ?? null;
+
+export function requireLst(): LstDeployment {
+  if (!LST)
+    throw new Error(
+      "the lst venue is not deployed in this environment: it exists only under local deploy " +
+        "(run.localDeploy: true with a state dump / deployer that includes lst). Drop lst from run.protocols to use a fork.",
+    );
+  return LST;
+}
+
+// ---------------------------------------------------------------------------
 // Market leg registry (ADR 0013). Venue-specific leg per protocol × base.
 // The fork default is WETH/USDC only (built from the existing venue constants). Under local-deploy,
 // genLocalConstants overlays a MARKET_LEGS that adds WBTC etc. (L?.MARKET_LEGS).

--- a/sdk/src/markets.ts
+++ b/sdk/src/markets.ts
@@ -33,8 +33,14 @@ const QUOTE_SYMBOL: TokenSymbol = "USDC";
 // Add here only when adding a new stable. A base is treated as a base without doing anything.
 const STABLE_SYMBOLS = new Set<TokenSymbol>(["USDC", "USDT", "DAI", "USDC.e"]);
 
+// Yield-bearing claims valued by their own venue rather than by the fair-price feed (issue #38).
+// Listed here so they stay out of the scorer's spot sweep -- see TokenKind for why.
+const LST_SYMBOLS = new Set<TokenSymbol>(["LST"]);
+
 export function kindOf(symbol: TokenSymbol): TokenKind {
-  return STABLE_SYMBOLS.has(symbol) ? "stable" : "base";
+  if (STABLE_SYMBOLS.has(symbol)) return "stable";
+  if (LST_SYMBOLS.has(symbol)) return "lst";
+  return "base";
 }
 
 export function tokenInfo(symbol: TokenSymbol): TokenInfo {

--- a/sdk/src/markets.ts
+++ b/sdk/src/markets.ts
@@ -114,7 +114,11 @@ function attachLeg(
 // Assemble the protocol's enabled markets from MARKET_LEGS. Preserves the base registration order
 // (WETH first → the deterministic-order premise for RNG/scoring. ADR 0013 backward compatibility).
 export function marketsFor(protocol: ProtocolId): MarketConfig[] {
-  const legs = MARKET_LEGS[protocol];
+  // A venue whose market is not a base/USDC pair has no leg table: the LST venue trades LST/WETH
+  // and keeps that market adapter-private (issue #38). Generalizing MarketConfig's `quote` so it
+  // could live here is a separate cleanup.
+  const legs = MARKET_LEGS[protocol as keyof typeof MARKET_LEGS];
+  if (!legs) return [];
   const out: MarketConfig[] = [];
   for (const base of Object.keys(legs)) {
     const market: MarketConfig = {

--- a/sdk/src/observation.ts
+++ b/sdk/src/observation.ts
@@ -96,6 +96,8 @@ export async function observationFor(
       maxGmxSizeUsd: config.maxGmxSizeUsd.toString(),
       maxAaveSupplyWethWei: config.maxAaveSupplyWethWei.toString(),
       maxAaveBorrowUsdcUnits: config.maxAaveBorrowUsdcUnits.toString(),
+      // Issue #38: per-stake cap for the LST venue.
+      maxLstDepositWethWei: config.lstMaxDepositWethWei.toString(),
       // ADR 0013: expose per-base caps. WETH is the existing value; additional bases come from config's per-base map (default 0).
       baseLimits: buildBaseLimits(config),
     },

--- a/sdk/src/protocols/aave.ts
+++ b/sdk/src/protocols/aave.ts
@@ -5,7 +5,7 @@ import {
   type Address,
   type PublicClient,
 } from "viem";
-import { AAVE, TOKENS, stableBalanceOf } from "../constants.js";
+import { AAVE, LST, TOKENS, stableBalanceOf } from "../constants.js";
 import { marketsFor, tokenInfo, tokenRegistry } from "../markets.js";
 import {
   accountAddress,
@@ -95,23 +95,32 @@ export const mockAggregatorAbi = parseAbi([
 // Aave uses native USDC as the reserve (settlement stable).
 const AAVE_STABLE = TOKENS.USDC.address;
 const AAVE_STABLE_SYMBOL: TokenSymbol = "USDC";
+// The LST venue's share token, when it is listed as collateral (issue #38 phase 3).
+const LST_SYMBOL: TokenSymbol = "LST";
 
 // Base symbols enabled for aave (from MARKET_LEGS.aave; WETH only on the default fork).
 function aaveBaseSymbols(): TokenSymbol[] {
   return marketsFor("aave").map((m) => m.base);
 }
 
-// Symbols of the reserves we read/write (enabled bases + settlement stable).
-// [WETH, USDC] on the default fork (matches prior behavior).
+// Symbols of the reserves we read/write (enabled bases + settlement stable + the LST when it is
+// listed). [WETH, USDC] on the default fork (matches prior behavior).
+//
+// The LST is collateral only (issue #38 phase 3): it is listed so ETH can be borrowed *against* it,
+// which is the leveraged-staking loop, and the reserve is deliberately not borrow-enabled. Supply
+// and withdraw are the operations that make sense; a borrow of it is rejected on chain.
 function aaveReserveSymbols(): TokenSymbol[] {
-  return [...aaveBaseSymbols(), AAVE_STABLE_SYMBOL];
+  const symbols = [...aaveBaseSymbols(), AAVE_STABLE_SYMBOL];
+  if (LST?.aaveAToken) symbols.push(LST_SYMBOL);
+  return symbols;
 }
 
-// Symbol -> reserve address. The stable is native USDC; everything else uses the registry address.
+// Symbol -> reserve address. The stable is native USDC; the LST is the vault's own share token
+// (it is not in the base registry, by design); everything else uses the registry address.
 function aaveAsset(symbol: TokenSymbol): Address {
-  return symbol === AAVE_STABLE_SYMBOL
-    ? AAVE_STABLE
-    : tokenInfo(symbol).address;
+  if (symbol === AAVE_STABLE_SYMBOL) return AAVE_STABLE;
+  if (symbol === LST_SYMBOL && LST) return LST.lstToken;
+  return tokenInfo(symbol).address;
 }
 
 type AaveActionType =
@@ -181,11 +190,17 @@ function validate(
     asset: TokenSymbol;
     amount: string;
   };
-  // The stable uses the aggregated USDC-equivalent balance; bases use the bases map (WETH equals wethWei for compatibility).
-  const assetBalance = (): bigint =>
-    a.asset === AAVE_STABLE_SYMBOL
-      ? stableBalanceOf(balances, AAVE_STABLE)
-      : (balances.bases?.[a.asset] ?? balances.wethWei);
+  // The stable uses the aggregated USDC-equivalent balance; bases use the bases map (WETH equals
+  // wethWei for compatibility). The LST is in neither: it is not a registry base, so its balance
+  // comes from its own venue's observation -- falling through to wethWei would compare an LST
+  // amount against a WETH balance and wave through a supply that reverts on chain.
+  const assetBalance = (): bigint => {
+    if (a.asset === AAVE_STABLE_SYMBOL)
+      return stableBalanceOf(balances, AAVE_STABLE);
+    if (a.asset === LST_SYMBOL)
+      return BigInt(obs.protocols.lst?.lstBalanceWei ?? "0");
+    return balances.bases?.[a.asset] ?? balances.wethWei;
+  };
   if (a.amount !== "max") {
     const amount = BigInt(a.amount);
     if (amount <= 0n) return { ok: false, reason: "amount must be positive" };
@@ -194,7 +209,8 @@ function validate(
         return { ok: false, reason: "supply amount exceeds balance" };
       // ADR 0013: apply the supply limit to every base. WETH=maxAaveSupplyWethWei; additional bases use
       // limits.baseLimits[asset] ("0"=no limit). Stable assets have no supply limit (as before).
-      if (a.asset !== AAVE_STABLE_SYMBOL) {
+      // The LST's own cap is the per-stake one on the venue itself, so it is not re-capped here.
+      if (a.asset !== AAVE_STABLE_SYMBOL && a.asset !== LST_SYMBOL) {
         const maxSupply =
           a.asset === "WETH"
             ? BigInt(obs.limits.maxAaveSupplyWethWei)
@@ -525,7 +541,15 @@ export const aaveAdapter: ProtocolAdapter = {
   // positive. Immutable for a deployment, so resolved once.
   async accountedTokens(publicClient): Promise<Address[]> {
     if (reserveTokenCache) return reserveTokenCache;
-    const assets = Object.values(tokenRegistry()).map((t) => t.address);
+    // Every reserve this venue trades, not just the ones in the token registry: the LST is listed
+    // as collateral but deliberately kept out of the registry (issue #38), so registry-only lookup
+    // left its aToken looking like an unaccounted holding in every levered run.
+    const assets = [
+      ...new Set([
+        ...Object.values(tokenRegistry()).map((t) => t.address),
+        ...aaveReserveSymbols().map(aaveAsset),
+      ]),
+    ];
     const results = (await publicClient.multicall({
       contracts: assets.map((asset) => ({
         address: AAVE.PoolDataProvider,

--- a/sdk/src/protocols/aave.ts
+++ b/sdk/src/protocols/aave.ts
@@ -15,7 +15,7 @@ import {
   sendAndMine,
   sendAsImpersonated,
 } from "../chain.js";
-import { erc20Abi } from "../abis.js";
+import { curveStableSwapNgAbi, erc20Abi, lstVaultAbi } from "../abis.js";
 import type {
   AaveObservation,
   AgentObservation,
@@ -28,10 +28,12 @@ import type {
   BuiltTx,
   ProtocolAdapter,
   SimContext,
+  UnpricedHoldingDetail,
   ValidationResult,
 } from "./types.js";
 import { approveTx } from "./uniswap.js";
 import { deployContract } from "./deploy.js";
+import { enabledProtocolIds } from "./enabled.js";
 
 const DECIMAL_INTEGER = /^[0-9]+$/;
 const VARIABLE_RATE = 2n;
@@ -111,7 +113,13 @@ function aaveBaseSymbols(): TokenSymbol[] {
 // and withdraw are the operations that make sense; a borrow of it is rejected on chain.
 function aaveReserveSymbols(): TokenSymbol[] {
   const symbols = [...aaveBaseSymbols(), AAVE_STABLE_SYMBOL];
-  if (LST?.aaveAToken) symbols.push(LST_SYMBOL);
+  // Gated on the run enabling lst, not merely on the deployment having listed it. Keying off the
+  // deployment alone meant a `protocols: [uniswap, aave]` run against the new state dump deployed
+  // an extra aggregator, sent an extra setAssetSources and setReserveFlashLoaning, added a reserve
+  // read per agent per block and an admin tx per block -- changing the nonce and tx ordering of
+  // every pre-existing local aave run, against this file's own "byte-identical when disabled" rule.
+  if (LST?.aaveAToken && enabledProtocolIds().includes("lst"))
+    symbols.push(LST_SYMBOL);
   return symbols;
 }
 
@@ -503,13 +511,86 @@ export const aaveAdapter: ProtocolAdapter = {
 
   // Aave needs no per-venue wiring in the scorer: getUserAccountData is an aggregate that already
   // covers every supplied asset, which is why this venue never had the #41 hole.
+  //
+  // It does have a different one once an LST is listed (issue #38 phase 3). Aave marks that
+  // collateral at its oracle price, which is the vault's *par* redemption rate — correct for
+  // deciding liquidations, and wrong for deciding what an agent could walk away with. Left alone,
+  // supplying LST to Aave launders a position the LST venue would have haircut into a par mark:
+  // in the last blocks of a run, ten shares in a wallet score the pool's discounted quote while
+  // the same ten shares posted here score par. That is free score for turning leverage on. So the
+  // LST leg of the collateral is re-marked in liquidatableValueUsdc, using the same realizable
+  // rule the venue itself applies.
   async *valueAtBlock(ctx) {
-    const results = yield ctx.agents.map((a) => ({
-      address: AAVE.Pool,
-      abi: aavePoolAbi,
-      functionName: "getUserAccountData",
-      args: [a.address],
-    }));
+    const lstListed = Boolean(LST?.aaveAToken);
+    const results = yield [
+      ...ctx.agents.map((a) => ({
+        address: AAVE.Pool,
+        abi: aavePoolAbi,
+        functionName: "getUserAccountData",
+        args: [a.address],
+      })),
+      ...(lstListed
+        ? ctx.agents.map((a) => ({
+            address: LST!.aaveAToken as Address,
+            abi: erc20Abi,
+            functionName: "balanceOf",
+            args: [a.address],
+          }))
+        : []),
+    ];
+    // Second stage only for agents actually holding LST collateral: what that many shares would
+    // fetch on the secondary market right now, and what the queue would charge in time.
+    const lstCollateral = new Map<number, bigint>();
+    if (lstListed) {
+      ctx.agents.forEach((_a, i) => {
+        const bal = results[ctx.agents.length + i];
+        if (typeof bal === "bigint" && bal > 0n) lstCollateral.set(i, bal);
+      });
+    }
+    const haircutTargets = [...lstCollateral.entries()];
+    let haircutReads: unknown[] = [];
+    if (haircutTargets.length > 0 && LST) {
+      const lst = LST;
+      haircutReads = yield haircutTargets.flatMap(([, shares]) => [
+        {
+          address: lst.pool,
+          abi: curveStableSwapNgAbi,
+          functionName: "get_dy",
+          args: [
+            BigInt(lst.poolLstIndex),
+            BigInt(lst.poolWethIndex),
+            shares,
+          ],
+        },
+        {
+          address: lst.vault,
+          abi: lstVaultAbi,
+          functionName: "convertToAssets",
+          args: [shares],
+        },
+        {
+          address: lst.vault,
+          abi: lstVaultAbi,
+          functionName: "estimateDelayBlocks",
+          args: [shares],
+        },
+      ]);
+    }
+    // agent -> WETH of par value that an exit could not actually recover.
+    const shortfallWei = new Map<number, bigint>();
+    haircutTargets.forEach(([agentIndex], k) => {
+      const exit = haircutReads[k * 3];
+      const par = haircutReads[k * 3 + 1];
+      const delay = haircutReads[k * 3 + 2];
+      if (typeof par !== "bigint" || par === 0n) return;
+      const queueFits =
+        typeof delay === "bigint" &&
+        ctx.blockNumber + Number(delay) <= ctx.horizonBlock;
+      if (queueFits) return; // par is reachable through the queue: no haircut
+      if (typeof exit !== "bigint") return; // cannot price the exit; leave the par mark alone
+      if (exit < par) shortfallWei.set(agentIndex, par - exit);
+    });
+
     const out: Record<string, AgentProtocolValue> = {};
     ctx.agents.forEach((agent, i) => {
       const account = results[i] as readonly bigint[] | undefined;
@@ -518,19 +599,35 @@ export const aaveAdapter: ProtocolAdapter = {
       // A failed read is the whole position going missing, and a zero there is indistinguishable
       // from having been liquidated — report it instead (issue #44).
       const usd = account ? Number(account[0] - account[1]) / 1e8 : 0;
+      const unpriced: UnpricedHoldingDetail[] = account
+        ? []
+        : [
+            {
+              source: "aave-account",
+              amountRaw: "",
+              reason: "read-failed" as const,
+              read: "AavePool.getUserAccountData",
+            },
+          ];
+      let liquidatableUsdc = usd;
+      const shortfall = shortfallWei.get(i);
+      const shares = lstCollateral.get(i);
+      if (account && shortfall !== undefined && shares !== undefined && LST) {
+        const shortfallUsd =
+          (Number(shortfall) / 1e18) * (ctx.fairByBase().WETH ?? 0);
+        liquidatableUsdc = usd - shortfallUsd;
+        unpriced.push({
+          token: LST.lstToken,
+          amountRaw: shares.toString(),
+          source: "aave-lst-collateral",
+          reason: "unrealizable",
+          read: "MockLSTVault.estimateDelayBlocks",
+        });
+      }
       out[agent.id] = {
         valueUsdc: usd,
-        liquidatableValueUsdc: usd,
-        unpriced: account
-          ? []
-          : [
-              {
-                source: "aave-account",
-                amountRaw: "",
-                reason: "read-failed",
-                read: "AavePool.getUserAccountData",
-              },
-            ],
+        liquidatableValueUsdc: liquidatableUsdc,
+        unpriced,
       };
     });
     return out;

--- a/sdk/src/protocols/enabled.ts
+++ b/sdk/src/protocols/enabled.ts
@@ -1,0 +1,17 @@
+// The run's enabled protocol ids, readable from an adapter without importing the registry.
+//
+// registry.ts imports every adapter, so an adapter importing it back is a cycle. This tiny module
+// owns the state instead: the registry writes it in setEnabledProtocols, adapters read it. It
+// exists because a venue must be able to ask "did this run enable me?" — answering from the
+// deployment alone makes a disabled venue change the behaviour of an enabled one (issue #38).
+import type { ProtocolId } from "../types.js";
+
+let enabled: ProtocolId[] = [];
+
+export function setEnabledProtocolIds(ids: ProtocolId[]): void {
+  enabled = [...ids];
+}
+
+export function enabledProtocolIds(): readonly ProtocolId[] {
+  return enabled;
+}

--- a/sdk/src/protocols/lst.ts
+++ b/sdk/src/protocols/lst.ts
@@ -479,6 +479,9 @@ async function observe(
       weth: state.reserves.weth.toString(),
       lst: state.reserves.lst.toString(),
     },
+    // Phase 3: only true when the deploy listed it, so an agent can tell "leverage is off" from
+    // "my supply failed".
+    aaveCollateral: Boolean(deployment.aaveAToken),
   };
 }
 

--- a/sdk/src/protocols/lst.ts
+++ b/sdk/src/protocols/lst.ts
@@ -64,7 +64,11 @@ export type LstState = {
   // sqrt(sell x buy): the mid the two sides imply once the symmetric fee cancels.
   midPriceWeth: number;
   // How far the market sits below redemption, in bps. Positive = the market is discounted.
+  // Zero when the pool refused to quote -- see marketQuoted.
   discountBps: number;
+  // Whether the pool actually quoted. False means there is no market leg right now (it reverted,
+  // or there is no liquidity at probe size), not that the market is worthless.
+  marketQuoted: boolean;
   apyBps: number;
   yieldPerBlockBps: number;
   withdrawalDelayBlocks: number;
@@ -219,6 +223,11 @@ export async function getLstState(ctx: SimContext): Promise<LstState> {
       : sellPriceWeth;
 
   const redemptionRateWeth = toFloat(redemptionRateRaw);
+  // A pool that refused to quote has no price, which is not the same as a price of zero. Treating
+  // it as zero made discountBps read 10000 -- an infinite free carry -- so an agent would empty its
+  // wallet into a market that just told us it could not fill, and setupLst would blame the rate
+  // oracle for it.
+  const marketQuoted = midPriceWeth > 0;
   return {
     deployment,
     redemptionRateWeth,
@@ -226,7 +235,10 @@ export async function getLstState(ctx: SimContext): Promise<LstState> {
     sellPriceWeth,
     buyPriceWeth,
     midPriceWeth,
-    discountBps: discountBpsFrom(redemptionRateWeth, midPriceWeth),
+    marketQuoted,
+    discountBps: marketQuoted
+      ? discountBpsFrom(redemptionRateWeth, midPriceWeth)
+      : 0,
     apyBps: apyBpsFrom(ratePerBlockRay, ctx.config.lstSimulatedSecondsPerBlock),
     yieldPerBlockBps: yieldPerBlockBpsFrom(ratePerBlockRay),
     withdrawalDelayBlocks: Number(delayBlocks),
@@ -461,6 +473,7 @@ async function observe(
       ? { marketBuyPriceWeth: state.buyPriceWeth }
       : {}),
     discountBps: state.discountBps,
+    marketQuoted: state.marketQuoted,
     apyBps: state.apyBps,
     yieldPerBlockBps: state.yieldPerBlockBps,
     withdrawalDelayBlocks: state.withdrawalDelayBlocks,
@@ -638,8 +651,11 @@ export async function* lstValuationRun(
     })),
   ];
 
+  // A failed read here must not become "no wait at all": zero would make every queue look
+  // reachable and mark every position at par, which is the silent-zero pattern this repo spent
+  // #44 removing. Undefined propagates and the positions are reported instead.
   const floorDelayBlocks =
-    typeof summaries[0] === "bigint" ? Number(summaries[0]) : 0;
+    typeof summaries[0] === "bigint" ? Number(summaries[0]) : undefined;
   const rateLimited =
     typeof summaries[1] === "bigint" && (summaries[1] as bigint) > 0n;
   const perAgent = ctx.agents.map((_agent, i) => {
@@ -684,14 +700,17 @@ export async function* lstValuationRun(
     ];
   }
   const quoteByIndex = new Map<number, bigint | undefined>();
-  const delayByIndex = new Map<number, number>();
+  const delayByIndex = new Map<number, number | undefined>();
   quoteTargets.forEach(({ i }, k) => {
     const q = quotes[k];
     quoteByIndex.set(i, typeof q === "bigint" ? q : undefined);
     const d = rateLimited ? quotes[quoteTargets.length + k] : undefined;
-    // A wait we could not read falls back to the floor, which understates it — but the alternative
-    // is refusing to mark a position we can otherwise price.
-    delayByIndex.set(i, typeof d === "bigint" ? Number(d) : floorDelayBlocks);
+    // The size-aware wait when the queue is rate-limited, otherwise the floor. Either can be
+    // undefined if its read failed, and undefined stays undefined: see the marking below.
+    delayByIndex.set(
+      i,
+      typeof d === "bigint" ? Number(d) : rateLimited ? undefined : floorDelayBlocks,
+    );
   });
 
   const fairWeth = ctx.fairByBase().WETH ?? 0;
@@ -728,6 +747,17 @@ export async function* lstValuationRun(
         read: "CurveStableSwapNG.get_dy",
       });
     }
+    const queueDelayBlocks = delayByIndex.get(i);
+    if (row.shares > 0n && queueDelayBlocks === undefined) {
+      // Without the wait there is no way to tell a reachable queue from an unreachable one, and
+      // guessing "reachable" marks the position at par. Report and mark at the market instead.
+      unpriced.push({
+        source: "lst-queue-delay",
+        amountRaw: "",
+        reason: "read-failed",
+        read: "MockLSTVault.withdrawalDelayBlocks",
+      });
+    }
     const { wei } = realizableWethWei({
       shares: row.shares,
       shareAssets: row.shareAssets,
@@ -737,11 +767,13 @@ export async function* lstValuationRun(
       unreachableAssets: row.unreachableAssets,
       blockNumber: ctx.blockNumber,
       horizonBlock: ctx.horizonBlock,
-      queueDelayBlocks: delayByIndex.get(i) ?? floorDelayBlocks,
+      // Unknown wait = treat the queue as closed. Understating the exit is recoverable; overstating
+      // it credits value the agent could never have taken.
+      queueDelayBlocks: queueDelayBlocks ?? Number.POSITIVE_INFINITY,
     });
     if (row.unreachableAssets > 0n) {
       // Queued at par, but the queue finalizes after the run ends: real value, not realizable
-      // inside the run. Excluded from the mark and reported, never silently zeroed.
+      // inside the run. Excluded from the realizable mark and reported, never silently zeroed.
       unpriced.push({
         token: deployment.asset,
         amountRaw: row.unreachableAssets.toString(),
@@ -750,12 +782,20 @@ export async function* lstValuationRun(
         read: "MockLSTVault.accountSummaryAt",
       });
     }
-    const valueUsdc = toFloat(wei) * fairWeth;
+    // Two marks, because they genuinely differ here and the difference is the venue's point:
+    //   valueUsdc              face value -- what the vault owes, the number Aave's oracle uses
+    //   liquidatableValueUsdc  what an exit would actually return before the run ends
+    // Reporting only the realizable one (as an earlier revision did) left #41's liquidatable
+    // plumbing carrying an identical copy, i.e. dead, and made this venue the only one whose
+    // headline mark was not face value.
+    const parWei =
+      row.shareAssets +
+      row.claimableAssets +
+      row.reachableAssets +
+      row.unreachableAssets;
     out[agent.id] = {
-      valueUsdc,
-      // The venue is marked at realizable value throughout, so the two agree here. They are kept
-      // separate because #39/#40 will have positions whose face value diverges from their exit.
-      liquidatableValueUsdc: valueUsdc,
+      valueUsdc: toFloat(parWei) * fairWeth,
+      liquidatableValueUsdc: toFloat(wei) * fairWeth,
       unpriced,
     };
   });

--- a/sdk/src/protocols/lst.ts
+++ b/sdk/src/protocols/lst.ts
@@ -73,6 +73,10 @@ export type LstState = {
   pooledWeth: bigint;
   shareSupply: bigint;
   reserves: { weth: bigint; lst: bigint };
+  // Issue #38 phase 2: 0 means the queue is not rate-limited and every request waits exactly
+  // withdrawalDelayBlocks. Otherwise the wait also covers what is queued ahead plus your own size.
+  queueThroughputWeiPerBlock: bigint;
+  queueDrainBlock: bigint;
 };
 
 function toFloat(wei: bigint): number {
@@ -194,6 +198,8 @@ export async function getLstState(ctx: SimContext): Promise<LstState> {
     queueLength,
     delayBlocks,
     ratePerBlockRay,
+    throughputWeiPerBlock,
+    drainBlock,
   ] = summary;
 
   // Two-sided probe, the same discipline as the balancer/curve adapters: a one-sided quote
@@ -229,6 +235,8 @@ export async function getLstState(ctx: SimContext): Promise<LstState> {
     pooledWeth,
     shareSupply,
     reserves: { weth: wethReserve, lst: lstReserve },
+    queueThroughputWeiPerBlock: throughputWeiPerBlock,
+    queueDrainBlock: drainBlock,
   };
 }
 
@@ -418,6 +426,31 @@ async function observe(
     claimable: blockNumber >= claimableAt[i],
   }));
 
+  // What queueing would actually cost right now. With a rate-limited queue this exceeds the floor
+  // by whatever is booked ahead plus this size's own drain time (issue #38 phase 2), and it is the
+  // number an agent must compare against the blocks left in the run.
+  const estimateDelay = async (assets: bigint): Promise<number> => {
+    if (state.queueThroughputWeiPerBlock === 0n)
+      return state.withdrawalDelayBlocks;
+    try {
+      return Number(
+        (await publicClient.readContract({
+          address: deployment.vault,
+          abi: lstVaultAbi,
+          functionName: "estimateDelayBlocks",
+          args: [assets],
+        })) as bigint,
+      );
+    } catch {
+      return state.withdrawalDelayBlocks;
+    }
+  };
+  const [estimatedQueueDelayBlocks, queueDelayPerWethBlocks] =
+    await Promise.all([
+      estimateDelay(shareAssets > 0n ? shareAssets : WAD),
+      estimateDelay(WAD),
+    ]);
+
   return {
     redemptionRateWeth: state.redemptionRateWeth,
     marketPriceWeth: state.midPriceWeth,
@@ -431,6 +464,9 @@ async function observe(
     apyBps: state.apyBps,
     yieldPerBlockBps: state.yieldPerBlockBps,
     withdrawalDelayBlocks: state.withdrawalDelayBlocks,
+    estimatedQueueDelayBlocks,
+    queueDelayPerWethBlocks,
+    queueThroughputWeiPerBlock: state.queueThroughputWeiPerBlock.toString(),
     queueLength: state.queueLength,
     rewardReserveWei: state.rewardReserveWei.toString(),
     lstBalanceWei: shares.toString(),
@@ -551,10 +587,12 @@ export function realizableWethWei(input: {
   unreachableAssets: bigint;
   blockNumber: number;
   horizonBlock: number;
-  withdrawalDelayBlocks: number;
+  // The wait this *particular* redemption would face, not the vault's floor: with a rate-limited
+  // queue it also covers what is booked ahead and this size's own drain time (issue #38 phase 2).
+  queueDelayBlocks: number;
 }): { wei: bigint; queueUsed: boolean } {
   const queueFitsInRun =
-    input.blockNumber + input.withdrawalDelayBlocks <= input.horizonBlock;
+    input.blockNumber + input.queueDelayBlocks <= input.horizonBlock;
   const viaQueue = queueFitsInRun ? input.shareAssets : 0n;
   const viaMarket = input.instantExitWei ?? 0n;
   const shareValue = viaQueue > viaMarket ? viaQueue : viaMarket;
@@ -566,9 +604,11 @@ export function realizableWethWei(input: {
 
 /// Historical valuation (issue #41's staged reads, issue #38's realizable marking).
 ///
-/// Two stages, because the instant-exit quote depends on a balance the first stage returns:
-///   0. every agent's account summary, split at the run's horizon, plus the queue delay
-///   1. get_dy for exactly the agents that hold shares
+/// Two stages, because both the instant-exit quote and the queue's wait depend on a balance the
+/// first stage returns:
+///   0. every agent's account summary, split at the run's horizon, plus the queue floor
+///   1. for exactly the agents that hold shares: the pool quote at that size, and — when the queue
+///      is rate-limited — the wait that size would actually face
 ///
 /// Takes the deployment explicitly rather than reading the module-level LST constant, so the
 /// marking rules can be exercised without a deployed vault.
@@ -582,6 +622,11 @@ export async function* lstValuationRun(
       abi: lstVaultAbi,
       functionName: "withdrawalDelayBlocks",
     },
+    {
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "queueThroughputWeiPerBlock",
+    },
     ...ctx.agents.map((a) => ({
       address: deployment.vault,
       abi: lstVaultAbi,
@@ -590,10 +635,12 @@ export async function* lstValuationRun(
     })),
   ];
 
-  const delayBlocks =
+  const floorDelayBlocks =
     typeof summaries[0] === "bigint" ? Number(summaries[0]) : 0;
+  const rateLimited =
+    typeof summaries[1] === "bigint" && (summaries[1] as bigint) > 0n;
   const perAgent = ctx.agents.map((_agent, i) => {
-    const row = summaries[1 + i] as readonly bigint[] | undefined;
+    const row = summaries[2 + i] as readonly bigint[] | undefined;
     if (!row) return undefined;
     return {
       shares: row[0],
@@ -604,7 +651,7 @@ export async function* lstValuationRun(
     };
   });
 
-  // Only agents holding shares need a pool quote.
+  // Only agents holding shares need a pool quote (and, if the queue is rate-limited, a wait quote).
   const quoteTargets = perAgent
     .map((row, i) => ({ row, i }))
     .filter((x): x is { row: NonNullable<typeof x.row>; i: number } =>
@@ -612,21 +659,36 @@ export async function* lstValuationRun(
     );
   let quotes: unknown[] = [];
   if (quoteTargets.length > 0) {
-    quotes = yield quoteTargets.map(({ row }): ValuationRead => ({
-      address: deployment.pool,
-      abi: curveStableSwapNgAbi,
-      functionName: "get_dy",
-      args: [
-        BigInt(deployment.poolLstIndex),
-        BigInt(deployment.poolWethIndex),
-        row.shares,
-      ],
-    }));
+    quotes = yield [
+      ...quoteTargets.map(({ row }): ValuationRead => ({
+        address: deployment.pool,
+        abi: curveStableSwapNgAbi,
+        functionName: "get_dy",
+        args: [
+          BigInt(deployment.poolLstIndex),
+          BigInt(deployment.poolWethIndex),
+          row.shares,
+        ],
+      })),
+      ...(rateLimited
+        ? quoteTargets.map(({ row }): ValuationRead => ({
+            address: deployment.vault,
+            abi: lstVaultAbi,
+            functionName: "estimateDelayBlocks",
+            args: [row.shareAssets],
+          }))
+        : []),
+    ];
   }
   const quoteByIndex = new Map<number, bigint | undefined>();
+  const delayByIndex = new Map<number, number>();
   quoteTargets.forEach(({ i }, k) => {
     const q = quotes[k];
     quoteByIndex.set(i, typeof q === "bigint" ? q : undefined);
+    const d = rateLimited ? quotes[quoteTargets.length + k] : undefined;
+    // A wait we could not read falls back to the floor, which understates it — but the alternative
+    // is refusing to mark a position we can otherwise price.
+    delayByIndex.set(i, typeof d === "bigint" ? Number(d) : floorDelayBlocks);
   });
 
   const fairWeth = ctx.fairByBase().WETH ?? 0;
@@ -672,7 +734,7 @@ export async function* lstValuationRun(
       unreachableAssets: row.unreachableAssets,
       blockNumber: ctx.blockNumber,
       horizonBlock: ctx.horizonBlock,
-      withdrawalDelayBlocks: delayBlocks,
+      queueDelayBlocks: delayByIndex.get(i) ?? floorDelayBlocks,
     });
     if (row.unreachableAssets > 0n) {
       // Queued at par, but the queue finalizes after the run ends: real value, not realizable
@@ -755,7 +817,7 @@ export const lstAdapter: ProtocolAdapter = {
       unreachableAssets: 0n,
       blockNumber,
       horizonBlock: blockNumber,
-      withdrawalDelayBlocks: Number(delayBlocks),
+      queueDelayBlocks: Number(delayBlocks),
     });
     return toFloat(wei) * fairPrice;
   },

--- a/sdk/src/protocols/lst.ts
+++ b/sdk/src/protocols/lst.ts
@@ -1,0 +1,792 @@
+// LST venue adapter (issue #38).
+//
+// The venue is a wstETH-style vault plus an LST/WETH stableswap-ng secondary market. What makes it
+// a distinct skill axis is that an LST has two prices at once:
+//
+//   redemption rate  what the vault owes per share. Reachable only through the withdrawal queue,
+//                    which takes `withdrawalDelayBlocks`.
+//   market price     what the pool pays right now, at whatever discount (or premium) it trades.
+//
+// So an exit is a real choice -- slow and at par, or fast and discounted -- and the other side of
+// that choice is a carry: buy LST while the pool is cheap and redeem at par, if the discount beats
+// the queue's time cost. Both prices are reported separately in the observation, and post-run
+// scoring marks the position at what it could *realize*, not at face redemption value.
+//
+// Unlike every other venue this one has no Arbitrum counterpart: the vault is ours, so it exists
+// only under local deploy and `requireLst()` fails fast on a fork.
+import { encodeFunctionData, type Address, type PublicClient } from "viem";
+import { curveStableSwapNgAbi, erc20Abi, lstVaultAbi } from "../abis.js";
+import { LST, requireLst, TOKENS, type LstDeployment } from "../constants.js";
+import type {
+  AgentObservation,
+  BalanceSnapshot,
+  LeafAction,
+  LstClaimWithdrawAction,
+  LstDepositAction,
+  LstObservation,
+  LstRequestWithdrawAction,
+  LstSwapAction,
+} from "../types.js";
+import type {
+  AgentProtocolValue,
+  BuiltTx,
+  ProtocolAdapter,
+  SimContext,
+  UnpricedHoldingDetail,
+  ValidationResult,
+  ValuationContext,
+  ValuationRead,
+  ValuationRun,
+} from "./types.js";
+import { approveTx } from "./uniswap.js";
+
+const DECIMAL_INTEGER = /^[0-9]+$/;
+const WAD = 10n ** 18n;
+const RAY = 10n ** 27n;
+const SECONDS_PER_YEAR = 31_536_000;
+// Probe size for the two-sided market quote. Small enough that impact is negligible, so the quote
+// reports the pool's price rather than the probe's own footprint.
+const PROBE_LST_WEI = WAD / 10n;
+const DEFAULT_SLIPPAGE_BPS = 50;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export type LstState = {
+  deployment: LstDeployment;
+  // WETH per 1e18 LST, as the vault reports it.
+  redemptionRateWeth: number;
+  redemptionRateRaw: bigint;
+  // Executable prices at probe size (WETH per LST), fee and impact included.
+  sellPriceWeth: number;
+  buyPriceWeth: number;
+  // sqrt(sell x buy): the mid the two sides imply once the symmetric fee cancels.
+  midPriceWeth: number;
+  // How far the market sits below redemption, in bps. Positive = the market is discounted.
+  discountBps: number;
+  apyBps: number;
+  yieldPerBlockBps: number;
+  withdrawalDelayBlocks: number;
+  queueLength: number;
+  rewardReserveWei: bigint;
+  pooledWeth: bigint;
+  shareSupply: bigint;
+  reserves: { weth: bigint; lst: bigint };
+};
+
+function toFloat(wei: bigint): number {
+  return Number(wei) / 1e18;
+}
+
+/// Per-block yield in bps, from the vault's ray rate. This is the number an agent should compare a
+/// discount against: waiting N blocks costs N x this in foregone... nothing, but earns it if held.
+export function yieldPerBlockBpsFrom(ratePerBlockRay: bigint): number {
+  return (Number(ratePerBlockRay) / Number(RAY)) * 10_000;
+}
+
+/// The APY that per-block rate implies on the run's compressed economic clock.
+export function apyBpsFrom(
+  ratePerBlockRay: bigint,
+  simulatedSecondsPerBlock: number,
+): number {
+  if (simulatedSecondsPerBlock <= 0) return 0;
+  const blocksPerYear = SECONDS_PER_YEAR / simulatedSecondsPerBlock;
+  return (Number(ratePerBlockRay) / Number(RAY)) * blocksPerYear * 10_000;
+}
+
+/// Ray per-block rate for a target APY on a given economic clock. The environment uses this to
+/// retune the vault; exported so the calibration lives in one place.
+export function rewardRatePerBlockRay(
+  apyBps: number,
+  simulatedSecondsPerBlock: number,
+): bigint {
+  if (apyBps <= 0 || simulatedSecondsPerBlock <= 0) return 0n;
+  return (
+    (BigInt(Math.round(apyBps)) *
+      BigInt(Math.round(simulatedSecondsPerBlock)) *
+      RAY) /
+    (10_000n * BigInt(SECONDS_PER_YEAR))
+  );
+}
+
+/// Discount of the market against redemption, in bps. Positive means LST is trading cheap: buying
+/// and queueing a redemption earns this, if the wait is worth it.
+export function discountBpsFrom(
+  redemptionRateWeth: number,
+  marketPriceWeth: number,
+): number {
+  if (!(redemptionRateWeth > 0)) return 0;
+  return ((redemptionRateWeth - marketPriceWeth) / redemptionRateWeth) * 10_000;
+}
+
+async function poolQuote(
+  publicClient: PublicClient,
+  deployment: LstDeployment,
+  amountLstWei: bigint,
+): Promise<bigint | undefined> {
+  try {
+    return (await publicClient.readContract({
+      address: deployment.pool,
+      abi: curveStableSwapNgAbi,
+      functionName: "get_dy",
+      args: [
+        BigInt(deployment.poolLstIndex),
+        BigInt(deployment.poolWethIndex),
+        amountLstWei,
+      ],
+    })) as bigint;
+  } catch {
+    // A quote the pool refuses (no liquidity at that size) is "no instant exit", not zero value.
+    return undefined;
+  }
+}
+
+async function poolBuyQuote(
+  publicClient: PublicClient,
+  deployment: LstDeployment,
+  amountWethWei: bigint,
+): Promise<bigint | undefined> {
+  try {
+    return (await publicClient.readContract({
+      address: deployment.pool,
+      abi: curveStableSwapNgAbi,
+      functionName: "get_dy",
+      args: [
+        BigInt(deployment.poolWethIndex),
+        BigInt(deployment.poolLstIndex),
+        amountWethWei,
+      ],
+    })) as bigint;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getLstState(ctx: SimContext): Promise<LstState> {
+  const deployment = requireLst();
+  const { publicClient } = ctx;
+  const [summary, wethReserve, lstReserve] = await Promise.all([
+    publicClient.readContract({
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "vaultSummary",
+    }) as Promise<readonly bigint[]>,
+    publicClient.readContract({
+      address: deployment.pool,
+      abi: curveStableSwapNgAbi,
+      functionName: "balances",
+      args: [BigInt(deployment.poolWethIndex)],
+    }) as Promise<bigint>,
+    publicClient.readContract({
+      address: deployment.pool,
+      abi: curveStableSwapNgAbi,
+      functionName: "balances",
+      args: [BigInt(deployment.poolLstIndex)],
+    }) as Promise<bigint>,
+  ]);
+  const [
+    pooledWeth,
+    shareSupply,
+    redemptionRateRaw,
+    rewardReserveWei,
+    ,
+    queueLength,
+    delayBlocks,
+    ratePerBlockRay,
+  ] = summary;
+
+  // Two-sided probe, the same discipline as the balancer/curve adapters: a one-sided quote
+  // under-reports the executable mid when the pool is imbalanced, and an agent that trades against
+  // that phantom spread bleeds fees (the WBTC all-agent bleed).
+  const sellOut = await poolQuote(publicClient, deployment, PROBE_LST_WEI);
+  const sellPriceWeth = sellOut ? toFloat(sellOut) / toFloat(PROBE_LST_WEI) : 0;
+  let buyPriceWeth = 0;
+  if (sellOut && sellOut > 0n) {
+    const buyOut = await poolBuyQuote(publicClient, deployment, sellOut);
+    if (buyOut && buyOut > 0n)
+      buyPriceWeth = toFloat(sellOut) / toFloat(buyOut);
+  }
+  const midPriceWeth =
+    sellPriceWeth > 0 && buyPriceWeth > 0
+      ? Math.sqrt(sellPriceWeth * buyPriceWeth)
+      : sellPriceWeth;
+
+  const redemptionRateWeth = toFloat(redemptionRateRaw);
+  return {
+    deployment,
+    redemptionRateWeth,
+    redemptionRateRaw,
+    sellPriceWeth,
+    buyPriceWeth,
+    midPriceWeth,
+    discountBps: discountBpsFrom(redemptionRateWeth, midPriceWeth),
+    apyBps: apyBpsFrom(ratePerBlockRay, ctx.config.lstSimulatedSecondsPerBlock),
+    yieldPerBlockBps: yieldPerBlockBpsFrom(ratePerBlockRay),
+    withdrawalDelayBlocks: Number(delayBlocks),
+    queueLength: Number(queueLength),
+    rewardReserveWei,
+    pooledWeth,
+    shareSupply,
+    reserves: { weth: wethReserve, lst: lstReserve },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parse / validate
+// ---------------------------------------------------------------------------
+
+function requireDecimalString(
+  value: unknown,
+  name: string,
+): asserts value is string {
+  if (typeof value !== "string" || !DECIMAL_INTEGER.test(value))
+    throw new Error(`${name} must be a decimal integer string`);
+}
+
+function withPriorityFee<T extends { maxPriorityFeePerGasWei?: string }>(
+  action: T,
+  obj: Record<string, unknown>,
+): T {
+  if (obj.maxPriorityFeePerGasWei !== undefined) {
+    requireDecimalString(
+      obj.maxPriorityFeePerGasWei,
+      "maxPriorityFeePerGasWei",
+    );
+    action.maxPriorityFeePerGasWei = obj.maxPriorityFeePerGasWei;
+  }
+  return action;
+}
+
+function parse(obj: Record<string, unknown>): LeafAction | null {
+  switch (obj.type) {
+    case "lstDeposit": {
+      requireDecimalString(obj.amountWethWei, "amountWethWei");
+      return withPriorityFee<LstDepositAction>(
+        { type: "lstDeposit", amountWethWei: obj.amountWethWei },
+        obj,
+      );
+    }
+    case "lstSwap": {
+      if (obj.tokenIn !== "WETH" && obj.tokenIn !== "LST")
+        throw new Error('lstSwap tokenIn must be "WETH" or "LST"');
+      requireDecimalString(obj.amountIn, "amountIn");
+      const action: LstSwapAction = {
+        type: "lstSwap",
+        tokenIn: obj.tokenIn,
+        amountIn: obj.amountIn,
+      };
+      if (obj.slippageBps !== undefined) {
+        if (
+          typeof obj.slippageBps !== "number" ||
+          !Number.isInteger(obj.slippageBps) ||
+          obj.slippageBps < 0 ||
+          obj.slippageBps > 1000
+        )
+          throw new Error("slippageBps must be an integer between 0 and 1000");
+        action.slippageBps = obj.slippageBps;
+      }
+      return withPriorityFee(action, obj);
+    }
+    case "lstRequestWithdraw": {
+      requireDecimalString(obj.amountLstWei, "amountLstWei");
+      return withPriorityFee<LstRequestWithdrawAction>(
+        { type: "lstRequestWithdraw", amountLstWei: obj.amountLstWei },
+        obj,
+      );
+    }
+    case "lstClaimWithdraw": {
+      const action: LstClaimWithdrawAction = { type: "lstClaimWithdraw" };
+      if (obj.requestId !== undefined && obj.requestId !== "all") {
+        requireDecimalString(obj.requestId, "requestId");
+        action.requestId = obj.requestId;
+      }
+      return withPriorityFee(action, obj);
+    }
+    default:
+      return null;
+  }
+}
+
+function validate(
+  action: LeafAction,
+  obs: AgentObservation,
+  balances: BalanceSnapshot,
+): ValidationResult {
+  const lst = obs.protocols.lst;
+  switch (action.type) {
+    case "lstDeposit": {
+      const amount = BigInt(action.amountWethWei);
+      if (amount <= 0n)
+        return { ok: false, reason: "amountWethWei must be positive" };
+      const wethBalance = balances.bases?.WETH ?? balances.wethWei;
+      if (amount > wethBalance)
+        return { ok: false, reason: "amountWethWei exceeds WETH balance" };
+      const cap = BigInt(obs.limits.maxLstDepositWethWei ?? "0");
+      if (cap > 0n && amount > cap)
+        return {
+          ok: false,
+          reason: "amountWethWei exceeds configured per-action limit",
+        };
+      return { ok: true };
+    }
+    case "lstSwap": {
+      const amount = BigInt(action.amountIn);
+      if (amount <= 0n)
+        return { ok: false, reason: "amountIn must be positive" };
+      if (action.tokenIn === "WETH") {
+        const wethBalance = balances.bases?.WETH ?? balances.wethWei;
+        if (amount > wethBalance)
+          return { ok: false, reason: "amountIn exceeds WETH balance" };
+        const maxWethIn = BigInt(obs.limits.maxWethInWei);
+        if (maxWethIn > 0n && amount > maxWethIn)
+          return {
+            ok: false,
+            reason: "amountIn exceeds configured per-round limit",
+          };
+        return { ok: true };
+      }
+      // The LST balance is not part of BalanceSnapshot (the token is not in the base registry --
+      // it is valued by this adapter, not summed as spot), so it comes from the observation.
+      if (!lst) return { ok: false, reason: "no lst observation available" };
+      if (amount > BigInt(lst.lstBalanceWei))
+        return { ok: false, reason: "amountIn exceeds LST balance" };
+      return { ok: true };
+    }
+    case "lstRequestWithdraw": {
+      const amount = BigInt(action.amountLstWei);
+      if (amount <= 0n)
+        return { ok: false, reason: "amountLstWei must be positive" };
+      if (!lst) return { ok: false, reason: "no lst observation available" };
+      if (amount > BigInt(lst.lstBalanceWei))
+        return { ok: false, reason: "amountLstWei exceeds LST balance" };
+      return { ok: true };
+    }
+    case "lstClaimWithdraw":
+      if (!lst) return { ok: false, reason: "no lst observation available" };
+      if (
+        action.requestId === undefined &&
+        BigInt(lst.claimableWithdrawalWethWei) <= 0n
+      )
+        return { ok: false, reason: "no finalized withdrawal to claim" };
+      return { ok: true };
+    default:
+      return { ok: false, reason: "not an lst action" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Observation
+// ---------------------------------------------------------------------------
+
+async function observe(
+  ctx: SimContext,
+  state: LstState,
+  agent: Address,
+): Promise<LstObservation> {
+  const { publicClient } = ctx;
+  const deployment = state.deployment;
+  const [summary, openRequests] = await Promise.all([
+    publicClient.readContract({
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "accountSummary",
+      args: [agent],
+    }) as Promise<readonly bigint[]>,
+    publicClient.readContract({
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "openRequestsOf",
+      args: [agent],
+    }) as Promise<readonly (readonly bigint[])[]>,
+  ]);
+  const [shares, shareAssets, pendingAssets, claimableAssets] = summary;
+
+  // Quote the instant exit at the agent's *own* size, not at probe size: the whole point of a thin
+  // secondary market is that a big exit is worth less per unit than a small one.
+  const instantExit =
+    shares > 0n
+      ? ((await poolQuote(publicClient, deployment, shares)) ?? 0n)
+      : 0n;
+
+  const [ids, assets, claimableAt] = openRequests;
+  const blockNumber = await publicClient.getBlockNumber();
+  const pendingWithdrawals = ids.map((id, i) => ({
+    requestId: id.toString(),
+    assetsWethWei: assets[i].toString(),
+    claimableAtBlock: claimableAt[i].toString(),
+    claimable: blockNumber >= claimableAt[i],
+  }));
+
+  return {
+    redemptionRateWeth: state.redemptionRateWeth,
+    marketPriceWeth: state.midPriceWeth,
+    ...(state.sellPriceWeth > 0
+      ? { marketSellPriceWeth: state.sellPriceWeth }
+      : {}),
+    ...(state.buyPriceWeth > 0
+      ? { marketBuyPriceWeth: state.buyPriceWeth }
+      : {}),
+    discountBps: state.discountBps,
+    apyBps: state.apyBps,
+    yieldPerBlockBps: state.yieldPerBlockBps,
+    withdrawalDelayBlocks: state.withdrawalDelayBlocks,
+    queueLength: state.queueLength,
+    rewardReserveWei: state.rewardReserveWei.toString(),
+    lstBalanceWei: shares.toString(),
+    lstRedemptionValueWethWei: shareAssets.toString(),
+    instantExitWethWei: instantExit.toString(),
+    pendingWithdrawals,
+    pendingWithdrawalWethWei: pendingAssets.toString(),
+    claimableWithdrawalWethWei: claimableAssets.toString(),
+    poolReserves: {
+      weth: state.reserves.weth.toString(),
+      lst: state.reserves.lst.toString(),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transactions
+// ---------------------------------------------------------------------------
+
+function applySlippage(amount: bigint, slippageBps: number): bigint {
+  return (amount * BigInt(10_000 - slippageBps)) / 10_000n;
+}
+
+async function buildTxs(
+  ctx: SimContext,
+  owner: Address,
+  action: LeafAction,
+): Promise<BuiltTx[]> {
+  const deployment = requireLst();
+  switch (action.type) {
+    case "lstDeposit":
+      return [
+        {
+          to: deployment.vault,
+          data: encodeFunctionData({
+            abi: lstVaultAbi,
+            functionName: "deposit",
+            args: [BigInt(action.amountWethWei), owner],
+          }),
+        },
+      ];
+    case "lstSwap": {
+      const amountIn = BigInt(action.amountIn);
+      const [i, j] =
+        action.tokenIn === "LST"
+          ? [deployment.poolLstIndex, deployment.poolWethIndex]
+          : [deployment.poolWethIndex, deployment.poolLstIndex];
+      const quoted = (await ctx.publicClient.readContract({
+        address: deployment.pool,
+        abi: curveStableSwapNgAbi,
+        functionName: "get_dy",
+        args: [BigInt(i), BigInt(j), amountIn],
+      })) as bigint;
+      const minDy = applySlippage(
+        quoted,
+        action.slippageBps ?? DEFAULT_SLIPPAGE_BPS,
+      );
+      return [
+        {
+          to: deployment.pool,
+          data: encodeFunctionData({
+            abi: curveStableSwapNgAbi,
+            functionName: "exchange",
+            args: [BigInt(i), BigInt(j), amountIn, minDy],
+          }),
+        },
+      ];
+    }
+    case "lstRequestWithdraw":
+      return [
+        {
+          to: deployment.vault,
+          data: encodeFunctionData({
+            abi: lstVaultAbi,
+            functionName: "requestWithdraw",
+            args: [BigInt(action.amountLstWei)],
+          }),
+        },
+      ];
+    case "lstClaimWithdraw":
+      return [
+        {
+          to: deployment.vault,
+          data:
+            action.requestId === undefined
+              ? encodeFunctionData({
+                  abi: lstVaultAbi,
+                  functionName: "claimAllWithdrawals",
+                })
+              : encodeFunctionData({
+                  abi: lstVaultAbi,
+                  functionName: "claimWithdraw",
+                  args: [BigInt(action.requestId)],
+                }),
+        },
+      ];
+    default:
+      throw new Error("lst buildTxs: unexpected action");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Valuation
+// ---------------------------------------------------------------------------
+
+/// What an LST position is actually worth in WETH, given how much of the run is left.
+///
+/// Shares can leave two ways and the better one wins: sell into the pool now (whatever the discount
+/// costs at that size) or queue a redemption at par -- but the queue only counts if it finalizes
+/// before the run ends. Queued WETH is par once it finalizes in time; anything finalizing after the
+/// horizon is not realizable inside the run and is reported rather than counted.
+export function realizableWethWei(input: {
+  shares: bigint;
+  shareAssets: bigint;
+  instantExitWei: bigint | undefined;
+  claimableAssets: bigint;
+  reachableAssets: bigint;
+  unreachableAssets: bigint;
+  blockNumber: number;
+  horizonBlock: number;
+  withdrawalDelayBlocks: number;
+}): { wei: bigint; queueUsed: boolean } {
+  const queueFitsInRun =
+    input.blockNumber + input.withdrawalDelayBlocks <= input.horizonBlock;
+  const viaQueue = queueFitsInRun ? input.shareAssets : 0n;
+  const viaMarket = input.instantExitWei ?? 0n;
+  const shareValue = viaQueue > viaMarket ? viaQueue : viaMarket;
+  return {
+    wei: shareValue + input.claimableAssets + input.reachableAssets,
+    queueUsed: input.shares > 0n && viaQueue >= viaMarket && queueFitsInRun,
+  };
+}
+
+/// Historical valuation (issue #41's staged reads, issue #38's realizable marking).
+///
+/// Two stages, because the instant-exit quote depends on a balance the first stage returns:
+///   0. every agent's account summary, split at the run's horizon, plus the queue delay
+///   1. get_dy for exactly the agents that hold shares
+///
+/// Takes the deployment explicitly rather than reading the module-level LST constant, so the
+/// marking rules can be exercised without a deployed vault.
+export async function* lstValuationRun(
+  deployment: LstDeployment,
+  ctx: ValuationContext,
+): ValuationRun {
+  const summaries = yield [
+    {
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "withdrawalDelayBlocks",
+    },
+    ...ctx.agents.map((a) => ({
+      address: deployment.vault,
+      abi: lstVaultAbi,
+      functionName: "accountSummaryAt",
+      args: [a.address, BigInt(ctx.horizonBlock)],
+    })),
+  ];
+
+  const delayBlocks =
+    typeof summaries[0] === "bigint" ? Number(summaries[0]) : 0;
+  const perAgent = ctx.agents.map((_agent, i) => {
+    const row = summaries[1 + i] as readonly bigint[] | undefined;
+    if (!row) return undefined;
+    return {
+      shares: row[0],
+      shareAssets: row[1],
+      claimableAssets: row[2],
+      reachableAssets: row[3],
+      unreachableAssets: row[4],
+    };
+  });
+
+  // Only agents holding shares need a pool quote.
+  const quoteTargets = perAgent
+    .map((row, i) => ({ row, i }))
+    .filter((x): x is { row: NonNullable<typeof x.row>; i: number } =>
+      Boolean(x.row && x.row.shares > 0n),
+    );
+  let quotes: unknown[] = [];
+  if (quoteTargets.length > 0) {
+    quotes = yield quoteTargets.map(({ row }): ValuationRead => ({
+      address: deployment.pool,
+      abi: curveStableSwapNgAbi,
+      functionName: "get_dy",
+      args: [
+        BigInt(deployment.poolLstIndex),
+        BigInt(deployment.poolWethIndex),
+        row.shares,
+      ],
+    }));
+  }
+  const quoteByIndex = new Map<number, bigint | undefined>();
+  quoteTargets.forEach(({ i }, k) => {
+    const q = quotes[k];
+    quoteByIndex.set(i, typeof q === "bigint" ? q : undefined);
+  });
+
+  const fairWeth = ctx.fairByBase().WETH ?? 0;
+  const out: Record<string, AgentProtocolValue> = {};
+  ctx.agents.forEach((agent, i) => {
+    const row = perAgent[i];
+    if (!row) {
+      // The read that would have revealed the position failed. Saying "zero" here is
+      // indistinguishable from having exited, so report it instead (issue #44).
+      out[agent.id] = {
+        valueUsdc: 0,
+        liquidatableValueUsdc: 0,
+        unpriced: [
+          {
+            source: "lst-position",
+            amountRaw: "",
+            reason: "read-failed",
+            read: "MockLSTVault.accountSummaryAt",
+          },
+        ],
+      };
+      return;
+    }
+    const unpriced: UnpricedHoldingDetail[] = [];
+    const instantExit = quoteByIndex.get(i);
+    if (row.shares > 0n && instantExit === undefined) {
+      // No instant exit available at this size. The queue may still reach par, so this is not
+      // automatically a loss -- but say that the market leg is missing from the comparison.
+      unpriced.push({
+        token: deployment.lstToken,
+        amountRaw: row.shares.toString(),
+        source: "lst-market-quote",
+        reason: "unpriced",
+        read: "CurveStableSwapNG.get_dy",
+      });
+    }
+    const { wei } = realizableWethWei({
+      shares: row.shares,
+      shareAssets: row.shareAssets,
+      instantExitWei: instantExit,
+      claimableAssets: row.claimableAssets,
+      reachableAssets: row.reachableAssets,
+      unreachableAssets: row.unreachableAssets,
+      blockNumber: ctx.blockNumber,
+      horizonBlock: ctx.horizonBlock,
+      withdrawalDelayBlocks: delayBlocks,
+    });
+    if (row.unreachableAssets > 0n) {
+      // Queued at par, but the queue finalizes after the run ends: real value, not realizable
+      // inside the run. Excluded from the mark and reported, never silently zeroed.
+      unpriced.push({
+        token: deployment.asset,
+        amountRaw: row.unreachableAssets.toString(),
+        source: "lst-withdrawal-queue",
+        reason: "unrealizable",
+        read: "MockLSTVault.accountSummaryAt",
+      });
+    }
+    const valueUsdc = toFloat(wei) * fairWeth;
+    out[agent.id] = {
+      valueUsdc,
+      // The venue is marked at realizable value throughout, so the two agree here. They are kept
+      // separate because #39/#40 will have positions whose face value diverges from their exit.
+      liquidatableValueUsdc: valueUsdc,
+      unpriced,
+    };
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export const lstAdapter: ProtocolAdapter = {
+  id: "lst",
+  parse,
+  // The vault and the pool are ordinary calls, so an LST leg can ride in a bundle with the AMM
+  // legs (e.g. buy LST cheap and queue the redemption in one shot).
+  bundleable: () => true,
+  validate,
+
+  async readState(ctx): Promise<LstState> {
+    return getLstState(ctx);
+  },
+
+  async observe(ctx, state, agent): Promise<LstObservation> {
+    return observe(ctx, state as LstState, agent);
+  },
+
+  async buildTxs(ctx, owner, action): Promise<BuiltTx[]> {
+    return buildTxs(ctx, owner, action);
+  },
+
+  async valueUsdc(ctx, agent, _state, fairPrice): Promise<number> {
+    if (!LST) return 0;
+    const deployment = LST;
+    // Live marking (the coordinator's end-of-run PnL). The horizon has passed by the time this
+    // runs, so only what is claimable *now* counts from the queue -- the same rule the historical
+    // path applies, evaluated at the last block.
+    const blockNumber = Number(await ctx.publicClient.getBlockNumber());
+    const [summary, delayBlocks] = await Promise.all([
+      ctx.publicClient.readContract({
+        address: deployment.vault,
+        abi: lstVaultAbi,
+        functionName: "accountSummaryAt",
+        args: [agent, BigInt(blockNumber)],
+      }) as Promise<readonly bigint[]>,
+      ctx.publicClient.readContract({
+        address: deployment.vault,
+        abi: lstVaultAbi,
+        functionName: "withdrawalDelayBlocks",
+      }) as Promise<bigint>,
+    ]);
+    const [shares, shareAssets, claimableAssets, reachableAssets] = summary;
+    const instantExit =
+      shares > 0n
+        ? await poolQuote(ctx.publicClient, deployment, shares)
+        : undefined;
+    const { wei } = realizableWethWei({
+      shares,
+      shareAssets,
+      instantExitWei: instantExit,
+      claimableAssets,
+      reachableAssets,
+      unreachableAssets: 0n,
+      blockNumber,
+      horizonBlock: blockNumber,
+      withdrawalDelayBlocks: Number(delayBlocks),
+    });
+    return toFloat(wei) * fairPrice;
+  },
+
+  valueAtBlock(ctx) {
+    if (!LST) {
+      const empty: Record<string, AgentProtocolValue> = {};
+      for (const a of ctx.agents)
+        empty[a.id] = { valueUsdc: 0, liquidatableValueUsdc: 0, unpriced: [] };
+      return (async function* () {
+        return empty;
+      })();
+    }
+    return lstValuationRun(LST, ctx);
+  },
+
+  async accountedTokens(): Promise<Address[]> {
+    // The share token is valued above. The pool's LP token deliberately is not listed: nothing
+    // values it yet, so leaving it out keeps an LP holding visible as an unaccounted one (#41)
+    // instead of quietly excusing it.
+    return LST ? [LST.lstToken] : [];
+  },
+
+  async setupWallet(_ctx, _owner): Promise<BuiltTx[]> {
+    if (!LST) return [];
+    return [
+      approveTx(TOKENS.WETH.address, LST.vault),
+      approveTx(TOKENS.WETH.address, LST.pool),
+      approveTx(LST.lstToken, LST.pool),
+    ];
+  },
+};
+
+export const LST_PROBE_LST_WEI = PROBE_LST_WEI;

--- a/sdk/src/protocols/oracles.ts
+++ b/sdk/src/protocols/oracles.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, type Address, type Hex } from "viem";
-import { TOKENS } from "../constants.js";
+import { LST, TOKENS } from "../constants.js";
 import { tokenInfo } from "../markets.js";
 import {
   bigintToStorageWord,
@@ -7,8 +7,43 @@ import {
   sendNoMine,
   setStorageAt,
 } from "../chain.js";
+import { lstVaultAbi } from "../abis.js";
 import type { SimContext } from "./types.js";
 import { mockAggregatorAbi, toAavePrice } from "./aave.js";
+
+// Aave's price for the LST, when it is listed as collateral (issue #38 phase 3).
+//
+// An LST is not worth what its underlying is worth: it is worth WETH x the vault's redemption
+// rate, which rises with yield and drops with a slash. Aave has no idea about any of that, so the
+// price is derived here and written through the same three paths as every other oracle -- which
+// also means it inherits the same one-block lag. That lag is what turns a slash into a liquidation
+// cascade: the cut lands on the vault, the oracle follows a block later, and positions that were
+// healthy become liquidatable together.
+//
+// Returns null when the LST is not listed, has no aggregator, or the rate cannot be read -- in
+// every case leaving the existing price alone rather than writing a wrong one.
+async function lstAaveAggregator(
+  ctx: SimContext,
+  fairPrice: number,
+): Promise<{ aggregator: Address; aavePrice: bigint } | null> {
+  if (!LST?.aaveAToken) return null;
+  const aggregator = ctx.oracle.aaveAggregators[LST.lstToken.toLowerCase()];
+  if (!aggregator) return null;
+  if (!Number.isFinite(fairPrice) || fairPrice <= 0) return null;
+  let rate: bigint;
+  try {
+    rate = (await ctx.publicClient.readContract({
+      address: LST.vault,
+      abi: lstVaultAbi,
+      functionName: "stEthPerToken",
+    })) as bigint;
+  } catch {
+    return null;
+  }
+  const priceUsd = (fairPrice * Number(rate)) / 1e18;
+  if (!Number.isFinite(priceUsd) || priceUsd <= 0) return null;
+  return { aggregator, aavePrice: toAavePrice(priceUsd) };
+}
 
 // ADR 0013: enumerate additional bases beyond WETH/USDC that have an Aave mock aggregator registered.
 // On the default fork ctx.fairPrices is unset or WETH-only, so this returns an empty array, byte-identical to before.
@@ -89,6 +124,26 @@ export async function updateOracles(
           abi: mockAggregatorAbi,
           functionName: "setAnswer",
           args: [aavePrice],
+        }),
+      },
+    );
+    wrote = true;
+  }
+
+  // Issue #38 phase 3: the LST's own price, WETH x the vault's redemption rate.
+  const lstAgg = await lstAaveAggregator(ctx, fairPrice);
+  if (lstAgg) {
+    await sendAndMine(
+      ctx.publicClient,
+      ctx.walletClient,
+      ctx.chain,
+      ctx.adminPk,
+      {
+        to: lstAgg.aggregator,
+        data: encodeFunctionData({
+          abi: mockAggregatorAbi,
+          functionName: "setAnswer",
+          args: [lstAgg.aavePrice],
         }),
       },
     );
@@ -179,6 +234,28 @@ export async function updateOraclesMempool(
       ),
     );
   }
+  // Issue #38 phase 3: the LST's own price, WETH x the vault's redemption rate.
+  const lstAgg = await lstAaveAggregator(ctx, fairPrice);
+  if (lstAgg) {
+    hashes.push(
+      await sendNoMine(
+        ctx.publicClient,
+        ctx.walletClient,
+        ctx.chain,
+        ctx.adminPk,
+        {
+          to: lstAgg.aggregator,
+          data: encodeFunctionData({
+            abi: mockAggregatorAbi,
+            functionName: "setAnswer",
+            args: [lstAgg.aavePrice],
+          }),
+          gas: SETTER_GAS,
+        },
+        priorityFeeWei,
+      ),
+    );
+  }
   if (ctx.oracle.gmxProvider && ctx.updateGmxOracle) {
     // GMX submits two txs internally (WETH/USDC). The hashes can't be tracked but they land in the mempool.
     await ctx.updateGmxOracle(ctx, fairPrice, { noMine: true, priorityFeeWei });
@@ -223,6 +300,16 @@ export async function writeAaveOraclesStorage(
       aggregator,
       AGG_ANSWER_SLOT,
       bigintToStorageWord(aavePrice),
+    );
+  }
+  // Issue #38 phase 3: the LST's own price, WETH x the vault's redemption rate.
+  const lstAgg = await lstAaveAggregator(ctx, fairPrice);
+  if (lstAgg) {
+    await setStorageAt(
+      ctx.publicClient,
+      lstAgg.aggregator,
+      AGG_ANSWER_SLOT,
+      bigintToStorageWord(lstAgg.aavePrice),
     );
   }
 }

--- a/sdk/src/protocols/registry.ts
+++ b/sdk/src/protocols/registry.ts
@@ -7,6 +7,7 @@ import { balancerAdapter } from "./balancer.js";
 import { curveAdapter } from "./curve.js";
 import { aaveAdapter } from "./aave.js";
 import { gmxAdapter } from "./gmx.js";
+import { lstAdapter } from "./lst.js";
 import { activeBaseSymbols, tokenInfo } from "../markets.js";
 
 // All adapters (only implemented ones are registered). Added as phases progress.
@@ -16,26 +17,27 @@ const ALL_ADAPTERS: ProtocolAdapter[] = [
   curveAdapter,
   aaveAdapter,
   gmxAdapter,
+  lstAdapter,
 ];
 
 const ALL_BY_ID = new Map<ProtocolId, ProtocolAdapter>(
   ALL_ADAPTERS.map((a) => [a.id, a]),
 );
 
-export const ALL_PROTOCOL_IDS: ProtocolId[] = [
-  "uniswap",
-  "balancer",
-  "curve",
-  "gmx",
-  "aave",
-];
+export const ALL_PROTOCOL_IDS: ProtocolId[] = ALL_ADAPTERS.map((a) => a.id);
 
-// Set by the coordinator at startup. When unset, all implemented adapters are treated as enabled.
-let enabledIds: ProtocolId[] = ALL_ADAPTERS.map((a) => a.id);
+// The venues a run gets when it does not say. lst is left out because it exists only under local
+// deploy (issue #38) -- defaulting it on would break every fork run at the first read.
+const DEFAULT_PROTOCOL_IDS: ProtocolId[] = ALL_ADAPTERS.map((a) => a.id).filter(
+  (id) => id !== "lst",
+);
+
+// Set by the coordinator at startup. When unset, the default set above is treated as enabled.
+let enabledIds: ProtocolId[] = [...DEFAULT_PROTOCOL_IDS];
 
 export function setEnabledProtocols(ids: ProtocolId[]): void {
   const filtered = ids.filter((id) => ALL_BY_ID.has(id));
-  enabledIds = filtered.length > 0 ? filtered : ALL_ADAPTERS.map((a) => a.id);
+  enabledIds = filtered.length > 0 ? filtered : [...DEFAULT_PROTOCOL_IDS];
 }
 
 export function enabledAdapters(): ProtocolAdapter[] {

--- a/sdk/src/protocols/registry.ts
+++ b/sdk/src/protocols/registry.ts
@@ -9,6 +9,7 @@ import { aaveAdapter } from "./aave.js";
 import { gmxAdapter } from "./gmx.js";
 import { lstAdapter } from "./lst.js";
 import { activeBaseSymbols, tokenInfo } from "../markets.js";
+import { setEnabledProtocolIds } from "./enabled.js";
 
 // All adapters (only implemented ones are registered). Added as phases progress.
 const ALL_ADAPTERS: ProtocolAdapter[] = [
@@ -34,10 +35,14 @@ const DEFAULT_PROTOCOL_IDS: ProtocolId[] = ALL_ADAPTERS.map((a) => a.id).filter(
 
 // Set by the coordinator at startup. When unset, the default set above is treated as enabled.
 let enabledIds: ProtocolId[] = [...DEFAULT_PROTOCOL_IDS];
+setEnabledProtocolIds(enabledIds);
 
 export function setEnabledProtocols(ids: ProtocolId[]): void {
   const filtered = ids.filter((id) => ALL_BY_ID.has(id));
   enabledIds = filtered.length > 0 ? filtered : [...DEFAULT_PROTOCOL_IDS];
+  // Published so an adapter can ask what the run enabled without importing this module back
+  // (which would be a cycle, since this one imports every adapter).
+  setEnabledProtocolIds(enabledIds);
 }
 
 export function enabledAdapters(): ProtocolAdapter[] {

--- a/sdk/src/protocols/types.ts
+++ b/sdk/src/protocols/types.ts
@@ -100,6 +100,10 @@ export type ValuationAgent = { id: string; address: Address };
 export type ValuationContext = {
   publicClient: PublicClient;
   blockNumber: number;
+  // Last block of the run window. Realizable-exit marking needs to know how much of the run is
+  // left: a redemption queued now is only worth par if it finalizes before the run ends (issue
+  // #38). Equals blockNumber when the caller has no horizon, which is the conservative reading.
+  horizonBlock: number;
   agents: readonly ValuationAgent[];
   // The stables the run already sums as USDC-equivalent spot.
   activeStables: readonly Address[];

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -126,6 +126,11 @@ const SCHEMA: Record<string, string> = {
   "stress.victimCount": "ERIS_STRESS_VICTIM_COUNT",
   "stress.victimHf0": "ERIS_STRESS_VICTIM_HF0",
   "stress.victimWethWei": "ERIS_STRESS_VICTIM_WETH_WEI",
+  // lst (issue #38: liquid staking venue)
+  "lst.simulatedSecondsPerBlock": "ERIS_LST_SIMULATED_SECONDS_PER_BLOCK",
+  "lst.apyBps": "ERIS_LST_APY_BPS",
+  "lst.withdrawalDelayBlocks": "ERIS_LST_WITHDRAWAL_DELAY_BLOCKS",
+  "lst.maxDepositWethWei": "ERIS_LST_MAX_DEPOSIT_WETH_WEI",
   // vuln (ADR 0014: vulnerability-occurrence events)
   "vuln.events": "ERIS_VULN_EVENTS",
   "vuln.poolLiquidityUsdcUnits": "ERIS_VULN_POOL_LIQUIDITY_USDC_UNITS",
@@ -141,7 +146,7 @@ const BASE_SECTIONS: Record<string, { prefix: string; infix?: string }> = {
   "limits.aaveSupplyBase": { prefix: "MAX_AAVE_SUPPLY" },
   "flow.baseMax": { prefix: "FLOW_MAX" },
 };
-const SECTIONS = ["run", "funding", "limits", "flow", "stress", "vuln"];
+const SECTIONS = ["run", "funding", "limits", "flow", "stress", "vuln", "lst"];
 
 function baseEnvName(prefix: string, sym: string, infix?: string): string {
   const unit = unitSuffixFor(tokenInfo(sym).decimals);

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -131,6 +131,9 @@ const SCHEMA: Record<string, string> = {
   "lst.apyBps": "ERIS_LST_APY_BPS",
   "lst.withdrawalDelayBlocks": "ERIS_LST_WITHDRAWAL_DELAY_BLOCKS",
   "lst.maxDepositWethWei": "ERIS_LST_MAX_DEPOSIT_WETH_WEI",
+  "lst.apyRangeBps": "ERIS_LST_APY_RANGE_BPS",
+  "lst.apyStepBlocks": "ERIS_LST_APY_STEP_BLOCKS",
+  "lst.queueThroughputWeiPerBlock": "ERIS_LST_QUEUE_THROUGHPUT_WEI_PER_BLOCK",
   // vuln (ADR 0014: vulnerability-occurrence events)
   "vuln.events": "ERIS_VULN_EVENTS",
   "vuln.poolLiquidityUsdcUnits": "ERIS_VULN_POOL_LIQUIDITY_USDC_UNITS",

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -363,7 +363,11 @@ export type LstObservation = {
   // Executable WETH paid per LST bought from the pool.
   marketBuyPriceWeth?: number;
   // (redemptionRate - marketPrice) / redemptionRate, in bps. Positive = the market is discounted.
+  // Zero when the pool did not quote -- check marketQuoted before acting on it.
   discountBps: number;
+  // False means the pool refused to quote (reverted, or no liquidity at probe size). There is no
+  // instant exit and no carry to take; it is not a 100% discount.
+  marketQuoted?: boolean;
   // The APY the vault is currently paying on its compressed economic clock (the run's clock, not
   // wall-clock: one block advances lst.simulatedSecondsPerBlock seconds of staking).
   apyBps: number;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -6,7 +6,8 @@ export type TokenSymbol = string;
 // base = a tradable with a USD price (WETH/WBTC…), stable = a $1-pegged settlement currency (USDC-equivalent).
 export type TokenKind = "base" | "stable";
 
-export type ProtocolId = "uniswap" | "balancer" | "curve" | "gmx" | "aave";
+export type ProtocolId =
+  "uniswap" | "balancer" | "curve" | "gmx" | "aave" | "lst";
 
 // ---------------------------------------------------------------------------
 // Market leg (venue-specific metadata. ADR 0013). One per protocol × base.
@@ -146,6 +147,38 @@ export type GmxDecreaseAction = {
   maxPriorityFeePerGasWei?: string;
 };
 
+// LST venue (issue #38). The market is LST/WETH -- adapter-private, not a base/USDC market -- so
+// these actions carry no `base` selector.
+export type LstDepositAction = {
+  type: "lstDeposit";
+  // WETH to stake, in wei. Mints LST at the current redemption rate.
+  amountWethWei: string;
+  maxPriorityFeePerGasWei?: string;
+};
+
+export type LstSwapAction = {
+  type: "lstSwap";
+  // "WETH" buys LST from the secondary market; "LST" sells into it (the instant, discounted exit).
+  tokenIn: "WETH" | "LST";
+  amountIn: string; // wei of tokenIn (both are 18-decimal)
+  slippageBps?: number;
+  maxPriorityFeePerGasWei?: string;
+};
+
+export type LstRequestWithdrawAction = {
+  type: "lstRequestWithdraw";
+  // LST shares to queue for redemption at par. Claimable after the queue delay.
+  amountLstWei: string;
+  maxPriorityFeePerGasWei?: string;
+};
+
+export type LstClaimWithdrawAction = {
+  type: "lstClaimWithdraw";
+  // A specific request id, or omitted / "all" to claim every finalized request.
+  requestId?: string;
+  maxPriorityFeePerGasWei?: string;
+};
+
 // Bundleable leaves (excluding GMX)
 export type BundleActionItem =
   | SwapAction
@@ -157,7 +190,11 @@ export type BundleActionItem =
   | AaveSupplyAction
   | AaveWithdrawAction
   | AaveBorrowAction
-  | AaveRepayAction;
+  | AaveRepayAction
+  | LstDepositAction
+  | LstSwapAction
+  | LstRequestWithdrawAction
+  | LstClaimWithdrawAction;
 
 // All leaf actions (including GMX. The unit of intent / buildTxs)
 export type LeafAction =
@@ -294,12 +331,67 @@ export type AaveObservation = {
   poolLiquidity?: Partial<Record<TokenSymbol, string>>;
 };
 
+// A queued redemption. The shares are already burnt; what is left is a par claim on WETH that
+// lands at `claimableAtBlock`.
+export type LstWithdrawalObservation = {
+  requestId: string;
+  assetsWethWei: string;
+  claimableAtBlock: string;
+  claimable: boolean;
+};
+
+// LST venue (issue #38).
+//
+// The whole point of the venue is that an LST has two prices, and they are reported separately:
+//   - redemptionRateWeth: what the vault owes per share. Reachable only through the queue.
+//   - marketPriceWeth:    what the pool pays per share right now, fee and impact included.
+// discountBps is how far the second sits below the first -- positive means the market is cheap, so
+// buying and queueing a redemption earns the discount in exchange for waiting.
+export type LstObservation = {
+  // WETH per 1e18 LST, from the vault (`stEthPerToken`).
+  redemptionRateWeth: number;
+  // Executable mid at probe size = sqrt(sell x buy), which cancels the pool's symmetric fee.
+  marketPriceWeth: number;
+  // Executable WETH received per LST sold into the pool (fee/impact included) -- the instant exit.
+  marketSellPriceWeth?: number;
+  // Executable WETH paid per LST bought from the pool.
+  marketBuyPriceWeth?: number;
+  // (redemptionRate - marketPrice) / redemptionRate, in bps. Positive = the market is discounted.
+  discountBps: number;
+  // The APY the vault is currently paying on its compressed economic clock (the run's clock, not
+  // wall-clock: one block advances lst.simulatedSecondsPerBlock seconds of staking).
+  apyBps: number;
+  // Yield per block as a fraction, so an agent can compare "wait N blocks" against a discount
+  // without re-deriving it from the APY.
+  yieldPerBlockBps: number;
+  // Blocks between requesting a redemption and being able to claim it.
+  withdrawalDelayBlocks: number;
+  // Unclaimed requests across the whole vault (the queue's length; congestion in phase 2).
+  queueLength: number;
+  // Remaining pre-funded rewards, in wei. Zero means yield has stopped accruing.
+  rewardReserveWei: string;
+  // Your position.
+  lstBalanceWei: string;
+  // What your shares redeem for through the queue, at the current rate.
+  lstRedemptionValueWethWei: string;
+  // What selling your whole share balance into the pool would fetch right now, fee and impact
+  // included -- the instant exit, quoted at your actual size rather than at probe size.
+  instantExitWethWei: string;
+  // Your queued redemptions.
+  pendingWithdrawals: LstWithdrawalObservation[];
+  pendingWithdrawalWethWei: string;
+  claimableWithdrawalWethWei: string;
+  // Pool depth, so an agent can size an exit against it.
+  poolReserves?: { weth: string; lst: string };
+};
+
 export type ProtocolObservations = {
   uniswap?: UniswapObservation;
   balancer?: AmmObservation;
   curve?: AmmObservation;
   gmx?: GmxObservation;
   aave?: AaveObservation;
+  lst?: LstObservation;
 };
 
 export type AgentObservation = {
@@ -318,6 +410,12 @@ export type AgentObservation = {
   // unit-convert base amounts (agents cannot call tokenInfo, so it is passed via the observation).
   baseDecimals?: Record<TokenSymbol, number>;
   markets?: string[];
+  // Blocks left before the run ends, counted from the first block this agent observed (undefined
+  // when the run has no block limit). An exit that takes longer than this cannot complete inside
+  // the run, which is exactly what makes the LST withdrawal queue a decision rather than a
+  // formality (issue #38). Approximate by a block or two: an agent starts observing right around
+  // the first competition block, not before it.
+  blocksRemaining?: number;
   enabledProtocols: ProtocolId[];
   balances: {
     ethWei: string;
@@ -348,6 +446,8 @@ export type AgentObservation = {
     maxGmxSizeUsd: string;
     maxAaveSupplyWethWei: string;
     maxAaveBorrowUsdcUnits: string;
+    // Issue #38: cap on a single LST stake (wei). "0" = uncapped (bounded by balance).
+    maxLstDepositWethWei?: string;
     // ADR 0013: base symbol -> per-round cap (base units, decimal string). WETH equals maxWethInWei
     // etc. above for compatibility. Caps for additional bases (WBTC etc.) go here. "0" = no cap
     // (balance bound). A base-agnostic agent can cap its base-sell size at this value.

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -364,9 +364,21 @@ export type LstObservation = {
   // Yield per block as a fraction, so an agent can compare "wait N blocks" against a discount
   // without re-deriving it from the APY.
   yieldPerBlockBps: number;
-  // Blocks between requesting a redemption and being able to claim it.
+  // Floor on the wait between requesting a redemption and being able to claim it.
   withdrawalDelayBlocks: number;
-  // Unclaimed requests across the whole vault (the queue's length; congestion in phase 2).
+  // What the wait would *actually* be if you queued your whole share balance right now: the floor
+  // plus whatever is already queued ahead of you plus your own size draining (issue #38 phase 2).
+  // Equal to withdrawalDelayBlocks when the queue is not rate-limited. This, not the floor, is the
+  // number to compare against blocksRemaining.
+  estimatedQueueDelayBlocks: number;
+  // The wait for a one-WETH redemption, i.e. the queue's congestion with your own size taken out.
+  // Lets an agent see that the queue is busy even when it holds nothing yet.
+  queueDelayPerWethBlocks?: number;
+  // WETH the queue finalizes per block ("0" = no limit). With it you can size a redemption to what
+  // will actually finalize in the blocks you have left, instead of queueing all of it and finding
+  // out none of it lands.
+  queueThroughputWeiPerBlock?: string;
+  // Unclaimed requests across the whole vault (the queue's length).
   queueLength: number;
   // Remaining pre-funded rewards, in wei. Zero means yield has stopped accruing.
   rewardReserveWei: string;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -3,8 +3,14 @@ import type { Address, Hex } from "viem";
 // Keys of the token registry (TOKENS in src/markets.ts). Made a string by stripping the literal union
 // (so adding a token is just adding a constant. ADR 0013). Actual existence is managed in TOKENS.
 export type TokenSymbol = string;
-// base = a tradable with a USD price (WETH/WBTC…), stable = a $1-pegged settlement currency (USDC-equivalent).
-export type TokenKind = "base" | "stable";
+// base = a tradable with a USD price (WETH/WBTC…), stable = a $1-pegged settlement currency
+// (USDC-equivalent), lst = a yield-bearing claim on a base whose venue values it itself.
+//
+// An lst is deliberately neither of the first two. Calling it a base would put it in the scorer's
+// spot sweep, priced off the fair-price feed at face value -- while its own adapter is separately
+// marking it at what it could realize (issue #38). That is a double count and a wrong number.
+// Keeping it its own kind means it is only ever valued by the venue that understands it.
+export type TokenKind = "base" | "stable" | "lst";
 
 export type ProtocolId =
   "uniswap" | "balancer" | "curve" | "gmx" | "aave" | "lst";
@@ -395,6 +401,10 @@ export type LstObservation = {
   claimableWithdrawalWethWei: string;
   // Pool depth, so an agent can size an exit against it.
   poolReserves?: { weth: string; lst: string };
+  // Issue #38 phase 3: whether the LST is listed as Aave collateral, which is what makes leveraged
+  // staking possible (supply LST, borrow WETH, stake again). Absent or false means the deploy had
+  // no Aave to list it on, and `aaveSupply` with asset "LST" will be rejected.
+  aaveCollateral?: boolean;
 };
 
 export type ProtocolObservations = {

--- a/sdk/src/valuation.ts
+++ b/sdk/src/valuation.ts
@@ -25,9 +25,12 @@ function stableVariantDecimals(token: Address): number | undefined {
 
 // Why a holding is missing from a value. "unpriced" means the amount is known but has no USD price;
 // "read-failed" means the read that would have revealed the holding failed, so the holding is
-// *unknown* rather than zero (issue #44). Both are excluded from the value and both are reported —
-// a zero in summary.json must never be mistaken for a trading loss.
-export type ScoringExclusionReason = "unpriced" | "read-failed";
+// *unknown* rather than zero (issue #44); "unrealizable" means it is known and priceable but
+// cannot be turned into anything before the run ends -- an LST redemption whose queue finalizes
+// after the last block (issue #38). All three are excluded from the value and all three are
+// reported — a zero in summary.json must never be mistaken for a trading loss.
+export type ScoringExclusionReason =
+  "unpriced" | "read-failed" | "unrealizable";
 
 // A holding left out of a value, and why.
 export type UnpricedAmount = {

--- a/test/gmxMarketToken.test.ts
+++ b/test/gmxMarketToken.test.ts
@@ -34,6 +34,7 @@ async function drive(stages: Array<(reads: unknown[]) => unknown[]>) {
   const run = gmxAdapter.valueAtBlock!({
     publicClient: undefined as never,
     blockNumber: 1,
+    horizonBlock: 1,
     agents: AGENTS,
     activeStables: [TOKENS.USDC.address as Address],
     fairByBase: () => FAIR,
@@ -228,6 +229,7 @@ test("a perp whose base has no fair price is reported, not scored at zero", asyn
   const run = gmxAdapter.valueAtBlock!({
     publicClient: undefined as never,
     blockNumber: 1,
+    horizonBlock: 1,
     agents: AGENTS,
     activeStables: [TOKENS.USDC.address as Address],
     fairByBase: () => ({}), // price feed read failed for every base

--- a/test/lst.test.ts
+++ b/test/lst.test.ts
@@ -1,0 +1,435 @@
+// LST venue (issue #38): the economic clock, the two prices, and realizable-exit marking.
+//
+// The venue's whole point is that face value and exit value are different numbers. These cover the
+// places where confusing the two would silently mis-score a run: the queue that outlives the run,
+// the pool quote at real size, and the calibration that decides how fast yield accrues.
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Address } from "viem";
+import { agentActionSchemaFor } from "@eris/sdk/actionSchema.js";
+import type { LstDeployment } from "@eris/sdk/constants.js";
+import {
+  apyBpsFrom,
+  discountBpsFrom,
+  lstAdapter,
+  lstValuationRun,
+  realizableWethWei,
+  rewardRatePerBlockRay,
+  yieldPerBlockBpsFrom,
+} from "@eris/sdk/protocols/lst.js";
+import type { ValuationContext } from "@eris/sdk/protocols/types.js";
+import type {
+  AgentObservation,
+  BalanceSnapshot,
+  LstObservation,
+} from "@eris/sdk/types.js";
+
+const WAD = 10n ** 18n;
+const FAIR = 3000;
+
+const DEPLOYMENT: LstDeployment = {
+  vault: "0x00000000000000000000000000000000000v0001" as Address,
+  lstToken: "0x00000000000000000000000000000000000v0001" as Address,
+  asset: "0x00000000000000000000000000000000000we7h" as Address,
+  pool: "0x00000000000000000000000000000000000p0001" as Address,
+  poolLstIndex: 1,
+  poolWethIndex: 0,
+  simulatedSecondsPerBlock: 3600,
+  targetApyBps: 300,
+  withdrawalDelayBlocks: 24,
+};
+
+const AGENT = {
+  id: "a1",
+  address: "0x00000000000000000000000000000000000a0001" as Address,
+};
+
+// ---------------------------------------------------------------------------
+// Economic clock
+// ---------------------------------------------------------------------------
+
+test("the reward rate round-trips through the APY it was derived from", () => {
+  // 3%/yr on a one-hour-per-block clock, which is what the deployer bakes in.
+  const rate = rewardRatePerBlockRay(300, 3600);
+  assert.ok(rate > 0n);
+  assert.ok(Math.abs(apyBpsFrom(rate, 3600) - 300) < 0.5);
+});
+
+test("a faster clock accrues proportionally more per block", () => {
+  const hourly = rewardRatePerBlockRay(300, 3600);
+  const daily = rewardRatePerBlockRay(300, 86_400);
+  assert.equal(daily / hourly, 24n);
+  // ... and still reports the same APY, because the clock is part of the conversion.
+  assert.ok(Math.abs(apyBpsFrom(daily, 86_400) - 300) < 0.5);
+});
+
+test("yield per block is small against a pool round trip at the shipped calibration", () => {
+  // The venue is calibrated so that staking does not dwarf every other venue: an 80-block run at
+  // 3%/yr on an hourly clock earns a few bps, well under the pool's ~12bps round trip. If this
+  // starts failing, the clock was sped up and the LST became free money.
+  const perBlock = yieldPerBlockBpsFrom(rewardRatePerBlockRay(300, 3600));
+  assert.ok(
+    perBlock * 80 < 12,
+    `80 blocks earned ${(perBlock * 80).toFixed(2)}bps`,
+  );
+});
+
+test("a zero clock or zero APY means no yield at all", () => {
+  assert.equal(rewardRatePerBlockRay(0, 3600), 0n);
+  assert.equal(rewardRatePerBlockRay(300, 0), 0n);
+  assert.equal(apyBpsFrom(10n ** 21n, 0), 0);
+});
+
+// ---------------------------------------------------------------------------
+// The two prices
+// ---------------------------------------------------------------------------
+
+test("discount is positive when the market trades below redemption", () => {
+  assert.ok(Math.abs(discountBpsFrom(1.05, 1.0446) - 51.4) < 1);
+  // A premium is the same measure with the sign flipped.
+  assert.ok(discountBpsFrom(1.0, 1.01) < 0);
+  // No rate means no meaningful discount rather than a divide-by-zero.
+  assert.equal(discountBpsFrom(0, 1), 0);
+});
+
+// ---------------------------------------------------------------------------
+// Realizable marking
+// ---------------------------------------------------------------------------
+
+const baseRealizable = {
+  shares: WAD,
+  shareAssets: WAD, // par: 1 WETH
+  instantExitWei: (WAD * 9900n) / 10_000n, // the pool pays 99%
+  claimableAssets: 0n,
+  reachableAssets: 0n,
+  unreachableAssets: 0n,
+  blockNumber: 100,
+  horizonBlock: 200,
+  withdrawalDelayBlocks: 20,
+};
+
+test("shares mark at par while the queue still fits inside the run", () => {
+  const { wei, queueUsed } = realizableWethWei(baseRealizable);
+  assert.equal(wei, WAD);
+  assert.ok(queueUsed);
+});
+
+test("shares mark at the pool's price once the queue no longer fits", () => {
+  // 100 + 20 > 110: a redemption queued here finalizes after the run ends, so par is out of reach
+  // and the only exit left is the discounted one.
+  const { wei, queueUsed } = realizableWethWei({
+    ...baseRealizable,
+    horizonBlock: 110,
+  });
+  assert.equal(wei, (WAD * 9900n) / 10_000n);
+  assert.ok(!queueUsed);
+});
+
+test("a pool trading above par beats the queue even when the queue is open", () => {
+  const { wei, queueUsed } = realizableWethWei({
+    ...baseRealizable,
+    instantExitWei: (WAD * 10_100n) / 10_000n,
+  });
+  assert.equal(wei, (WAD * 10_100n) / 10_000n);
+  assert.ok(!queueUsed);
+});
+
+test("shares with no pool quote fall back to the queue, not to zero", () => {
+  const { wei } = realizableWethWei({
+    ...baseRealizable,
+    instantExitWei: undefined,
+  });
+  assert.equal(wei, WAD);
+});
+
+test("shares with neither a quote nor a reachable queue are worth nothing realizable", () => {
+  const { wei } = realizableWethWei({
+    ...baseRealizable,
+    instantExitWei: undefined,
+    horizonBlock: 110,
+  });
+  assert.equal(wei, 0n);
+});
+
+test("queued WETH counts when it finalizes in time and not when it does not", () => {
+  const queued = {
+    ...baseRealizable,
+    shares: 0n,
+    shareAssets: 0n,
+    instantExitWei: 0n,
+    claimableAssets: WAD,
+    reachableAssets: 2n * WAD,
+    unreachableAssets: 5n * WAD,
+  };
+  // Claimable now plus finalizing before the horizon. The 5 WETH finalizing after it is excluded --
+  // real value, but not realizable inside the run.
+  assert.equal(realizableWethWei(queued).wei, 3n * WAD);
+});
+
+// ---------------------------------------------------------------------------
+// Staged historical valuation (issue #41's batching contract)
+// ---------------------------------------------------------------------------
+
+function valuationCtx(
+  overrides: Partial<ValuationContext> = {},
+): ValuationContext {
+  return {
+    publicClient: {} as never,
+    blockNumber: 100,
+    horizonBlock: 200,
+    agents: [AGENT],
+    activeStables: [],
+    fairByBase: () => ({ WETH: FAIR }),
+    ...overrides,
+  };
+}
+
+// Drive the generator with canned stage results, recording what each stage asked for.
+async function drive(
+  ctx: ValuationContext,
+  stages: Array<(reads: unknown[]) => unknown[]>,
+) {
+  const run = lstValuationRun(DEPLOYMENT, ctx);
+  const asked: unknown[][] = [];
+  let step = await run.next();
+  let i = 0;
+  while (!step.done) {
+    asked.push(step.value);
+    const reply = stages[i]?.(step.value) ?? step.value.map(() => undefined);
+    i += 1;
+    step = await run.next(reply);
+  }
+  return { asked, values: step.value };
+}
+
+// accountSummaryAt returns (shares, shareAssets, claimable, reachable, unreachable, openRequests).
+function summary(
+  shares: bigint,
+  shareAssets: bigint,
+  claimable = 0n,
+  reachable = 0n,
+  unreachable = 0n,
+): readonly bigint[] {
+  return [shares, shareAssets, claimable, reachable, unreachable, 0n];
+}
+
+test("valuation reads the queue delay and every account in one stage", async () => {
+  const { asked, values } = await drive(valuationCtx(), [
+    () => [20n, summary(WAD, WAD)],
+    () => [(WAD * 9900n) / 10_000n],
+  ]);
+  // Stage 0 is one delay read plus one summary per agent; stage 1 is one quote for the holder.
+  assert.equal(asked[0].length, 2);
+  assert.equal(asked[1].length, 1);
+  // Par, since the queue fits (block 100 + 20 <= horizon 200), valued at the WETH fair.
+  assert.equal(values[AGENT.id].valueUsdc, FAIR);
+  assert.equal(values[AGENT.id].liquidatableValueUsdc, FAIR);
+  assert.deepEqual(values[AGENT.id].unpriced, []);
+});
+
+test("an agent holding nothing costs no second-stage read", async () => {
+  const { asked, values } = await drive(valuationCtx(), [
+    () => [20n, summary(0n, 0n)],
+  ]);
+  assert.equal(
+    asked.length,
+    1,
+    "a pool quote was requested for an empty position",
+  );
+  assert.equal(values[AGENT.id].valueUsdc, 0);
+});
+
+test("a redemption that outlives the run is reported, not counted", async () => {
+  const { values } = await drive(valuationCtx(), [
+    () => [20n, summary(0n, 0n, 0n, 0n, 2n * WAD)],
+  ]);
+  const value = values[AGENT.id];
+  assert.equal(value.valueUsdc, 0);
+  assert.deepEqual(value.unpriced, [
+    {
+      token: DEPLOYMENT.asset,
+      amountRaw: (2n * WAD).toString(),
+      source: "lst-withdrawal-queue",
+      reason: "unrealizable",
+      read: "MockLSTVault.accountSummaryAt",
+    },
+  ]);
+});
+
+test("an unreadable account is reported instead of scored as exited", async () => {
+  const { values } = await drive(valuationCtx(), [() => [20n, undefined]]);
+  const value = values[AGENT.id];
+  assert.equal(value.valueUsdc, 0);
+  assert.equal(value.unpriced[0].reason, "read-failed");
+  assert.equal(value.unpriced[0].source, "lst-position");
+});
+
+test("a refused pool quote is reported while the queue still carries the value", async () => {
+  const { values } = await drive(valuationCtx(), [
+    () => [20n, summary(WAD, WAD)],
+    () => [undefined], // get_dy reverted (no liquidity at this size)
+  ]);
+  const value = values[AGENT.id];
+  assert.equal(value.valueUsdc, FAIR, "the queue should still reach par");
+  assert.equal(value.unpriced[0].source, "lst-market-quote");
+});
+
+test("the horizon the scorer passes is the one the vault splits the queue at", async () => {
+  const { asked } = await drive(valuationCtx({ horizonBlock: 175 }), [
+    () => [20n, summary(0n, 0n)],
+  ]);
+  const summaryRead = asked[0][1] as { args: unknown[] };
+  assert.deepEqual(summaryRead.args, [AGENT.address, 175n]);
+});
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+test("the action schema exposes the lst actions only when the venue is enabled", () => {
+  const withLst = agentActionSchemaFor(["lst"]);
+  assert.ok(
+    withLst.safeParse({ type: "lstDeposit", amountWethWei: "1000" }).success,
+  );
+  const withoutLst = agentActionSchemaFor(["uniswap"]);
+  assert.ok(
+    !withoutLst.safeParse({ type: "lstDeposit", amountWethWei: "1000" })
+      .success,
+  );
+});
+
+test("lstSwap only accepts the two tokens the market trades", () => {
+  const schema = agentActionSchemaFor(["lst"]);
+  assert.ok(
+    schema.safeParse({ type: "lstSwap", tokenIn: "LST", amountIn: "1" })
+      .success,
+  );
+  assert.ok(
+    !schema.safeParse({ type: "lstSwap", tokenIn: "USDC", amountIn: "1" })
+      .success,
+  );
+});
+
+test("parse rejects a float amount and keeps the wei string intact", () => {
+  assert.throws(() =>
+    lstAdapter.parse({ type: "lstDeposit", amountWethWei: 1.5 }),
+  );
+  assert.deepEqual(
+    lstAdapter.parse({
+      type: "lstDeposit",
+      amountWethWei: "1500000000000000000",
+    }),
+    { type: "lstDeposit", amountWethWei: "1500000000000000000" },
+  );
+});
+
+test('claiming "all" is spelled as an omitted requestId', () => {
+  assert.deepEqual(
+    lstAdapter.parse({ type: "lstClaimWithdraw", requestId: "all" }),
+    {
+      type: "lstClaimWithdraw",
+    },
+  );
+  assert.deepEqual(
+    lstAdapter.parse({ type: "lstClaimWithdraw", requestId: "7" }),
+    {
+      type: "lstClaimWithdraw",
+      requestId: "7",
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function lstObservation(
+  overrides: Partial<LstObservation> = {},
+): LstObservation {
+  return {
+    redemptionRateWeth: 1.02,
+    marketPriceWeth: 1.01,
+    discountBps: 98,
+    apyBps: 300,
+    yieldPerBlockBps: 0.034,
+    withdrawalDelayBlocks: 20,
+    queueLength: 0,
+    rewardReserveWei: (50n * WAD).toString(),
+    lstBalanceWei: "0",
+    lstRedemptionValueWethWei: "0",
+    instantExitWethWei: "0",
+    pendingWithdrawals: [],
+    pendingWithdrawalWethWei: "0",
+    claimableWithdrawalWethWei: "0",
+    ...overrides,
+  };
+}
+
+function observation(lst: LstObservation): AgentObservation {
+  return {
+    limits: {
+      maxWethInWei: WAD.toString(),
+      maxUsdcInUnits: "5000000000",
+      maxLstDepositWethWei: (5n * WAD).toString(),
+      defaultPriorityFeePerGasWei: "100000000",
+      maxPriorityFeePerGasWei: "5000000000",
+    },
+    protocols: { lst },
+  } as unknown as AgentObservation;
+}
+
+const balances = (wethWei: bigint): BalanceSnapshot => ({
+  ethWei: WAD,
+  wethWei,
+  usdcUnits: 0n,
+  bases: { WETH: wethWei },
+});
+
+test("a stake beyond the configured cap is rejected before it reaches the chain", () => {
+  const obs = observation(lstObservation());
+  const action = {
+    type: "lstDeposit" as const,
+    amountWethWei: (6n * WAD).toString(),
+  };
+  const result = lstAdapter.validate(action, obs, balances(10n * WAD));
+  assert.equal(result.ok, false);
+});
+
+test("a stake beyond the WETH balance is rejected", () => {
+  const obs = observation(lstObservation());
+  const action = {
+    type: "lstDeposit" as const,
+    amountWethWei: (2n * WAD).toString(),
+  };
+  assert.equal(lstAdapter.validate(action, obs, balances(WAD / 2n)).ok, false);
+  assert.equal(lstAdapter.validate(action, obs, balances(4n * WAD)).ok, true);
+});
+
+test("selling more LST than you hold is rejected against the observation, not the wallet", () => {
+  // The LST balance is not part of BalanceSnapshot -- the token is valued by the adapter rather
+  // than summed as spot -- so the check has to come from the observation.
+  const obs = observation(lstObservation({ lstBalanceWei: WAD.toString() }));
+  const tooMuch = {
+    type: "lstSwap" as const,
+    tokenIn: "LST" as const,
+    amountIn: (2n * WAD).toString(),
+  };
+  assert.equal(lstAdapter.validate(tooMuch, obs, balances(0n)).ok, false);
+  const fits = { ...tooMuch, amountIn: (WAD / 2n).toString() };
+  assert.equal(lstAdapter.validate(fits, obs, balances(0n)).ok, true);
+});
+
+test("claiming with nothing finalized is rejected rather than burned on a revert", () => {
+  const obs = observation(lstObservation());
+  assert.equal(
+    lstAdapter.validate({ type: "lstClaimWithdraw" }, obs, balances(0n)).ok,
+    false,
+  );
+  const ready = observation(
+    lstObservation({ claimableWithdrawalWethWei: WAD.toString() }),
+  );
+  assert.equal(
+    lstAdapter.validate({ type: "lstClaimWithdraw" }, ready, balances(0n)).ok,
+    true,
+  );
+});

--- a/test/lst.test.ts
+++ b/test/lst.test.ts
@@ -222,7 +222,8 @@ test("valuation reads the queue delay and every account in one stage", async () 
   // for the holder.
   assert.equal(asked[0].length, 3);
   assert.equal(asked[1].length, 1);
-  // Par, since the queue fits (block 100 + 20 <= horizon 200), valued at the WETH fair.
+  // Par, since the queue fits (block 100 + 20 <= horizon 200), valued at the WETH fair. Both
+  // marks agree here, which is the normal case -- they only diverge when an exit cannot complete.
   assert.equal(values[AGENT.id].valueUsdc, FAIR);
   assert.equal(values[AGENT.id].liquidatableValueUsdc, FAIR);
   assert.deepEqual(values[AGENT.id].unpriced, []);
@@ -240,12 +241,15 @@ test("an agent holding nothing costs no second-stage read", async () => {
   assert.equal(values[AGENT.id].valueUsdc, 0);
 });
 
-test("a redemption that outlives the run is reported, not counted", async () => {
+test("a redemption that outlives the run is reported, and excluded from the realizable mark", async () => {
   const { values } = await drive(valuationCtx(), [
     () => [20n, 0n, summary(0n, 0n, 0n, 0n, 2n * WAD)],
   ]);
   const value = values[AGENT.id];
-  assert.equal(value.valueUsdc, 0);
+  // Face value still counts the queued WETH -- it exists, the vault owes it. What it cannot do is
+  // arrive before the run ends, which is what the realizable mark says.
+  assert.equal(value.valueUsdc, 2 * FAIR);
+  assert.equal(value.liquidatableValueUsdc, 0);
   assert.deepEqual(value.unpriced, [
     {
       token: DEPLOYMENT.asset,
@@ -451,8 +455,9 @@ test("scoring uses the congested wait, not the vault's advertised floor", async 
     // stage 1 is [get_dy, estimateDelayBlocks] for the one holder
     () => [(WAD * 9000n) / 10_000n, 90n],
   ]);
-  // Falls back to the pool's price rather than par.
-  assert.equal(values[AGENT.id].valueUsdc, FAIR * 0.9);
+  // Face value is par; the realizable mark falls back to the pool's price.
+  assert.equal(values[AGENT.id].valueUsdc, FAIR);
+  assert.equal(values[AGENT.id].liquidatableValueUsdc, FAIR * 0.9);
 });
 
 test("an unlimited queue costs no extra read", async () => {
@@ -462,4 +467,79 @@ test("an unlimited queue costs no extra read", async () => {
   ]);
   // Stage 1 is the pool quote only: no delay read when the queue is not rate-limited.
   assert.equal(asked[1].length, 1);
+});
+
+test("an unreadable queue delay marks at the market, not at par", async () => {
+  // The silent-zero pattern this repo removed in #44, in a new place: a failed
+  // withdrawalDelayBlocks read used to become a zero-block wait, which makes every queue look
+  // reachable and marks every position at par. Unknown means "assume closed" and say so.
+  const { values } = await drive(valuationCtx(), [
+    () => [undefined /* delay read failed */, 0n, summary(WAD, WAD)],
+    () => [(WAD * 9500n) / 10_000n],
+  ]);
+  const value = values[AGENT.id];
+  assert.equal(value.valueUsdc, FAIR, "face value is unaffected");
+  assert.equal(
+    value.liquidatableValueUsdc,
+    FAIR * 0.95,
+    "realizable must fall back to the pool quote",
+  );
+  assert.ok(
+    value.unpriced.some(
+      (u) => u.source === "lst-queue-delay" && u.reason === "read-failed",
+    ),
+    "the failed read must be reported",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3: LST posted as Aave collateral must not escape the realizable mark
+// ---------------------------------------------------------------------------
+
+test("LST supplied to Aave is haircut the same way a wallet balance is", async () => {
+  // The hole this closes: Aave marks collateral at its oracle price, which for an LST is the
+  // vault's par rate. Left alone, ten shares in a wallet score the pool's discounted quote while
+  // the same ten shares posted to Aave score par -- free score for switching leverage on, with no
+  // skill in it. Both must reach the same answer, because withdrawing the aToken leaves you
+  // holding exactly the same unexitable shares.
+  const { aaveAdapter } = await import("@eris/sdk/protocols/aave.js");
+  const ctx = valuationCtx({ horizonBlock: 105 }); // block 100: only a 5-block queue would fit
+  const run = aaveAdapter.valueAtBlock?.(ctx);
+  assert.ok(run);
+
+  const stage0 = await run.next();
+  // getUserAccountData per agent, then the aToken balance per agent when the LST is listed.
+  const collateralUsd8 = 3000n * 10n ** 8n; // $3000 of collateral, no debt
+  const stage1 = await run.next([
+    [collateralUsd8, 0n, 0n, 8000n, 7000n, 2n ** 128n],
+    WAD, // 1 LST posted
+  ]);
+  if (stage1.done) {
+    // No LST in this deployment (the fork default): nothing to haircut, and that is fine.
+    assert.ok(!stage0.done);
+    return;
+  }
+  const done = await run.next([
+    (WAD * 9000n) / 10_000n, // get_dy: the pool pays 0.9 WETH for the share
+    WAD, // convertToAssets: par is 1 WETH
+    40n, // estimateDelayBlocks: 40 blocks, far past the 5-block horizon
+  ]);
+  assert.ok(done.done);
+  const value = done.value[AGENT.id];
+  assert.equal(value.valueUsdc, 3000, "face value stays at the oracle mark");
+  // 0.1 WETH of the par value cannot be recovered: $3000 - 0.1 * $3000.
+  assert.equal(value.liquidatableValueUsdc, 3000 - 0.1 * FAIR);
+  assert.ok(
+    value.unpriced.some((u) => u.source === "aave-lst-collateral"),
+    "the unrecoverable part must be reported",
+  );
+});
+
+test("a pool that will not quote is no market, not a 10000bps discount", () => {
+  // sellPrice 0 used to flow into discountBps as (rate - 0)/rate = 10000, which reads as an
+  // infinite free carry: the agent empties its wallet into a pool that just said it cannot fill,
+  // and startup blames the rate oracle for it.
+  const obs = lstObservation({ marketQuoted: false, discountBps: 0 });
+  assert.equal(obs.discountBps, 0);
+  assert.equal(obs.marketQuoted, false);
 });

--- a/test/lst.test.ts
+++ b/test/lst.test.ts
@@ -105,7 +105,7 @@ const baseRealizable = {
   unreachableAssets: 0n,
   blockNumber: 100,
   horizonBlock: 200,
-  withdrawalDelayBlocks: 20,
+  queueDelayBlocks: 20,
 };
 
 test("shares mark at par while the queue still fits inside the run", () => {
@@ -215,11 +215,12 @@ function summary(
 
 test("valuation reads the queue delay and every account in one stage", async () => {
   const { asked, values } = await drive(valuationCtx(), [
-    () => [20n, summary(WAD, WAD)],
+    () => [20n, 0n, summary(WAD, WAD)],
     () => [(WAD * 9900n) / 10_000n],
   ]);
-  // Stage 0 is one delay read plus one summary per agent; stage 1 is one quote for the holder.
-  assert.equal(asked[0].length, 2);
+  // Stage 0 is the queue floor, the throughput, and one summary per agent; stage 1 is one quote
+  // for the holder.
+  assert.equal(asked[0].length, 3);
   assert.equal(asked[1].length, 1);
   // Par, since the queue fits (block 100 + 20 <= horizon 200), valued at the WETH fair.
   assert.equal(values[AGENT.id].valueUsdc, FAIR);
@@ -241,7 +242,7 @@ test("an agent holding nothing costs no second-stage read", async () => {
 
 test("a redemption that outlives the run is reported, not counted", async () => {
   const { values } = await drive(valuationCtx(), [
-    () => [20n, summary(0n, 0n, 0n, 0n, 2n * WAD)],
+    () => [20n, 0n, summary(0n, 0n, 0n, 0n, 2n * WAD)],
   ]);
   const value = values[AGENT.id];
   assert.equal(value.valueUsdc, 0);
@@ -257,7 +258,9 @@ test("a redemption that outlives the run is reported, not counted", async () => 
 });
 
 test("an unreadable account is reported instead of scored as exited", async () => {
-  const { values } = await drive(valuationCtx(), [() => [20n, undefined]]);
+  const { values } = await drive(valuationCtx(), [
+    () => [20n, 0n, undefined],
+  ]);
   const value = values[AGENT.id];
   assert.equal(value.valueUsdc, 0);
   assert.equal(value.unpriced[0].reason, "read-failed");
@@ -266,7 +269,7 @@ test("an unreadable account is reported instead of scored as exited", async () =
 
 test("a refused pool quote is reported while the queue still carries the value", async () => {
   const { values } = await drive(valuationCtx(), [
-    () => [20n, summary(WAD, WAD)],
+    () => [20n, 0n, summary(WAD, WAD)],
     () => [undefined], // get_dy reverted (no liquidity at this size)
   ]);
   const value = values[AGENT.id];
@@ -276,9 +279,9 @@ test("a refused pool quote is reported while the queue still carries the value",
 
 test("the horizon the scorer passes is the one the vault splits the queue at", async () => {
   const { asked } = await drive(valuationCtx({ horizonBlock: 175 }), [
-    () => [20n, summary(0n, 0n)],
+    () => [20n, 0n, summary(0n, 0n)],
   ]);
-  const summaryRead = asked[0][1] as { args: unknown[] };
+  const summaryRead = asked[0][2] as { args: unknown[] };
   assert.deepEqual(summaryRead.args, [AGENT.address, 175n]);
 });
 
@@ -353,6 +356,7 @@ function lstObservation(
     apyBps: 300,
     yieldPerBlockBps: 0.034,
     withdrawalDelayBlocks: 20,
+    estimatedQueueDelayBlocks: 20,
     queueLength: 0,
     rewardReserveWei: (50n * WAD).toString(),
     lstBalanceWei: "0",
@@ -432,4 +436,30 @@ test("claiming with nothing finalized is rejected rather than burned on a revert
     lstAdapter.validate({ type: "lstClaimWithdraw" }, ready, balances(0n)).ok,
     true,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2: congestion, varying yield, slashing
+// ---------------------------------------------------------------------------
+
+test("scoring uses the congested wait, not the vault's advertised floor", async () => {
+  // The floor is 20 blocks and the horizon is 80 away, so judging by the floor the queue "fits".
+  // The real wait for this size is 90 blocks, which does not -- and marking it at par would credit
+  // an exit the agent could never complete.
+  const { values } = await drive(valuationCtx({ horizonBlock: 180 }), [
+    () => [20n, WAD /* throughput: rate-limited */, summary(WAD, WAD)],
+    // stage 1 is [get_dy, estimateDelayBlocks] for the one holder
+    () => [(WAD * 9000n) / 10_000n, 90n],
+  ]);
+  // Falls back to the pool's price rather than par.
+  assert.equal(values[AGENT.id].valueUsdc, FAIR * 0.9);
+});
+
+test("an unlimited queue costs no extra read", async () => {
+  const { asked } = await drive(valuationCtx(), [
+    () => [20n, 0n /* throughput 0 = no limit */, summary(WAD, WAD)],
+    () => [WAD],
+  ]);
+  // Stage 1 is the pool quote only: no delay read when the queue is not rate-limited.
+  assert.equal(asked[1].length, 1);
 });

--- a/test/lstAgent.test.ts
+++ b/test/lstAgent.test.ts
@@ -241,9 +241,9 @@ test("congestion, not the advertised floor, closes the queue", () => {
 });
 
 test("a position too large for the queue is redeemed in the slice that fits", () => {
-  // 30 blocks left, a 20-block floor and a 4-block margin leave 6 blocks of draining at 1 WETH per
-  // block. Queueing all 10 WETH would strand 4 of them past the horizon (scored as unrealizable);
-  // refusing to queue would forfeit the 6 that would have made it.
+  // 30 blocks left against the wait the vault is actually quoting (21) plus a 4-block margin
+  // leaves 5 blocks of draining at 1 WETH per block. Queueing all 10 WETH would strand the rest
+  // past the horizon (scored as unrealizable); refusing to queue would forfeit what would fit.
   const decision = decideCarry({
     ...base,
     blocksRemaining: 30,
@@ -260,7 +260,7 @@ test("a position too large for the queue is redeemed in the slice that fits", ()
   });
   assert.equal(decision.kind, "queue");
   if (decision.kind !== "queue") return;
-  assert.equal(decision.lstIn, 6n * WAD);
+  assert.equal(decision.lstIn, 5n * WAD);
 });
 
 test("an unlimited queue still redeems the whole position", () => {
@@ -339,4 +339,78 @@ test("a borrow is sized to land on the target health factor, not past it", async
   // $1500 at $3000/WETH = 0.5 WETH.
   assert.equal(decision.wethOut, WAD / 2n);
   process.env.ERIS_LST_LEVERAGE_TARGET_HF = "0";
+});
+
+test("a market that did not quote is not traded on", () => {
+  // discountBps is 0 when there is no quote, but the agent must not fall through to "sell into the
+  // premium" either — there is nothing to sell into.
+  const decision = decideCarry({
+    ...base,
+    lst: lst({
+      marketQuoted: false,
+      discountBps: 0,
+      lstBalanceWei: WAD.toString(),
+    }),
+  });
+  assert.notEqual(decision.kind, "carry");
+  assert.notEqual(decision.kind, "harvest");
+  assert.notEqual(decision.kind, "queue");
+});
+
+test("leverage yields to a claimable redemption and to a premium", async () => {
+  // decideLeverage runs first, so an unconditional "post any LST as collateral" made decideCarry's
+  // claim (free money already finalized) and harvest branches unreachable for a levered agent —
+  // which holds LST continuously by construction.
+  process.env.ERIS_LST_LEVERAGE_TARGET_HF = "2.0";
+  const mod = await import(
+    `../example/agents/lst-carry/agent.js?yield=${Date.now()}`
+  );
+  const aave = {
+    healthFactor: (2n ** 256n - 1n).toString(),
+    totalDebtBase: "0",
+    availableBorrowsBase: "0",
+  };
+  const claimable = mod.decideLeverage({
+    lst: lst({
+      aaveCollateral: true,
+      lstBalanceWei: WAD.toString(),
+      claimableWithdrawalWethWei: WAD.toString(),
+    }),
+    aave,
+    wethBalanceWei: 0n,
+    fairPriceUsd: 3000,
+  });
+  assert.equal(claimable, null, "a finalized redemption comes first");
+
+  const premium = mod.decideLeverage({
+    lst: lst({ aaveCollateral: true, lstBalanceWei: WAD.toString() }),
+    aave,
+    wethBalanceWei: 0n,
+    fairPriceUsd: 3000,
+    premiumWorthHarvesting: true,
+  });
+  assert.equal(premium, null, "a premium is worth more than posting collateral");
+  process.env.ERIS_LST_LEVERAGE_TARGET_HF = "0";
+});
+
+test("the redeemable slice is sized off the congested wait, not the floor", async () => {
+  // The fit check already used the quoted wait; sizing used the advertised floor. With the queue
+  // booked out the two disagreed and the agent queued more than could finalize — the stranded-WETH
+  // loss queueableShares exists to prevent.
+  const mod = await import(
+    `../example/agents/lst-carry/agent.js?size=${Date.now()}`
+  );
+  const congested = lst({
+    lstBalanceWei: (10n * WAD).toString(),
+    lstRedemptionValueWethWei: (10n * WAD).toString(),
+    withdrawalDelayBlocks: 20,
+    queueDelayPerWethBlocks: 31, // 20 floor + 11 already booked ahead
+    queueThroughputWeiPerBlock: WAD.toString(),
+  });
+  // 40 left - 31 quoted - 4 margin = 5 blocks of draining = 5 WETH, not the 16 the floor implies.
+  const shares = mod.queueableShares(
+    { lst: congested, blocksRemaining: 40 },
+    10n * WAD,
+  );
+  assert.equal(shares, 5n * WAD);
 });

--- a/test/lstAgent.test.ts
+++ b/test/lstAgent.test.ts
@@ -6,6 +6,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  decide,
   decideCarry,
   queueFitsInRun,
 } from "../example/agents/lst-carry/agent.js";
@@ -277,4 +278,65 @@ test("an unlimited queue still redeems the whole position", () => {
   assert.equal(decision.kind, "queue");
   if (decision.kind !== "queue") return;
   assert.equal(decision.lstIn, 10n * WAD);
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3: leverage, and the empty-hands case it created
+// ---------------------------------------------------------------------------
+
+test("empty hands with a posted position is not treated as an unusable venue", () => {
+  // The bug this pins: a levered position holds its whole book as Aave collateral, so checking the
+  // wallet alone reads "no WETH and no LST" as a misconfigured run. The agent then returned noop
+  // from before the decision log, and the run looked like an agent that had stopped responding.
+  const obs = {
+    balances: { wethWei: "0", usdcUnits: "0", ethWei: "0" },
+    fairPriceUsdcPerWeth: 3000,
+    round: 1,
+    limits: {
+      maxWethInWei: WAD.toString(),
+      maxLstDepositWethWei: (5n * WAD).toString(),
+      defaultPriorityFeePerGasWei: "100000000",
+    },
+    protocols: {
+      lst: lst({ aaveCollateral: true }),
+      aave: {
+        healthFactor: (2n ** 256n - 1n).toString(),
+        totalCollateralBase: "1500000000000", // $15k posted
+        totalDebtBase: "0",
+        availableBorrowsBase: "0",
+        supplied: {},
+        borrowed: {},
+      },
+    },
+  } as never;
+  const action = decide(obs) as { type: string; reason?: string };
+  assert.notEqual(
+    action.reason,
+    "no WETH and no LST: the lst venue is WETH-denominated, so this run needs funding.wethWei > 0",
+  );
+});
+
+test("a borrow is sized to land on the target health factor, not past it", async () => {
+  // Sizing off the headroom overshoots the target and the floor beneath it: measured as 24 borrows
+  // against 22 forced repayments, oscillating 2.89 <-> 1.56. Scaling the existing debt by
+  // hf/target lands on the target instead, because HF is collateral x LT / debt.
+  process.env.ERIS_LST_LEVERAGE_TARGET_HF = "2.0";
+  const mod = await import(
+    `../example/agents/lst-carry/agent.js?lev=${Date.now()}`
+  );
+  // $3000 of debt at HF 3.0, target 2.0 -> borrow another $1500 to halve the ratio.
+  const decision = mod.decideLeverage({
+    lst: lst({ aaveCollateral: true }),
+    aave: {
+      healthFactor: (3n * WAD).toString(),
+      totalDebtBase: (3000n * 10n ** 8n).toString(),
+      availableBorrowsBase: (9000n * 10n ** 8n).toString(),
+    },
+    wethBalanceWei: 0n,
+    fairPriceUsd: 3000,
+  });
+  assert.equal(decision?.kind, "borrow");
+  // $1500 at $3000/WETH = 0.5 WETH.
+  assert.equal(decision.wethOut, WAD / 2n);
+  process.env.ERIS_LST_LEVERAGE_TARGET_HF = "0";
 });

--- a/test/lstAgent.test.ts
+++ b/test/lstAgent.test.ts
@@ -1,0 +1,195 @@
+// lst-carry's decision surface (issue #38).
+//
+// The venue is only exercised if the reference agent actually uses all of it, so these pin the
+// branches that would otherwise rot into "always deposit": the carry, the premium harvest, and the
+// two decisions that depend on how much run is left.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  decideCarry,
+  queueFitsInRun,
+} from "../example/agents/lst-carry/agent.js";
+import type { LstObservation } from "@eris/sdk/types.js";
+
+const WAD = 10n ** 18n;
+
+function lst(overrides: Partial<LstObservation> = {}): LstObservation {
+  return {
+    redemptionRateWeth: 1.02,
+    marketPriceWeth: 1.02,
+    discountBps: 0,
+    apyBps: 300,
+    yieldPerBlockBps: 0.034,
+    withdrawalDelayBlocks: 20,
+    queueLength: 0,
+    rewardReserveWei: (50n * WAD).toString(),
+    lstBalanceWei: "0",
+    lstRedemptionValueWethWei: "0",
+    instantExitWethWei: "0",
+    pendingWithdrawals: [],
+    pendingWithdrawalWethWei: "0",
+    claimableWithdrawalWethWei: "0",
+    ...overrides,
+  };
+}
+
+const base = {
+  wethBalanceWei: 10n * WAD,
+  maxStakeWei: 5n * WAD,
+  maxSwapWei: WAD,
+  blocksRemaining: 60,
+};
+
+test("the queue check leaves slack rather than cutting it fine", () => {
+  assert.ok(queueFitsInRun(60, 20));
+  assert.ok(
+    !queueFitsInRun(22, 20),
+    "22 blocks is not enough room for a 20-block queue",
+  );
+  // No block limit means the queue is always an option.
+  assert.ok(queueFitsInRun(undefined, 20));
+});
+
+test("a finalized redemption is claimed before anything else is considered", () => {
+  // Even with a fat discount on the table, free WETH already in the queue comes first.
+  const decision = decideCarry({
+    ...base,
+    lst: lst({ discountBps: 200, claimableWithdrawalWethWei: WAD.toString() }),
+  });
+  assert.equal(decision.kind, "claim");
+});
+
+test("a discount wider than costs buys LST", () => {
+  const decision = decideCarry({ ...base, lst: lst({ discountBps: 60 }) });
+  assert.equal(decision.kind, "carry");
+  if (decision.kind !== "carry") return;
+  // Sized off the WETH balance but clamped by the per-round swap cap.
+  assert.equal(decision.wethIn, base.maxSwapWei);
+});
+
+test("a discount inside costs does not trade", () => {
+  const decision = decideCarry({ ...base, lst: lst({ discountBps: 20 }) });
+  assert.notEqual(decision.kind, "carry");
+});
+
+test("shares bought at a discount are queued for par on the next cycle", () => {
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 0n, // spent on the carry leg
+    lst: lst({ discountBps: 60, lstBalanceWei: WAD.toString() }),
+  });
+  assert.equal(decision.kind, "queue");
+  if (decision.kind !== "queue") return;
+  assert.equal(decision.lstIn, WAD);
+});
+
+test("redeeming what it holds comes before buying more", () => {
+  // Buying first means buying until the discount closes and then holding an open position instead
+  // of a realised profit -- measured in a live run as five buys and no redemption.
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 10n * WAD,
+    lst: lst({ discountBps: 60, lstBalanceWei: WAD.toString() }),
+  });
+  assert.equal(decision.kind, "queue");
+});
+
+test("a discount too small to have bought on is not worth queueing either", () => {
+  // The bug this pins: a looser gate on the queue than on the buy drags the staked position into
+  // the queue whenever the market drifts below par. A live run turned that into stake -> queue ->
+  // stake churn and stranded 14 WETH in a queue that outlived the run.
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 0n,
+    lst: lst({ discountBps: 20, lstBalanceWei: WAD.toString() }),
+  });
+  assert.notEqual(decision.kind, "queue");
+});
+
+test("a premium is harvested by selling into the pool instead of queueing", () => {
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 0n,
+    lst: lst({ discountBps: -60, lstBalanceWei: WAD.toString() }),
+  });
+  assert.equal(decision.kind, "harvest");
+});
+
+test("with no dislocation it stakes toward the target allocation", () => {
+  const decision = decideCarry({ ...base, lst: lst() });
+  assert.equal(decision.kind, "stake");
+  if (decision.kind !== "stake") return;
+  // Target is 70% of the 10 WETH book, clamped by the 5 WETH per-stake cap.
+  assert.equal(decision.wethIn, 5n * WAD);
+});
+
+test("it stops staking once the target allocation is reached", () => {
+  // The bug this pins: staking a fixed slice of the *remaining* balance every block converges on the
+  // same allocation while paying gas every time. A live run spent its entire loss that way.
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 2n * WAD,
+    lst: lst({ lstRedemptionValueWethWei: (8n * WAD).toString() }),
+  });
+  assert.equal(decision.kind, "hold");
+});
+
+test("queued WETH still counts as staked for the allocation", () => {
+  // Shares in the withdrawal queue are on their way out, but they are not free WETH either --
+  // counting them as unstaked would restake the same capital twice.
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 2n * WAD,
+    lst: lst({ pendingWithdrawalWethWei: (8n * WAD).toString() }),
+  });
+  assert.equal(decision.kind, "hold");
+});
+
+test("it stops staking once an exit could no longer be queued", () => {
+  // Staking into the last blocks buys yield you cannot collect and an exit that has to pay the
+  // pool's discount.
+  const decision = decideCarry({ ...base, blocksRemaining: 10, lst: lst() });
+  assert.equal(decision.kind, "hold");
+});
+
+test("it does not chase a discount it cannot redeem in time", () => {
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 10,
+    lst: lst({ discountBps: 200 }),
+  });
+  assert.notEqual(decision.kind, "carry");
+});
+
+test("late in the run it holds rather than paying the pool to exit", () => {
+  // Scoring already marks the shares at what the pool would pay, so selling here just donates the
+  // fee. The reason has to say that, since a silent noop reads as a bug.
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 5,
+    lst: lst({ lstBalanceWei: (2n * WAD).toString() }),
+  });
+  assert.equal(decision.kind, "hold");
+  if (decision.kind !== "hold") return;
+  assert.match(decision.reason, /queue no longer fits/);
+});
+
+test("a premium is still harvested late in the run", () => {
+  // Selling is the only exit left anyway, so a pool paying above par is worth taking.
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 5,
+    wethBalanceWei: 0n,
+    lst: lst({ discountBps: -80, lstBalanceWei: WAD.toString() }),
+  });
+  assert.equal(decision.kind, "harvest");
+});
+
+test("dust does not trigger an action", () => {
+  const decision = decideCarry({
+    ...base,
+    wethBalanceWei: 10n ** 12n, // 0.000001 WETH: gas would cost more than the yield
+    lst: lst(),
+  });
+  assert.equal(decision.kind, "hold");
+});

--- a/test/lstAgent.test.ts
+++ b/test/lstAgent.test.ts
@@ -21,6 +21,7 @@ function lst(overrides: Partial<LstObservation> = {}): LstObservation {
     apyBps: 300,
     yieldPerBlockBps: 0.034,
     withdrawalDelayBlocks: 20,
+    estimatedQueueDelayBlocks: 20,
     queueLength: 0,
     rewardReserveWei: (50n * WAD).toString(),
     lstBalanceWei: "0",
@@ -192,4 +193,88 @@ test("dust does not trigger an action", () => {
     lst: lst(),
   });
   assert.equal(decision.kind, "hold");
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2: the yield moves, so staking is a live decision
+// ---------------------------------------------------------------------------
+
+test("it does not stake through a lean stretch", () => {
+  // The yield varies during the run (issue #38 phase 2). Below the floor it stops paying for the
+  // slashing exposure that holding LST carries, so the right move is to sit in WETH.
+  const decision = decideCarry({ ...base, lst: lst({ apyBps: 120 }) });
+  assert.equal(decision.kind, "hold");
+  if (decision.kind !== "hold") return;
+  assert.match(decision.reason, /below the 200bps floor/);
+});
+
+test("it stakes again once the yield recovers", () => {
+  const decision = decideCarry({ ...base, lst: lst({ apyBps: 600 }) });
+  assert.equal(decision.kind, "stake");
+});
+
+test("a lean yield does not stop it taking a real discount", () => {
+  // The carry is paid by the discount, not by the yield, so a poor APY is no reason to skip it.
+  const decision = decideCarry({
+    ...base,
+    lst: lst({ apyBps: 120, discountBps: 60 }),
+  });
+  assert.equal(decision.kind, "carry");
+});
+
+test("congestion, not the advertised floor, closes the queue", () => {
+  // The floor says 20 blocks and 40 remain, so the floor would green-light this. The queue is
+  // congested and actually quotes 36, which does not fit.
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 40,
+    wethBalanceWei: 0n,
+    lst: lst({
+      discountBps: 60,
+      lstBalanceWei: WAD.toString(),
+      withdrawalDelayBlocks: 20,
+      estimatedQueueDelayBlocks: 36,
+    }),
+  });
+  assert.notEqual(decision.kind, "queue");
+});
+
+test("a position too large for the queue is redeemed in the slice that fits", () => {
+  // 30 blocks left, a 20-block floor and a 4-block margin leave 6 blocks of draining at 1 WETH per
+  // block. Queueing all 10 WETH would strand 4 of them past the horizon (scored as unrealizable);
+  // refusing to queue would forfeit the 6 that would have made it.
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 30,
+    wethBalanceWei: 0n,
+    lst: lst({
+      discountBps: 60,
+      lstBalanceWei: (10n * WAD).toString(),
+      lstRedemptionValueWethWei: (10n * WAD).toString(),
+      withdrawalDelayBlocks: 20,
+      queueDelayPerWethBlocks: 21,
+      estimatedQueueDelayBlocks: 30,
+      queueThroughputWeiPerBlock: WAD.toString(),
+    }),
+  });
+  assert.equal(decision.kind, "queue");
+  if (decision.kind !== "queue") return;
+  assert.equal(decision.lstIn, 6n * WAD);
+});
+
+test("an unlimited queue still redeems the whole position", () => {
+  const decision = decideCarry({
+    ...base,
+    blocksRemaining: 30,
+    wethBalanceWei: 0n,
+    lst: lst({
+      discountBps: 60,
+      lstBalanceWei: (10n * WAD).toString(),
+      lstRedemptionValueWethWei: (10n * WAD).toString(),
+      // No throughput limit reported: the floor is the whole story.
+    }),
+  });
+  assert.equal(decision.kind, "queue");
+  if (decision.kind !== "queue") return;
+  assert.equal(decision.lstIn, 10n * WAD);
 });

--- a/test/lstLeverage.test.ts
+++ b/test/lstLeverage.test.ts
@@ -1,0 +1,274 @@
+// Issue #38 phase 3: the LST listed as Aave collateral, on a real chain.
+//
+// Phase 3's requirement is environmental -- "register LST as an Aave reserve and enable ETH
+// borrowing against it" -- so this checks the market rather than a strategy: that the reserve
+// exists with the parameters an LST warrants, that ETH can actually be borrowed against it, that
+// the LST itself cannot be borrowed, and that a slash reaches the health factor once the oracle
+// follows. The last one is the liquidation cascade in miniature.
+//
+// It needs the full local deploy (Aave takes minutes to stand up via hardhat-deploy), so unlike the
+// vault test it does not spawn its own chain: it runs against an already-deployed anvil and skips
+// when there is not one. `cd deployer && npm run deploy -- --keep-fresh` provides it, and
+// ERIS_LOCAL_DEPLOY=1 opts in.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPublicClient,
+  createTestClient,
+  createWalletClient,
+  http,
+  parseAbi,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { AAVE, LST, TOKENS } from "@eris/sdk/constants.js";
+import { lstVaultAbi } from "@eris/sdk/abis.js";
+import { aaveOracleAbi, aavePoolAbi } from "@eris/sdk/protocols/aave.js";
+
+const RPC = process.env.ANVIL_RPC_URL ?? "http://127.0.0.1:8545";
+const WAD = 10n ** 18n;
+// anvil default account 3, which no roster in this repo hands to an agent.
+const PK =
+  "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6" as Hex;
+// The simulation's admin, which the deploy registers as a vault operator (keccak256("eris-role:admin")).
+const OPERATOR_PK =
+  "0x3975d4550834ac20d287d0ca1dbcbdc2dc5724d61d25acd5570b87f370bc7d8a" as Hex;
+
+const anvilChain = {
+  id: 31337,
+  name: "anvil",
+  nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: [RPC] } },
+} as const;
+
+const erc20 = parseAbi([
+  "function approve(address spender, uint256 amount) returns (bool)",
+  "function balanceOf(address owner) view returns (uint256)",
+  "function deposit() payable",
+]);
+const dataProviderAbi = parseAbi([
+  "function getReserveConfigurationData(address asset) view returns (uint256 decimals, uint256 ltv, uint256 liquidationThreshold, uint256 liquidationBonus, uint256 reserveFactor, bool usageAsCollateralEnabled, bool borrowingEnabled, bool stableBorrowRateEnabled, bool isActive, bool isFrozen)",
+]);
+
+async function healthFactor(
+  pub: ReturnType<typeof createPublicClient>,
+  user: Address,
+): Promise<number> {
+  const data = (await pub.readContract({
+    address: AAVE.Pool,
+    abi: aavePoolAbi,
+    functionName: "getUserAccountData",
+    args: [user],
+  })) as readonly bigint[];
+  return Number(data[5]) / 1e18;
+}
+
+test("LST as Aave collateral: listing, borrowing ETH against it, and a slash reaching the health factor (requires a local deploy)", async (t) => {
+  if (process.env.ERIS_LOCAL_DEPLOY !== "1") {
+    t.skip("set ERIS_LOCAL_DEPLOY=1 against a local deploy to run this");
+    return;
+  }
+  if (!LST?.aaveAToken) {
+    t.skip("this deployment has no LST reserve");
+    return;
+  }
+  const lst = LST;
+  const pub = createPublicClient({ chain: anvilChain, transport: http(RPC) });
+  try {
+    await pub.getChainId();
+  } catch {
+    t.skip(`no chain at ${RPC}`);
+    return;
+  }
+
+  const account = privateKeyToAccount(PK);
+  const operator = privateKeyToAccount(OPERATOR_PK);
+  const wallet = createWalletClient({
+    account,
+    chain: anvilChain,
+    transport: http(RPC),
+  });
+  const testClient = createTestClient({
+    chain: anvilChain,
+    mode: "anvil",
+    transport: http(RPC),
+  });
+
+  // Snapshot first: this deployment may be in use, and the test stakes, borrows and slashes.
+  const snapshot = await testClient.snapshot();
+  try {
+    await testClient.setAutomine(true);
+    const send = async (
+      to: Address,
+      // biome-ignore lint/suspicious/noExplicitAny: a handful of heterogeneous ABIs
+      abi: any,
+      functionName: string,
+      args: unknown[] = [],
+      value?: bigint,
+    ) => {
+      const hash = await wallet.writeContract({
+        address: to,
+        abi,
+        functionName,
+        args: args as never,
+        value,
+        account,
+        chain: anvilChain,
+      });
+      const rc = await pub.waitForTransactionReceipt({ hash });
+      assert.equal(rc.status, "success", `${functionName} reverted`);
+    };
+
+    // ---- 1. listed with parameters stated for an LST, and collateral only ----
+    const cfg = (await pub.readContract({
+      address: AAVE.PoolDataProvider,
+      abi: dataProviderAbi,
+      functionName: "getReserveConfigurationData",
+      args: [lst.lstToken],
+    })) as readonly [
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      boolean,
+      boolean,
+      boolean,
+      boolean,
+      boolean,
+    ];
+    assert.equal(cfg[1], 7000n, "LTV");
+    assert.equal(cfg[2], 7500n, "liquidation threshold");
+    assert.ok(cfg[5], "must be usable as collateral");
+    assert.ok(
+      !cfg[6],
+      "borrowing the LST itself stays disabled: the point is borrowing ETH against it",
+    );
+
+    // ---- 2. priced as WETH x the redemption rate, not as WETH ----
+    const rate = (await pub.readContract({
+      address: lst.vault,
+      abi: lstVaultAbi,
+      functionName: "stEthPerToken",
+    })) as bigint;
+    const [lstPrice, wethPrice] = (await Promise.all([
+      pub.readContract({
+        address: AAVE.AaveOracle,
+        abi: aaveOracleAbi,
+        functionName: "getAssetPrice",
+        args: [lst.lstToken],
+      }),
+      pub.readContract({
+        address: AAVE.AaveOracle,
+        abi: aaveOracleAbi,
+        functionName: "getAssetPrice",
+        args: [TOKENS.WETH.address],
+      }),
+    ])) as [bigint, bigint];
+    assert.ok(lstPrice > 0n, "the LST has no Aave price");
+    const impliedRate = Number(lstPrice) / Number(wethPrice);
+    assert.ok(
+      Math.abs(impliedRate - Number(rate) / 1e18) < 0.02,
+      `Aave prices the LST at ${impliedRate.toFixed(4)} x WETH, the vault says ${(Number(rate) / 1e18).toFixed(4)}`,
+    );
+
+    // ---- 3. stake, post as collateral, borrow WETH against it ----
+    await send(TOKENS.WETH.address, erc20, "deposit", [], 10n * WAD);
+    await send(TOKENS.WETH.address, erc20, "approve", [lst.vault, 10n * WAD]);
+    await send(lst.vault, lstVaultAbi, "deposit", [5n * WAD, account.address]);
+    const shares = (await pub.readContract({
+      address: lst.vault,
+      abi: erc20,
+      functionName: "balanceOf",
+      args: [account.address],
+    })) as bigint;
+    assert.ok(shares > 0n, "staking minted nothing");
+
+    await send(lst.vault, erc20, "approve", [AAVE.Pool, shares]);
+    await send(AAVE.Pool, aavePoolAbi, "supply", [
+      lst.lstToken,
+      shares,
+      account.address,
+      0,
+    ]);
+    const posted = (await pub.readContract({
+      address: AAVE.Pool,
+      abi: aavePoolAbi,
+      functionName: "getUserAccountData",
+      args: [account.address],
+    })) as readonly bigint[];
+    assert.ok(posted[0] > 0n, "the LST was not counted as collateral");
+    assert.ok(posted[2] > 0n, "posting LST gave no borrowing power");
+
+    // One turn of leveraged staking: borrow a quarter of the headroom as WETH.
+    const borrowWei = (posted[2] * WAD) / wethPrice / 4n;
+    assert.ok(borrowWei > 0n, "headroom too small to borrow against");
+    await send(AAVE.Pool, aavePoolAbi, "borrow", [
+      TOKENS.WETH.address,
+      borrowWei,
+      2n,
+      0,
+      account.address,
+    ]);
+    const hfBefore = await healthFactor(pub, account.address);
+    assert.ok(
+      hfBefore > 1 && hfBefore < 100,
+      `expected a real levered position, got HF ${hfBefore}`,
+    );
+
+    // ---- 4. a slash reaches the health factor, but only once the oracle follows ----
+    // The vault is cut first and Aave keeps the old price until the environment writes the new one.
+    // Both halves are asserted, because the lag is the mechanism: the position stays stale-healthy
+    // for exactly as long as the oracle is stale, and then a whole cohort turns liquidatable at once.
+    await testClient.setBalance({ address: operator.address, value: WAD });
+    const opWallet = createWalletClient({
+      account: operator,
+      chain: anvilChain,
+      transport: http(RPC),
+    });
+    const slashHash = await opWallet.writeContract({
+      address: lst.vault,
+      abi: lstVaultAbi,
+      functionName: "slash",
+      args: [2000n], // 20%: far above a run's calibration, to move the health factor visibly
+      account: operator,
+      chain: anvilChain,
+    });
+    const slashRc = await pub.waitForTransactionReceipt({ hash: slashHash });
+    assert.equal(slashRc.status, "success", "slash reverted");
+
+    const hfStale = await healthFactor(pub, account.address);
+    assert.ok(
+      Math.abs(hfStale - hfBefore) < 0.02,
+      `the health factor moved before the oracle did (${hfBefore} -> ${hfStale}), so there is no lag`,
+    );
+
+    // The environment's per-block write lands: same aggregator, price rebuilt from the new rate.
+    const newRate = (await pub.readContract({
+      address: lst.vault,
+      abi: lstVaultAbi,
+      functionName: "stEthPerToken",
+    })) as bigint;
+    const aggregator = (await pub.readContract({
+      address: AAVE.AaveOracle,
+      abi: aaveOracleAbi,
+      functionName: "getSourceOfAsset",
+      args: [lst.lstToken],
+    })) as Address;
+    const newPrice = (wethPrice * newRate) / WAD;
+    await testClient.setStorageAt({
+      address: aggregator,
+      index: "0x0",
+      value: `0x${newPrice.toString(16).padStart(64, "0")}` as Hex,
+    });
+
+    const hfAfter = await healthFactor(pub, account.address);
+    assert.ok(
+      hfAfter < hfBefore * 0.9,
+      `the slash never reached the health factor (${hfBefore} -> ${hfAfter})`,
+    );
+  } finally {
+    await testClient.revert({ id: snapshot });
+  }
+});

--- a/test/lstPhase2.test.ts
+++ b/test/lstPhase2.test.ts
@@ -1,0 +1,132 @@
+// Issue #38 phase 2: what makes the LST choice non-trivial.
+//
+// Phase 1 shipped a venue whose optimum was "stake everything at block 0" and stay there. These
+// cover the three things that break that: a yield that moves, a queue that congests, and a slash
+// that repricess the vault mid-run.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ApySchedule } from "../core/src/realtime/lst.js";
+import { EventSchedule, parseStressEvents } from "../core/src/realtime/events.js";
+import { queueFitsInRun } from "../example/agents/lst-carry/agent.js";
+
+// ---------------------------------------------------------------------------
+// Seed-driven APY variation
+// ---------------------------------------------------------------------------
+
+function sample(schedule: ApySchedule, blocks: number): Array<number | null> {
+  return Array.from({ length: blocks }, (_, i) => schedule.nextAt(i));
+}
+
+test("the APY only moves on its own cadence", () => {
+  const s = new ApySchedule(1, [100, 900], 10, 300);
+  const path = sample(s, 30);
+  // Blocks 0, 10, 20 may change it; nothing in between does.
+  for (let i = 0; i < 30; i++) {
+    if (i % 10 !== 0) assert.equal(path[i], null, `block ${i} changed the APY`);
+  }
+  assert.ok(path.filter((v) => v !== null).length > 0, "the APY never moved");
+});
+
+test("the APY stays inside the configured range", () => {
+  const s = new ApySchedule(7, [100, 900], 1, 300);
+  for (const v of sample(s, 200)) {
+    if (v === null) continue;
+    assert.ok(v >= 100 && v <= 900, `sampled ${v} outside [100,900]`);
+  }
+});
+
+test("the same seed gives the same yield path, a different seed does not", () => {
+  const a = sample(new ApySchedule(1, [100, 900], 5, 300), 50);
+  const b = sample(new ApySchedule(1, [100, 900], 5, 300), 50);
+  const c = sample(new ApySchedule(2, [100, 900], 5, 300), 50);
+  assert.deepEqual(a, b, "the same seed must reproduce the path");
+  assert.notDeepEqual(a, c, "a different seed should change it (anti-overfitting)");
+});
+
+test("a degenerate range pins the yield and stops writing", () => {
+  // min == max: the first step sets it, and nothing after that is a change worth a transaction.
+  const s = new ApySchedule(1, [500, 500], 1, 300);
+  const path = sample(s, 10);
+  assert.equal(path[0], 500);
+  assert.ok(path.slice(1).every((v) => v === null));
+});
+
+// ---------------------------------------------------------------------------
+// The slash event in the stress overlay
+// ---------------------------------------------------------------------------
+
+const slashCfg = JSON.stringify([
+  { type: "lstSlash", magnitudeRange: [0.01, 0.03], windowFrac: [0.3, 0.5] },
+]);
+
+test("a slash parses without the trapezoid fields spike/crash require", () => {
+  const [cfg] = parseStressEvents(slashCfg);
+  assert.equal(cfg.type, "lstSlash");
+  assert.equal(cfg.rampBlocks, 0);
+  assert.equal(cfg.holdBlocks, 0);
+  assert.equal(cfg.decayBlocks, 0);
+});
+
+test("a slash magnitude at or above the whole pool is rejected", () => {
+  assert.throws(
+    () =>
+      parseStressEvents(
+        JSON.stringify([
+          { type: "lstSlash", magnitudeRange: [0.5, 1.5], windowFrac: [0, 1] },
+        ]),
+      ),
+    /magnitudeRange max must be <= 1/,
+  );
+});
+
+test("a slash lands on exactly one block and never touches the price overlay", () => {
+  const schedule = new EventSchedule(parseStressEvents(slashCfg), 1, 100);
+  const [ev] = schedule.events;
+  assert.equal(ev.endBlock, ev.startBlock + 1);
+  const fired: number[] = [];
+  for (let i = 0; i < 100; i++) {
+    if (schedule.pointEventsAt(i).length > 0) fired.push(i);
+    // A slash is not a price distortion: the overlay stays neutral throughout.
+    assert.equal(schedule.at(i).wethMult, 1);
+  }
+  assert.deepEqual(fired, [ev.startBlock]);
+  assert.ok(ev.magnitude >= 0.01 && ev.magnitude <= 0.03);
+});
+
+test("a slash coexists with a crash without disturbing it", () => {
+  const configs = parseStressEvents(
+    JSON.stringify([
+      {
+        type: "crash",
+        magnitudeRange: [0.1, 0.1],
+        windowFrac: [0.2, 0.2],
+        rampBlocks: 2,
+        holdBlocks: 2,
+        decayBlocks: 2,
+      },
+      { type: "lstSlash", magnitudeRange: [0.02, 0.02], windowFrac: [0.6, 0.6] },
+    ]),
+  );
+  const schedule = new EventSchedule(configs, 1, 100);
+  const crash = schedule.events[0];
+  const slash = schedule.events[1];
+  // The crash still moves the price at its peak, and the slash's block does not.
+  assert.ok(schedule.at(crash.startBlock + 2).wethMult < 1);
+  assert.equal(schedule.at(slash.startBlock).wethMult, 1);
+  assert.deepEqual(
+    schedule.pointEventsAt(slash.startBlock).map((e) => e.type),
+    ["lstSlash"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Congestion, from the agent's side
+// ---------------------------------------------------------------------------
+
+test("congestion can close the queue that the floor says is open", () => {
+  // 40 blocks left against a 20-block floor: judged on the floor the queue is comfortably open.
+  // Judged on what a congested queue actually quotes for this size (36 blocks, plus the agent's
+  // 4-block margin), it is not.
+  assert.ok(queueFitsInRun(40, 20));
+  assert.ok(!queueFitsInRun(40, 36));
+});

--- a/test/lstPhase2.test.ts
+++ b/test/lstPhase2.test.ts
@@ -68,15 +68,20 @@ test("a slash parses without the trapezoid fields spike/crash require", () => {
 });
 
 test("a slash magnitude at or above the whole pool is rejected", () => {
-  assert.throws(
-    () =>
-      parseStressEvents(
-        JSON.stringify([
-          { type: "lstSlash", magnitudeRange: [0.5, 1.5], windowFrac: [0, 1] },
-        ]),
-      ),
-    /magnitudeRange max must be <= 1/,
-  );
+  for (const hi of [1.5, 1]) {
+    assert.throws(
+      () =>
+        parseStressEvents(
+          JSON.stringify([
+            { type: "lstSlash", magnitudeRange: [0.5, hi], windowFrac: [0, 1] },
+          ]),
+        ),
+      /magnitudeRange max must be < 1/,
+      `magnitudeRange max ${hi} should be rejected`,
+    );
+  }
+  // Exactly 1 wipes the pool: totalPooledWeth hits zero, convertToAssets falls back to 1:1, the
+  // rate oracle snaps to par, and every staker is erased with the discount reading 0.
 });
 
 test("a slash lands on exactly one block and never touches the price overlay", () => {
@@ -129,4 +134,41 @@ test("congestion can close the queue that the floor says is open", () => {
   // 4-block margin), it is not.
   assert.ok(queueFitsInRun(40, 20));
   assert.ok(!queueFitsInRun(40, 36));
+});
+
+// ---------------------------------------------------------------------------
+// Surviving the coordinator's dropped blocks
+// ---------------------------------------------------------------------------
+
+test("a slash still fires when its block is skipped", () => {
+  // onBlock returns early while it is still processing the previous block, so the index a slash
+  // was scheduled on is not guaranteed to be handed to us. Matching it exactly meant the whole
+  // stress axis silently did nothing while stress_schedule claimed otherwise.
+  const schedule = new EventSchedule(parseStressEvents(slashCfg), 1, 100);
+  const [ev] = schedule.events;
+  // The coordinator caught up across a gap that spans the scheduled index.
+  const caught = schedule.pointEventsAt(ev.startBlock - 2, ev.startBlock + 2);
+  assert.equal(caught.length, 1);
+  // ... and it is not double-fired by a range that has already passed it.
+  assert.equal(schedule.pointEventsAt(ev.startBlock + 1, ev.startBlock + 5).length, 0);
+});
+
+test("a dropped block costs the APY one step of staleness, not its whole path", () => {
+  // A missed index used to skip the Rng draw as well, so every later step drew a different value
+  // than the same seed produced elsewhere — exactly what the salted Rng exists to prevent.
+  const undisturbed = new ApySchedule(1, [100, 900], 10, 300);
+  const path: Array<number | null> = [];
+  for (let i = 0; i < 60; i++) path.push(undisturbed.nextAt(i));
+
+  const dropped = new ApySchedule(1, [100, 900], 10, 300);
+  const droppedPath: Array<number | null> = [];
+  for (let i = 0; i < 60; i++) {
+    if (i === 20 || i === 21) continue; // the coordinator was busy
+    droppedPath.push(dropped.nextAt(i));
+  }
+  // Same seed, same values in the same order — the only difference is when they were observed.
+  assert.deepEqual(
+    droppedPath.filter((v) => v !== null),
+    path.filter((v) => v !== null),
+  );
 });

--- a/test/lstVault.integration.test.ts
+++ b/test/lstVault.integration.test.ts
@@ -1,0 +1,338 @@
+// MockLSTVault on a real chain (issue #38).
+//
+// The pure tests cover the marking rules; this covers the Solidity the venue is actually made of,
+// which is where the properties that matter are enforced:
+//   1. staking mints at the current rate, and yield raises that rate for everyone holding shares
+//   2. a direct WETH transfer is a donation to nobody -- it must not move the exchange rate
+//   3. accrual is bounded by the funded reserve, and its size depends only on blocks elapsed
+//   4. the withdrawal queue pays par, but only after its delay, and only to the requester
+//   5. the queue locks in its rate at request time, so later yield does not retro-price it
+//
+// Auto-skips where foundry is absent, keeping `npm test` green.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  createPublicClient,
+  createTestClient,
+  createWalletClient,
+  http,
+  type Abi,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const PORT = 8578; // verification-only port that does not collide with the usual 8545
+const RPC = `http://127.0.0.1:${PORT}`;
+const WAD = 10n ** 18n;
+const RAY = 10n ** 27n;
+// anvil default accounts 0 and 1
+const PK =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as Hex;
+const OTHER_PK =
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as Hex;
+
+const anvilChain = {
+  id: 31337,
+  name: "anvil",
+  nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: [RPC] } },
+} as const;
+
+// The vault and WETH9 are the deployer's contracts, so their artifacts live under deployer/out.
+function artifact(name: string): { abi: Abi; bytecode: Hex } {
+  const a = JSON.parse(
+    readFileSync(
+      resolve(ROOT, `deployer/out/${name}.sol/${name}.json`),
+      "utf8",
+    ),
+  );
+  return {
+    abi: a.abi as Abi,
+    bytecode: (a.bytecode?.object ?? a.bytecode) as Hex,
+  };
+}
+
+async function startAnvil(): Promise<ChildProcess | null> {
+  let child: ChildProcess;
+  try {
+    child = spawn("anvil", ["--port", String(PORT), "--silent"], {
+      stdio: "ignore",
+    });
+  } catch {
+    return null;
+  }
+  const failed = new Promise<null>((res) => {
+    child.once("error", () => res(null));
+    child.once("exit", () => res(null));
+  });
+  const pub = createPublicClient({ chain: anvilChain, transport: http(RPC) });
+  for (let i = 0; i < 50; i++) {
+    const raced = await Promise.race([
+      pub
+        .getChainId()
+        .then(() => "ok" as const)
+        .catch(() => "retry" as const),
+      failed,
+    ]);
+    if (raced === "ok") return child;
+    if (raced === null) return null;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  child.kill();
+  return null;
+}
+
+test("MockLSTVault: rate, donations, reserve and the withdrawal queue (requires anvil)", async (t) => {
+  if (
+    !existsSync(
+      resolve(ROOT, "deployer/out/MockLSTVault.sol/MockLSTVault.json"),
+    )
+  ) {
+    t.skip("run `cd deployer && forge build` first");
+    return;
+  }
+  const anvil = await startAnvil();
+  if (!anvil) {
+    t.skip("anvil unavailable (foundry not installed, etc.)");
+    return;
+  }
+  try {
+    const account = privateKeyToAccount(PK);
+    const other = privateKeyToAccount(OTHER_PK);
+    const pub = createPublicClient({ chain: anvilChain, transport: http(RPC) });
+    const wallet = createWalletClient({
+      account,
+      chain: anvilChain,
+      transport: http(RPC),
+    });
+    const otherWallet = createWalletClient({
+      account: other,
+      chain: anvilChain,
+      transport: http(RPC),
+    });
+    const testClient = createTestClient({
+      chain: anvilChain,
+      mode: "anvil",
+      transport: http(RPC),
+    });
+
+    const deploy = async (
+      name: string,
+      args: readonly unknown[],
+    ): Promise<Address> => {
+      const { abi, bytecode } = artifact(name);
+      const hash = await wallet.deployContract({
+        abi,
+        bytecode,
+        args: args as never,
+      });
+      const rc = await pub.waitForTransactionReceipt({ hash });
+      if (!rc.contractAddress) throw new Error(`${name} deploy failed`);
+      return rc.contractAddress;
+    };
+
+    const weth = await deploy("WETH9", []);
+    const wethAbi = artifact("WETH9").abi;
+    const vaultAbi = artifact("MockLSTVault").abi;
+
+    // 1%/block: a deliberately absurd rate so the effects are visible in a handful of blocks.
+    const ratePerBlockRay = RAY / 100n;
+    const delayBlocks = 5n;
+    const vault = await deploy("MockLSTVault", [
+      weth,
+      other.address, // a second operator, as the deployer wires the simulation's admin key
+      ratePerBlockRay,
+      delayBlocks,
+    ]);
+
+    const read = async (fn: string, args: unknown[] = []) =>
+      pub.readContract({
+        address: vault,
+        abi: vaultAbi,
+        functionName: fn,
+        args: args as never,
+      });
+
+    // Freeze mining before anything is measured: accrual counts blocks, so every call has to land
+    // in a block this test chose. `send` therefore submits, mines exactly one block, and checks the
+    // receipt -- reading before the mine would see the pre-tx state.
+    await testClient.setAutomine(false);
+    await testClient.setIntervalMining({ interval: 0 });
+    const send = async (
+      to: Address,
+      abi: Abi,
+      fn: string,
+      args: unknown[] = [],
+      opts: { value?: bigint; from?: typeof wallet } = {},
+    ) => {
+      const from = opts.from ?? wallet;
+      const hash = await from.writeContract({
+        address: to,
+        abi,
+        functionName: fn,
+        args: args as never,
+        value: opts.value,
+        account: from.account!,
+        chain: anvilChain,
+      });
+      await testClient.mine({ blocks: 1 });
+      const rc = await pub.waitForTransactionReceipt({ hash });
+      assert.equal(rc.status, "success", `${fn} reverted`);
+      return rc;
+    };
+
+    await send(weth, wethAbi, "deposit", [], { value: 100n * WAD });
+    await send(weth, wethAbi, "approve", [vault, 100n * WAD]);
+
+    // ---- 1. staking mints at the current rate ----
+    await send(vault, vaultAbi, "deposit", [10n * WAD, account.address]);
+    assert.equal(await read("totalPooledWeth"), 10n * WAD);
+    assert.equal(await read("stEthPerToken"), WAD, "the first stake sets 1:1");
+    // The bootstrap burn is locked away, not handed to the depositor.
+    const bootstrapBurn = (await read("BOOTSTRAP_BURN_SHARES")) as bigint;
+    assert.equal(
+      await read("balanceOf", [account.address]),
+      10n * WAD - bootstrapBurn,
+    );
+
+    // ---- 2. a direct transfer does not move the exchange rate ----
+    // The classic donation attack: if totalPooledWeth were balanceOf(this), this would reprice
+    // every share and let a first depositor grief the next one.
+    await send(weth, wethAbi, "transfer", [vault, 5n * WAD]);
+    assert.equal(await read("stEthPerToken"), WAD, "a donation moved the rate");
+    assert.equal(await read("totalPooledWeth"), 10n * WAD);
+    assert.equal(
+      await read("surplusWeth"),
+      5n * WAD,
+      "the donation is visible",
+    );
+
+    // ---- 3. accrual is bounded by the funded reserve ----
+    // Nothing funded yet, so poking accrual pays nothing however many blocks pass.
+    await testClient.mine({ blocks: 3 });
+    await send(vault, vaultAbi, "accrueRewards");
+    assert.equal(
+      await read("stEthPerToken"),
+      WAD,
+      "yield accrued with an empty reserve",
+    );
+
+    await send(weth, wethAbi, "approve", [vault, 100n * WAD]);
+    await send(vault, vaultAbi, "fundRewards", [2n * WAD]);
+    assert.equal(await read("rewardReserve"), 2n * WAD);
+    assert.equal(
+      await read("stEthPerToken"),
+      WAD,
+      "funding the reserve is not itself yield",
+    );
+
+    // Accrual at 1%/block on a 10 WETH pool, over the blocks since the last poke.
+    await send(vault, vaultAbi, "accrueRewards");
+    const afterOne = (await read("stEthPerToken")) as bigint;
+    assert.ok(
+      afterOne > WAD,
+      `the rate should rise once rewards are funded (got ${afterOne})`,
+    );
+    assert.ok(
+      ((await read("totalPooledWeth")) as bigint) > 10n * WAD,
+      "the pool did not grow",
+    );
+
+    // ---- 4. the queue pays par, after its delay, to the requester only ----
+    const shares = (await read("balanceOf", [account.address])) as bigint;
+    const queued = shares / 2n;
+    const parAtRequest = (await read("convertToAssets", [queued])) as bigint;
+    await send(vault, vaultAbi, "requestWithdraw", [queued]);
+    assert.equal(
+      await read("balanceOf", [account.address]),
+      shares - queued,
+      "requesting burns the shares",
+    );
+    assert.equal(await read("openRequestCount"), 1n);
+    assert.equal(await read("pendingWithdrawalWeth"), parAtRequest);
+
+    // Not finalized yet: claiming has to fail rather than pay early.
+    await assert.rejects(
+      pub.simulateContract({
+        address: vault,
+        abi: vaultAbi,
+        functionName: "claimWithdraw",
+        args: [0n],
+        account,
+      }),
+      /not finalized/,
+    );
+    // ... and it never belongs to anyone else.
+    await testClient.mine({ blocks: Number(delayBlocks) + 1 });
+    await assert.rejects(
+      pub.simulateContract({
+        address: vault,
+        abi: vaultAbi,
+        functionName: "claimWithdraw",
+        args: [0n],
+        account: other,
+      }),
+      /not request owner/,
+    );
+
+    // ---- 5. later yield does not retro-price a queued request ----
+    await send(vault, vaultAbi, "accrueRewards");
+    const wethBefore = (await pub.readContract({
+      address: weth,
+      abi: wethAbi,
+      functionName: "balanceOf",
+      args: [account.address],
+    })) as bigint;
+    await send(vault, vaultAbi, "claimWithdraw", [0n]);
+    const wethAfter = (await pub.readContract({
+      address: weth,
+      abi: wethAbi,
+      functionName: "balanceOf",
+      args: [account.address],
+    })) as bigint;
+    assert.equal(
+      wethAfter - wethBefore,
+      parAtRequest,
+      "the queue paid something other than the rate locked in at request time",
+    );
+    assert.equal(await read("openRequestCount"), 0n);
+    assert.equal(await read("pendingWithdrawalWeth"), 0n);
+
+    // The vault still covers every obligation it has left.
+    const held = (await pub.readContract({
+      address: weth,
+      abi: wethAbi,
+      functionName: "balanceOf",
+      args: [vault],
+    })) as bigint;
+    const owed =
+      ((await read("totalPooledWeth")) as bigint) +
+      ((await read("pendingWithdrawalWeth")) as bigint) +
+      ((await read("rewardReserve")) as bigint);
+    assert.ok(held >= owed, `vault is short: holds ${held}, owes ${owed}`);
+
+    // ---- 6. reconfiguration is operator-only ----
+    await assert.rejects(
+      pub.simulateContract({
+        address: vault,
+        abi: vaultAbi,
+        functionName: "setRewardRate",
+        args: [0n],
+        account: privateKeyToAccount(
+          "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+        ),
+      }),
+      /not operator/,
+    );
+    // The environment's admin key was registered at construction, so it can.
+    await send(vault, vaultAbi, "setRewardRate", [0n], { from: otherWallet });
+    assert.equal(await read("rewardRatePerBlockRay"), 0n);
+  } finally {
+    anvil.kill();
+  }
+});

--- a/test/scoringExclusions.test.ts
+++ b/test/scoringExclusions.test.ts
@@ -147,6 +147,7 @@ function valuationCtx(): ValuationContext {
   return {
     publicClient: {} as never,
     blockNumber: 100,
+    horizonBlock: 100,
     agents: [AGENT],
     activeStables: [USDC],
     fairByBase: () => ({ WETH: FAIR }),


### PR DESCRIPTION
Implements issue #38 in full: phases 1, 2 and 3.

A wstETH-style vault whose redemption rate rises with yield, plus an LST/WETH
stableswap-ng secondary market that can trade away from it. The venue exists to
add a skill axis nothing else here has: an asset with **two prices at once**, and
an exit that is a choice between them.

    redemption rate   what the vault owes per share, reachable only through a
                      withdrawal queue that takes time
    market price      what the pool pays right now, at whatever discount it trades

## What is here

**Phase 1 — the venue.** `MockLSTVault` (non-rebasing, ERC-4626 shaped with the
wstETH aliases and a Lido-style request/finalize/claim queue), its market on the
stableswap-ng factory Curve already deploys, an `lst` adapter with four actions,
and an observation that reports both prices separately. Not a Lido fork, for the
reasons the issue gives.

**Phase 2 — making the choice non-trivial.** A seed-driven APY that moves during
the run, a queue that finalizes at a bounded rate (so the wait grows with your own
size and with whatever is queued ahead), and an `lstSlash` event in the stress
overlay using the same range-based config as spike/crash.

**Phase 3 — leverage.** The LST listed as Aave collateral, collateral-only, with
risk parameters stated rather than cloned (the issue is right that there is
nothing to clone them from). Priced at WETH x the redemption rate, written every
block through the same paths as every other oracle — so it inherits the same
one-block lag, which is what turns a slash into a liquidation cascade.

**Scoring** keeps two marks: `valueUsdc` is face value, `liquidatableValueUsdc`
is what an exit would actually return before the run ends (the better of an
instant pool exit and a queue that finalizes in time). A redemption that outlives
the run is excluded from the second and reported as `unrealizable`, never
silently zeroed. This is what #41 left `liquidatableValueUsdc` unwired for.

Also: `config/example.yaml` now defaults to local deploy, settling a split where
the README Quick Start and the official regimes already did and only the
zero-config template still assumed a fork. That is what makes the LST roster entry
the issue asks for possible at all — the vault has no Arbitrum counterpart.

## Calibration, all measured rather than guessed

- **Pool depth 100 WETH / A=100.** At the 400 WETH / A=500 first tried, dumping
  12% of the book moved the price 9bps — nothing an agent could work with.
- **Slash 10-30bps, not 100-300.** It does not open a discount: the pool reads the
  vault's rate as its oracle and reprices with the cut. So it has to be read
  against the yield, and at 15x the yield staking simply lost on every seed.
- **APY the same order as Aave's WETH supply rate.** A 1000x-speed LST would make
  every other venue irrelevant.

## Bugs this surfaced, each with a regression test

- Accrual raced the oracle txs on the admin nonce; anvil rejected the loser and
  the redemption rate sat frozen for a whole run while everything looked healthy.
- A CLI `--blocks` override never reached agent processes, so an agent believed
  the run was longer than it was and queued exits it could not finish — 14 WETH
  stranded. Affects more than this venue.
- The reference agent restaked every block (its entire loss was gas), queued its
  staked position on any drift below par, and read a levered position's empty
  wallet as an unusable venue — from *before* the decision log, so it looked like
  a hung agent. Agent processes now also report dying on their own.

## Review round (commit `6374386`)

A review of this PR raised fifteen findings; all were real and all are fixed. The
two that changed conclusions:

- **LST posted to Aave escaped the realizable mark.** Aave values collateral at
  par, so ten shares in a wallet scored the pool's discount while the same ten
  posted as collateral scored par — free score for enabling leverage. The aave
  adapter now haircuts the LST leg by the venue's own rule. **This invalidates the
  first measurement in this PR:** "alpha 139 levered / 66 unlevered" was largely
  that artefact. After the fix, on the same regime, levered is *worse* than
  unlevered (-100 vs -51), which is what doubling both yield and slashing
  exposure should look like.
- **`liquidatableValueUsdc` was dead**: every adapter returned it equal to
  `valueUsdc`. Face value and realizable value are now genuinely separate, and the
  difference reaches summary.json.

The rest: a refused pool quote read as a 10000bps discount (agent emptied its
wallet into a pool that could not fill); a failed queue-delay read became a
zero-block wait and marked everything at par; `slash()` refunded itself through
the reward reserve; a 100% slash parsed; dropped block notifications could swallow
the slash entirely and desynchronise the seeded APY path; the LST reserve was
wired even for runs that never enabled it, changing tx ordering for existing aave
runs; bundled LST legs skipped cumulative balance validation; leverage made
claiming and premium-harvesting unreachable; redemption sizing used the advertised
floor while the fit check used the quoted wait; `blocksRemaining` ignored startup
lag and the wall-clock terminator; the aggregator was deployed before the
idempotency check. Re-verification also found the LST listing on Aave at the spot
seed price rather than Aave's own WETH price.

## Verified

`npm run test` 301 (300 pass, 1 requires a local deploy), typecheck,
check:boundaries, check:strategy, deployer typecheck.

On a live local deploy: all four spot paths firing in one run
(carry -> queue -> claim), the LLM path doing the same through `prompt.md`, the
phase 2 mechanisms each visibly changing what the agent does, and the leverage
loop settling at its target health factor. On chain: the vault's rate, donation
resistance, bounded reserve and queue semantics; and for phase 3, the listing,
ETH borrowed against it, and a slash reaching the health factor only once the
oracle follows.

The state dump is rebuilt with all six venues and `config/regimes/lst-01.yaml`
added, so this is reachable from backtest.

## Worth knowing before merging

A strategy holding LST is **structurally penalised by a USDC-denominated score**
for carrying WETH exposure it gets no credit for. That is the scoring frame, not
the venue — and the ETH-denominated competition issue #38 opens with is exactly
the follow-on this makes possible.

Both follow-ons the issue names are left out on purpose, as it asks: generalizing
`MarketConfig.quote` so LST/WETH becomes an ordinary market, and scoring in ETH.
Each is worth its own issue.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)