### PR TITLE
feat(infra): local Blockscout explorer for the run anvil (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ drawdown からの回復・レジームをまたぐ資本配分は競技の対�
   - `--score-every N` は採点断面の間引き。成績は初期/最終断面しか使わない（`alphaByAgent = alphaLast − alphaFirst`）ので**スコアは不変**、equity curve が粗くなるだけ
 - `npm run metrics -- <runDir...>` — 保存済み run を**全候補指標で採点し直す**（issue #56。M1 PnL / M4 超過対数成長 / M7 MPPM / M9 `mean−λ·std` / M13 Sharpe と、run 集合に対する M27 Borda）。チェーン不要・再 run 不要で `summary.json` の epoch 系列だけを読む。`--lambda` / `--rho` / `--out <path>`。**`resetUnit` が混ざった run 集合は拒否**する（ADR 0020 §1）。実測の記録は `docs/scoring-metric-measurements.md`
 - `npm run metrics -- --matrix runs/matrix-<id>` — **シナリオ行列を「指標 × 集約」の総当たりで採点し直す**（ADR 0020 §5）。連続経済では「どの指標か」だけが問いだが、`scenario` モードでは**シナリオ横断の集約**という第 2 の選択が要る（`core/src/scoring/aggregate.ts` = `zscore` 現行 / `borda` 順位 / `mean` 絶対量。どれもレジーム等重み）。出力は各組み合わせの順位、M9×zscore との一致/不一致、そして **#55 の露出**（1 体が場の sd を何倍に膨らませているか。1.0 = 誰も場のスケールを決めていない）。matrix.json の `runDir` は相対なので、spot から回収した tarball を展開したディレクトリでもそのまま読める
+- `npm run explorer` — sim anvil を索引するローカル Blockscout（issue #31。stock イメージ pin、`infra/blockscout/`）。UI は http://localhost:3100。**チェーンをリセットしたら `npm run explorer:reset`**（resetFork/snapshot-revert の巻き戻しに indexer は追従できないので DB を消して再索引するのが正規のライフサイクル）。`npm run explorer:tag` が最新 run の `summary.json` から agent アドレスに名前タグを付ける（reset で消えるので run ごと）。接続先・chain id・fork 用 `FIRST_BLOCK` は `infra/blockscout/explorer.env`
 - `npm run typecheck` / `npm run test` — 型チェック / ユニットテスト
 - `npm run check:strategy` — 戦略コードの cheatcode 静的検査（入口ゲート）
 - `npm run check:boundaries` — workspace 依存方向（example → sdk ← core）の検査

--- a/infra/blockscout/README.md
+++ b/infra/blockscout/README.md
@@ -1,0 +1,83 @@
+# Local Blockscout explorer for the run anvil (issue #31)
+
+Stock Blockscout — official images pinned by tag, no source vendored or patched — pointed
+at whichever sim anvil is running. Gives blocks / txs / addresses / logs a browsable UI
+instead of raw `cast` calls, and gives the Eris dashboard (#32) a link target for tx and
+address detail pages.
+
+```
+npm run explorer          # start → http://localhost:3100
+npm run explorer:reset    # wipe the indexer DB and reindex (run after every chain reset)
+npm run explorer:tag      # name agent wallets from the latest run's summary.json
+npm run explorer:down     # stop (indexer DB survives)
+```
+
+All knobs live in [`explorer.env`](explorer.env): anvil port, chain id, explorer port,
+image tags. Defaults match local-deploy mode (deployer anvil on 8545, chain 31337), which
+is also what `npm run sim:realtime` runs on out of the box.
+
+## Lifecycle: reset the explorer whenever the chain resets
+
+Every run rewinds the chain — local-deploy mode snapshot/reverts to the clean deploy
+cross-section, fork mode re-forks. A block-height rewind is something no indexer can
+follow (it has indexed blocks that no longer exist), so the supported lifecycle is:
+
+1. chain resets (new run starts)
+2. `npm run explorer:reset` — drops the postgres volume, reindexes from scratch
+3. optionally `npm run explorer:tag` once the run has a `runs/<id>/summary.json`
+
+Reindexing a run-sized chain (hundreds of blocks) takes well under a minute. Skipping the
+reset does not crash anything, but the explorer will show a mix of stale and current
+blocks at the same heights.
+
+## Pointing it at the different anvils
+
+| target | `RPC_PORT` | `CHAIN_ID` | `FIRST_BLOCK` |
+|---|---|---|---|
+| deployer anvil (local-deploy mode, default) | 8545 | 31337 | 0 |
+| backtest replay anvil (`npm run backtest`) | 8547 | 31337 | 0 |
+| Arbitrum fork anvil (`npm run anvil`) | 8545 | 42161 | **the fork block** |
+
+Edit `explorer.env`, then `npm run explorer:reset`. `explorer.sh` cross-checks the
+configured `CHAIN_ID` against what the anvil actually reports and refuses to start on a
+mismatch.
+
+Fork-mode caveats:
+
+- **`FIRST_BLOCK` is mandatory** (set it to `FORK_BLOCK_NUMBER`). Without it the indexer
+  walks all of Arbitrum history backwards from the head.
+- **Receipts are fetched per transaction.** `ETHEREUM_JSONRPC_VARIANT=anvil` uses
+  `eth_getTransactionReceipt`, not `eth_getBlockReceipts` — required because
+  `eth_getBlockReceipts` is known-broken on anvil Arbitrum forks in this project.
+- Historical state on a fork is ~1,050 blocks deep, so
+  `ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES=true` is set: balances are fetched at the
+  current block only.
+
+## Agent wallet naming
+
+`npm run explorer:tag` (optionally `-- runs/<id>`) reads `agents[].{id,address}` from a
+run's `summary.json` and inserts them as Blockscout address tags (`address_tags` /
+`address_to_tags` in the indexer DB — config-level; no Blockscout change). Each agent id
+becomes a badge on its address pages, plus `env:deployer` for anvil account 0, whose txs
+(venue seeding, liquidityPull reconciles) would otherwise read as a participant's. Tags
+live in the indexer DB, so a `reset` wipes them; re-tag after the next run.
+
+## What runs, and what was deliberately dropped
+
+`db` (postgres 17) / `redis-db` / `backend` / `frontend` / nginx `proxy`, following the
+official `docker-compose/anvil.yml`. Dropped from that layout: `stats` (+ its db),
+`visualizer` (sol2uml), `sig-provider`, `user-ops-indexer`, `nft_media_handler` — spectator
+polish, not debugging. The homepage consequently shows no per-day counters; blocks and txs
+are unaffected. Internal-transaction and pending-transaction fetchers are disabled exactly
+as the official anvil compose does (the former needs `debug_traceBlockByNumber`, and both
+add RPC load to the anvil that is also serving every agent's observe loop).
+
+**Egress**: the only outbound dependency is contract verification through Blockscout's
+hosted eth-bytecode-db, which names canonical bytecode (Uniswap V3, Aave, …) without a
+local verifier. Set `MICROSERVICE_SC_VERIFIER_ENABLED=false` in
+`envs/common-blockscout.env` to run fully offline; everything else keeps working.
+
+Linux note: the compose reaches the host's anvil via `host.docker.internal` (mapped with
+`host-gateway`). On Linux that resolves to the docker bridge, so an anvil bound to
+127.0.0.1 is unreachable — start it with `--host 0.0.0.0` there. macOS Docker Desktop
+forwards to loopback and needs nothing.

--- a/infra/blockscout/docker-compose.yml
+++ b/infra/blockscout/docker-compose.yml
@@ -1,0 +1,96 @@
+# Stock Blockscout against the sim anvil (issue #31). No Blockscout source is vendored or
+# patched — this is the official docker-compose/anvil.yml layout trimmed to the services a
+# local explorer needs (db / redis / backend / frontend / nginx proxy; stats, visualizer,
+# sig-provider, user-ops-indexer and the NFT media handler are dropped).
+#
+# Knobs (RPC port, chain id, explorer port, image tags) live in explorer.env — drive this
+# file through explorer.sh, which passes it with --env-file.
+name: eris-explorer
+
+services:
+  redis-db:
+    image: redis:7.4-alpine
+    container_name: eris-explorer-redis
+    restart: unless-stopped
+    command: redis-server
+
+  db:
+    image: postgres:17
+    container_name: eris-explorer-db
+    restart: unless-stopped
+    shm_size: 256m
+    command: postgres -c 'max_connections=200' -c 'client_connection_check_interval=60000'
+    environment:
+      POSTGRES_DB: blockscout
+      POSTGRES_USER: blockscout
+      POSTGRES_PASSWORD: ceWb1MeLBEeOIfk65gU8EjF8
+    volumes:
+      # Named volume, not a bind mount: `explorer.sh reset` wipes it with `compose down -v`
+      # (each run rewinds the chain via resetFork / snapshot-revert, which the indexer
+      # cannot follow — the reset is the supported lifecycle, not an edge case).
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U blockscout -d blockscout"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  backend:
+    image: ghcr.io/blockscout/blockscout:${BACKEND_TAG:?set BACKEND_TAG in explorer.env}
+    container_name: eris-explorer-backend
+    restart: unless-stopped
+    stop_grace_period: 1m
+    depends_on:
+      db:
+        condition: service_healthy
+      redis-db:
+        condition: service_started
+    command: sh -c "bin/blockscout eval \"Elixir.Explorer.ReleaseTasks.create_and_migrate()\" && bin/blockscout start"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    env_file:
+      - ./envs/common-blockscout.env
+    environment:
+      ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:${RPC_PORT:?}/
+      ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:${RPC_PORT}/
+      ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:${RPC_PORT}/
+      CHAIN_ID: ${CHAIN_ID:?}
+      # Fork mode must set this to the fork block, or the indexer walks all of Arbitrum
+      # history backwards from the head. Local-deploy / backtest anvil starts at 0.
+      FIRST_BLOCK: ${FIRST_BLOCK:-0}
+
+  frontend:
+    image: ghcr.io/blockscout/frontend:${FRONTEND_TAG:?set FRONTEND_TAG in explorer.env}
+    # The frontend image is published amd64-only (matches the official compose); on Apple
+    # Silicon it runs under emulation, which is fine for a local explorer.
+    platform: linux/amd64
+    container_name: eris-explorer-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    env_file:
+      - ./envs/common-frontend.env
+    environment:
+      NEXT_PUBLIC_API_PORT: ${EXPLORER_PORT:?}
+      NEXT_PUBLIC_APP_PORT: ${EXPLORER_PORT}
+      NEXT_PUBLIC_NETWORK_ID: ${CHAIN_ID}
+      NEXT_PUBLIC_NETWORK_RPC_URL: http://localhost:${RPC_PORT}/
+
+  proxy:
+    image: nginx:1.27-alpine
+    container_name: eris-explorer-proxy
+    restart: unless-stopped
+    depends_on:
+      - backend
+      - frontend
+    volumes:
+      - ./proxy:/etc/nginx/templates:ro
+    environment:
+      BACK_PROXY_PASS: http://backend:4000
+      FRONT_PROXY_PASS: http://frontend:3000
+    ports:
+      - "${EXPLORER_PORT}:80"
+
+volumes:
+  db-data:

--- a/infra/blockscout/envs/common-blockscout.env
+++ b/infra/blockscout/envs/common-blockscout.env
@@ -1,0 +1,56 @@
+# Backend env, based on the official docker-compose/envs/common-blockscout.env plus the
+# overrides the official docker-compose/anvil.yml applies, trimmed to the services this
+# compose actually runs. RPC URL / chain id / first block are interpolated per-setup and
+# therefore live in docker-compose.yml (env_file values are never interpolated).
+
+# --- chain access ---
+# The anvil variant fetches receipts per transaction (eth_getTransactionReceipt), which is
+# required here: eth_getBlockReceipts is known-broken on anvil Arbitrum forks in this
+# project (decode failure; see memory/CLAUDE.md).
+ETHEREUM_JSONRPC_VARIANT=anvil
+ETHEREUM_JSONRPC_TRANSPORT=http
+# Anvil keeps limited historical state (~1,050 blocks on a fork); fetch current balances
+# only instead of balances at historical blocks.
+ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES=true
+
+# Same two fetchers the official anvil.yml disables: internal transactions need
+# debug_traceBlockByNumber, and both add constant RPC load on the run anvil, which is
+# also serving every agent's observe loop.
+INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
+INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER=true
+
+# --- app plumbing (official sample values; local-only stack, nothing secret) ---
+DATABASE_URL=postgresql://blockscout:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
+ECTO_USE_SSL=false
+SECRET_KEY_BASE=56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN
+PORT=4000
+POOL_SIZE=80
+POOL_SIZE_API=10
+HEART_BEAT_TIMEOUT=30
+# The official compose bind-mounts ./logs for these; we don't, so keep logs on stdout.
+DISABLE_FILE_LOGGING=true
+
+# --- features ---
+# No market data for a sim chain.
+DISABLE_MARKET=true
+COIN_NAME=
+COIN=
+ADMIN_PANEL_ENABLED=false
+ACCOUNT_ENABLED=false
+ACCOUNT_REDIS_URL=redis://redis-db:6379
+RE_CAPTCHA_DISABLED=true
+API_V1_READ_METHODS_DISABLED=false
+API_V1_WRITE_METHODS_DISABLED=false
+DECODE_NOT_A_CONTRACT_CALLS=true
+TXS_STATS_DAYS_TO_COMPILE_AT_INIT=10
+COIN_BALANCE_HISTORY_DAYS=90
+
+# --- microservices this compose does not run ---
+MICROSERVICE_VISUALIZE_SOL2UML_ENABLED=false
+MICROSERVICE_SIG_PROVIDER_ENABLED=false
+NFT_MEDIA_HANDLER_ENABLED=false
+# Contract verification stays on (stock default): it goes through Blockscout's hosted
+# eth-bytecode-db, so canonical bytecode (Uniswap V3, Aave, …) gets names + decoded calls
+# without any local verifier. This is the stack's only egress — set
+# MICROSERVICE_SC_VERIFIER_ENABLED=false here to run fully offline.
+MICROSERVICE_SC_VERIFIER_TYPE=eth_bytecode_db

--- a/infra/blockscout/envs/common-frontend.env
+++ b/infra/blockscout/envs/common-frontend.env
@@ -1,0 +1,21 @@
+# Frontend env, based on the official docker-compose/envs/common-frontend.env. Everything
+# that depends on explorer.env knobs (ports, chain id, RPC URL) is interpolated in
+# docker-compose.yml instead (env_file values are never interpolated).
+NEXT_PUBLIC_API_HOST=localhost
+NEXT_PUBLIC_API_PROTOCOL=http
+NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
+NEXT_PUBLIC_API_BASE_PATH=/
+NEXT_PUBLIC_APP_HOST=localhost
+NEXT_PUBLIC_APP_PROTOCOL=http
+NEXT_PUBLIC_NETWORK_NAME=Eris run anvil
+NEXT_PUBLIC_NETWORK_SHORT_NAME=Eris
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=Ether
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ETH
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_IS_TESTNET=true
+# The stock frontend serves third-party ads by default — pointless egress on a local
+# explorer (and the banner is the first thing on the page).
+NEXT_PUBLIC_AD_BANNER_PROVIDER=none
+NEXT_PUBLIC_AD_TEXT_PROVIDER=none
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml

--- a/infra/blockscout/explorer.env
+++ b/infra/blockscout/explorer.env
@@ -1,0 +1,26 @@
+# Knobs for the local Blockscout explorer (no secrets — committed on purpose; the root
+# .gitignore would eat a file named .env). explorer.sh passes this to docker compose
+# with --env-file.
+
+# Where the sim anvil listens on the host.
+#   8545 = deployer anvil (local-deploy mode) and the fork anvil (npm run anvil)
+#   8547 = backtest replay anvil (npm run backtest)
+RPC_PORT=8545
+
+# Must match the chain the anvil runs.
+#   31337 = local-deploy / backtest anvil (anvil default)
+#   42161 = Arbitrum fork mode (npm run anvil)
+CHAIN_ID=31337
+
+# Fork mode only: set to the fork block number (FORK_BLOCK_NUMBER), or the indexer walks
+# all of Arbitrum history backwards from the head. 0 = index from genesis (local deploy).
+FIRST_BLOCK=0
+
+# Host port the explorer UI + API are served on (http://localhost:<EXPLORER_PORT>).
+EXPLORER_PORT=3100
+
+# Official images, pinned by tag (issue #31: stock, no fork).
+# backend  = ghcr.io/blockscout/blockscout, tags follow releases without the "v"
+# frontend = ghcr.io/blockscout/frontend, tags keep the "v"
+BACKEND_TAG=9.0.2
+FRONTEND_TAG=v2.3.5

--- a/infra/blockscout/explorer.sh
+++ b/infra/blockscout/explorer.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Local Blockscout explorer for the sim anvil (issue #31). Thin driver around docker
+# compose; all configuration lives in explorer.env next to this script.
+#
+#   explorer.sh up            start (or restart) the stack against the anvil in explorer.env
+#   explorer.sh down          stop the stack (indexer DB survives)
+#   explorer.sh reset         wipe the indexer DB and restart — run this after every chain
+#                             reset (resetFork / snapshot-revert rewinds the chain, which
+#                             the indexer cannot follow)
+#   explorer.sh tag [runDir]  name the agent wallets from a run's summary.json as address
+#                             tags (default: the newest runs/*/summary.json)
+#   explorer.sh status        compose ps + recent backend log lines
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+COMPOSE=(docker compose --env-file explorer.env -f docker-compose.yml)
+
+# explorer.env is trusted repo config; read the knobs the script itself needs.
+knob() { sed -n "s/^$1=//p" explorer.env | tail -1; }
+RPC_PORT="$(knob RPC_PORT)"
+CHAIN_ID="$(knob CHAIN_ID)"
+EXPLORER_PORT="$(knob EXPLORER_PORT)"
+
+require_docker() {
+  if ! docker info >/dev/null 2>&1; then
+    echo "docker daemon is not running (start Docker Desktop first)" >&2
+    exit 1
+  fi
+}
+
+check_rpc() {
+  command -v cast >/dev/null 2>&1 || return 0
+  local chain_dec
+  chain_dec=$(cast chain-id --rpc-url "http://127.0.0.1:${RPC_PORT}" 2>/dev/null) || true
+  if [ -z "${chain_dec:-}" ]; then
+    echo "warning: no anvil answering on 127.0.0.1:${RPC_PORT} — the indexer will retry until one appears" >&2
+    return 0
+  fi
+  if [ "$chain_dec" != "$CHAIN_ID" ]; then
+    echo "error: anvil on port ${RPC_PORT} reports chain id ${chain_dec}, but explorer.env says CHAIN_ID=${CHAIN_ID}" >&2
+    echo "       (fork anvil = 42161, local-deploy/backtest anvil = 31337 — fix explorer.env, then 'reset')" >&2
+    exit 1
+  fi
+}
+
+cmd_up() {
+  require_docker
+  check_rpc
+  "${COMPOSE[@]}" up -d
+  echo
+  echo "explorer: http://localhost:${EXPLORER_PORT}  (indexing 127.0.0.1:${RPC_PORT}, chain ${CHAIN_ID})"
+  echo "first start pulls images and boots the backend; give it ~1 minute"
+}
+
+cmd_down() {
+  require_docker
+  "${COMPOSE[@]}" down
+}
+
+cmd_reset() {
+  require_docker
+  check_rpc
+  "${COMPOSE[@]}" down -v
+  "${COMPOSE[@]}" up -d
+  echo
+  echo "indexer DB wiped; reindexing 127.0.0.1:${RPC_PORT} from scratch"
+  echo "address tags were wiped with it — re-run 'explorer.sh tag' after the next run"
+}
+
+cmd_status() {
+  require_docker
+  "${COMPOSE[@]}" ps
+  echo
+  "${COMPOSE[@]}" logs --tail 15 backend
+}
+
+cmd_tag() {
+  require_docker
+  local run_dir="${1:-}"
+  if [ -z "$run_dir" ]; then
+    local d
+    for d in $(ls -td "${REPO_ROOT}"/runs/*/ 2>/dev/null); do
+      if [ -f "${d}summary.json" ]; then run_dir="${d%/}"; break; fi
+    done
+    if [ -z "${run_dir:-}" ]; then
+      echo "no runs/*/summary.json found — pass a run directory explicitly" >&2
+      exit 1
+    fi
+  fi
+  if [ ! -f "${run_dir}/summary.json" ]; then
+    echo "no summary.json in ${run_dir}" >&2
+    exit 1
+  fi
+  echo "tagging agent wallets from ${run_dir}"
+  python3 - "$run_dir" <<'PY' | "${COMPOSE[@]}" exec -T db psql -q -U blockscout -d blockscout -v ON_ERROR_STOP=1 -f -
+import json, sys, pathlib
+
+summary = json.loads((pathlib.Path(sys.argv[1]) / "summary.json").read_text())
+rows = [(a["id"], a["address"]) for a in summary.get("agents", []) if a.get("address")]
+# The environment/deployer key (anvil account 0) seeds every venue and moves LP in
+# liquidityPull windows — worth naming so its txs don't read as a participant's.
+rows.append(("env:deployer", "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+
+def q(s: str) -> str:
+    return s.replace("'", "''")
+
+for label, address in rows:
+    addr_hex = address.lower().removeprefix("0x")
+    if len(addr_hex) != 40 or any(c not in "0123456789abcdef" for c in addr_hex):
+        print(f"-- skipped {label}: bad address {address!r}", file=sys.stderr)
+        continue
+    print(f"""\
+INSERT INTO address_tags (label, display_name, inserted_at, updated_at)
+VALUES ('{q(label)}', '{q(label)}', now(), now())
+ON CONFLICT (label) DO NOTHING;
+INSERT INTO address_to_tags (address_hash, tag_id, inserted_at, updated_at)
+SELECT decode('{addr_hex}', 'hex'), id, now(), now()
+FROM address_tags WHERE label = '{q(label)}'
+ON CONFLICT DO NOTHING;""")
+PY
+  echo "done — tags show on the address pages (wiped again by 'reset')"
+}
+
+case "${1:-}" in
+  up)     cmd_up ;;
+  down)   cmd_down ;;
+  reset)  cmd_reset ;;
+  status) cmd_status ;;
+  tag)    shift; cmd_tag "${1:-}" ;;
+  *)
+    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+    ;;
+esac

--- a/infra/blockscout/proxy/default.conf.template
+++ b/infra/blockscout/proxy/default.conf.template
@@ -1,0 +1,35 @@
+# Official docker-compose/proxy/default.conf.template, kept to the port-80 server only
+# (the 8080/8081 servers proxy the stats and visualizer services this compose drops).
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+server {
+    listen       80;
+    server_name  localhost;
+    proxy_http_version 1.1;
+
+    location ~ ^/(api(?!-docs$)|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
+        proxy_pass            ${BACK_PROXY_PASS};
+        proxy_http_version    1.1;
+        proxy_set_header      Host "$host";
+        proxy_set_header      X-Real-IP "$remote_addr";
+        proxy_set_header      X-Forwarded-For "$proxy_add_x_forwarded_for";
+        proxy_set_header      X-Forwarded-Proto "$scheme";
+        proxy_set_header      Upgrade "$http_upgrade";
+        proxy_set_header      Connection $connection_upgrade;
+        proxy_cache_bypass    $http_upgrade;
+    }
+    location / {
+        proxy_pass            ${FRONT_PROXY_PASS};
+        proxy_http_version    1.1;
+        proxy_set_header      Host "$host";
+        proxy_set_header      X-Real-IP "$remote_addr";
+        proxy_set_header      X-Forwarded-For "$proxy_add_x_forwarded_for";
+        proxy_set_header      X-Forwarded-Proto "$scheme";
+        proxy_set_header      Upgrade "$http_upgrade";
+        proxy_set_header      Connection $connection_upgrade;
+        proxy_cache_bypass    $http_upgrade;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "check:strategy": "tsx scripts/checkStrategyCode.ts",
     "check:boundaries": "tsx scripts/checkImportBoundaries.ts",
     "bundle:agent": "tsx scripts/bundleAgent.ts",
+    "explorer": "infra/blockscout/explorer.sh up",
+    "explorer:down": "infra/blockscout/explorer.sh down",
+    "explorer:reset": "infra/blockscout/explorer.sh reset",
+    "explorer:tag": "infra/blockscout/explorer.sh tag",
     "build:contracts": "forge build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"


### PR DESCRIPTION
Closes #31.

## What

Stock Blockscout pointed at whichever sim anvil is running, as a thin config set in `infra/blockscout/` — official images pinned by tag (`blockscout:9.0.2` / `frontend:v2.3.5`, ground-truthed against ghcr), no Blockscout source vendored or patched. The layout follows the official `docker-compose/anvil.yml` trimmed to db (postgres 17) / redis / backend / frontend / nginx proxy; stats, visualizer, sig-provider, user-ops-indexer and the NFT media handler are spectator polish rather than debugging value and are dropped.

```
npm run explorer          # → http://localhost:3100
npm run explorer:reset    # wipe the indexer DB and reindex (after every chain reset)
npm run explorer:tag      # name agent wallets from a run's summary.json
npm run explorer:down
```

All knobs (RPC port, chain id, explorer port, fork `FIRST_BLOCK`, image tags) live in `infra/blockscout/explorer.env`; defaults match local-deploy mode. `explorer.sh` cross-checks the configured chain id against what the anvil actually reports and refuses to start on a mismatch.

## The three points from the issue

- **Chain-reset lifecycle** — `explorer:reset` drops the postgres volume and reindexes from scratch. A resetFork / snapshot-revert rewind is something no indexer can follow, so the wipe is the supported lifecycle, not a workaround. Reindexing a run-sized chain takes well under a minute.
- **Arbitrum-fork caveat** — `ETHEREUM_JSONRPC_VARIANT=anvil` fetches receipts per transaction (`eth_getTransactionReceipt`), never `eth_getBlockReceipts` (known-broken on anvil Arbitrum forks in this project). Archive balance fetching is disabled for the ~1,050-block historical state depth, and `FIRST_BLOCK` is mandatory in fork mode (without it the indexer walks all of Arbitrum history backwards from the head).
- **Agent wallet naming** — `explorer:tag` reads `agents[].{id,address}` from a run's `summary.json` and inserts Blockscout address tags (`address_tags` / `address_to_tags`; config-level, no Blockscout change), plus `env:deployer` for anvil account 0 so environment txs don't read as a participant's. Tags live in the indexer DB and are wiped by `reset`.

Also disabled the stock frontend's third-party ads (`NEXT_PUBLIC_AD_*_PROVIDER=none`) — pointless egress on a local explorer. The one remaining egress is contract verification through Blockscout's hosted eth-bytecode-db (names canonical bytecode like Uniswap V3 / Aave without a local verifier); `MICROSERVICE_SC_VERIFIER_ENABLED=false` turns it off for fully offline use.

## Verified

End-to-end against a live anvil (chain 31337): compose up and indexing, frontend rendering checked in a real browser (homepage, tx list, address page), tag badges visible on address pages via API v2 `public_tags`, and the reset flow (DB wiped, reindexed to head, tags gone). The stale-mix failure mode the reset exists for was also reproduced and cleared by `explorer:reset`.

Not yet exercised live: fork mode (42161) against a real Arbitrum fork — the config for it is in place per the caveats above and documented in `infra/blockscout/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)