### PR TITLE
fix(core,example): a decision log has to follow the segment it happens in

### DIFF
--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -1074,8 +1074,15 @@ export async function runRealtimeSimulation(
       };
     }
     // Merge the stress victim env (ADR 0009) and vuln env (ADR 0014) into a single extra env for distribution.
+    // ERIS_RUN_DIR is fixed when the process starts; the segment it names is not (ADR 0021 sec 6).
+    // Hand the child the pointer so its log follows the roll instead of piling into segment 0.
+    const segmentEnv = segments
+      ? { ERIS_RUN_DIR_POINTER: segments.pointerPath }
+      : undefined;
     const agentExtraEnv =
-      victimEnv || vulnEnv ? { ...victimEnv, ...vulnEnv } : undefined;
+      victimEnv || vulnEnv || segmentEnv
+        ? { ...victimEnv, ...vulnEnv, ...segmentEnv }
+        : undefined;
 
     // Emit the agent registry in one line (ADR 0008 P0). The dashboard can grasp all agents (id/address/
     // classification hint) immediately from a file tail alone (closes the gap for agents that never act or are

--- a/core/src/segments.ts
+++ b/core/src/segments.ts
@@ -26,6 +26,9 @@ import {
   type RunArtifactWriter,
 } from "./logger.js";
 
+/** The file inside a competition directory naming the segment that is current right now. */
+export const CURRENT_SEGMENT_FILE = "current-segment";
+
 export type SegmentIndexEntry = {
   /** Scenario shape, so the dashboard reads this with the code it already has. */
   regime: "segment";
@@ -72,6 +75,25 @@ export class SegmentedRun implements RunArtifactWriter {
       this.segmentDirId,
     );
     this.writeIndex();
+    this.writePointer();
+  }
+
+  /**
+   * Where a running agent process reads the directory it should be writing its decision log into.
+   *
+   * An agent is spawned once and handed ERIS_RUN_DIR; a segment roll changes the directory under it
+   * hours later. Without a pointer every log line for the rest of the period lands in the first
+   * segment, and every segment after it shows a local agent with no lines -- which the dashboard
+   * states as "it never logged a decision" (runsProvider.ts). That is false, and it is the one
+   * reading a viewer cannot check.
+   */
+  get pointerPath(): string {
+    return join(this.competitionDir, CURRENT_SEGMENT_FILE);
+  }
+
+  private writePointer(): void {
+    // Written after the directory exists, so a reader never sees a path that is not there yet.
+    writeFileSync(this.pointerPath, `${this.logger.runDir}\n`);
   }
 
   // Named by when it started rather than by its number: a viewer looking for Tuesday should not
@@ -157,6 +179,7 @@ export class SegmentedRun implements RunArtifactWriter {
     this.segmentDirId = this.newSegmentId();
     this.logger = new RunLogger(this.competitionDir, this.segmentDirId);
     this.writeIndex();
+    this.writePointer();
     return this.logger.runDir;
   }
 

--- a/example/agents/runtime/agentLog.ts
+++ b/example/agents/runtime/agentLog.ts
@@ -18,7 +18,7 @@
  * Note: when not running under the coordinator (ERIS_RUN_DIR unset) the log is a no-op.
  *       A log write failure never stops strategy execution (it is swallowed).
  */
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { safeStringify } from "@eris/sdk/logger.js";
 import type { AgentLogEntry } from "@eris/sdk/agent.js";
@@ -37,21 +37,41 @@ export function createJsonlAppender(
   suffix = "",
 ): (record: Record<string, unknown>) => void {
   if (!runDir) return () => {}; // do nothing when not running under the coordinator
-  const dir = join(runDir, "agents");
-  const path = join(dir, `${agentId}${suffix}.jsonl`);
-  let ready = false;
+  // A segmented period rolls the run directory while this process keeps going (ADR 0021 sec 6), so
+  // the directory is resolved per write rather than captured. The coordinator points at the segment
+  // that is current; without this every line after the first roll lands in segment 0, and every
+  // later segment shows a local agent with no lines -- which reads as "it never logged a decision".
+  const pointer = process.env.ERIS_RUN_DIR_POINTER;
+  let currentDir = runDir;
+  let pointerMtimeMs = -1;
+  const resolveDir = (): string => {
+    if (!pointer) return runDir;
+    try {
+      const mtimeMs = statSync(pointer).mtimeMs;
+      if (mtimeMs !== pointerMtimeMs) {
+        pointerMtimeMs = mtimeMs;
+        const next = readFileSync(pointer, "utf8").trim();
+        if (next) currentDir = next;
+      }
+    } catch {
+      // the pointer is an optimisation, not a requirement: keep writing where we were
+    }
+    return currentDir;
+  };
+  const ready = new Set<string>();
   return (record) => {
     try {
-      if (!ready) {
+      const dir = join(resolveDir(), "agents");
+      if (!ready.has(dir)) {
         mkdirSync(dir, { recursive: true });
-        ready = true;
+        ready.add(dir);
       }
       const line = safeStringify({
         ts: new Date().toISOString(),
         agentId,
         ...record,
       });
-      appendFileSync(path, `${line}\n`);
+      appendFileSync(join(dir, `${agentId}${suffix}.jsonl`), `${line}\n`);
     } catch {
       // a log failure must not affect strategy execution
     }

--- a/test/agentLogSegment.test.ts
+++ b/test/agentLogSegment.test.ts
@@ -1,0 +1,79 @@
+// A segmented period rolls the run directory while an agent process keeps going (ADR 0021 §6).
+// The log has to follow, or every segment after the first shows a local agent with no lines --
+// which the dashboard states as "it never logged a decision".
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createJsonlAppender } from "../example/agents/runtime/agentLog.js";
+
+const lines = (path: string): Record<string, unknown>[] =>
+  existsSync(path)
+    ? readFileSync(path, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l))
+    : [];
+
+test("the decision log follows a segment roll", () => {
+  const root = mkdtempSync(join(tmpdir(), "eris-seg-"));
+  const s0 = join(root, "s00");
+  const s1 = join(root, "s01");
+  mkdirSync(s0, { recursive: true });
+  mkdirSync(s1, { recursive: true });
+  const pointer = join(root, "current-segment");
+  writeFileSync(pointer, `${s0}\n`);
+
+  const previous = process.env.ERIS_RUN_DIR_POINTER;
+  process.env.ERIS_RUN_DIR_POINTER = pointer;
+  try {
+    const append = createJsonlAppender(s0, "house-arb");
+    append({ round: 1 });
+
+    // The coordinator rolls: same process, new directory.
+    writeFileSync(pointer, `${s1}\n`);
+    append({ round: 2 });
+
+    const first = lines(join(s0, "agents", "house-arb.jsonl"));
+    const second = lines(join(s1, "agents", "house-arb.jsonl"));
+    assert.deepEqual(first.map((l) => l.round), [1]);
+    assert.deepEqual(second.map((l) => l.round), [2], "the line after the roll belongs to the new segment");
+  } finally {
+    if (previous === undefined) delete process.env.ERIS_RUN_DIR_POINTER;
+    else process.env.ERIS_RUN_DIR_POINTER = previous;
+  }
+});
+
+test("without a pointer the log stays where the process was told to write", () => {
+  const root = mkdtempSync(join(tmpdir(), "eris-seg-"));
+  mkdirSync(root, { recursive: true });
+  const previous = process.env.ERIS_RUN_DIR_POINTER;
+  delete process.env.ERIS_RUN_DIR_POINTER;
+  try {
+    const append = createJsonlAppender(root, "solo");
+    append({ round: 7 });
+    assert.deepEqual(
+      lines(join(root, "agents", "solo.jsonl")).map((l) => l.round),
+      [7],
+    );
+  } finally {
+    if (previous !== undefined) process.env.ERIS_RUN_DIR_POINTER = previous;
+  }
+});
+
+test("an unreadable pointer does not stop the log", () => {
+  const root = mkdtempSync(join(tmpdir(), "eris-seg-"));
+  mkdirSync(root, { recursive: true });
+  const previous = process.env.ERIS_RUN_DIR_POINTER;
+  process.env.ERIS_RUN_DIR_POINTER = join(root, "does-not-exist");
+  try {
+    const append = createJsonlAppender(root, "solo");
+    append({ round: 9 });
+    assert.deepEqual(
+      lines(join(root, "agents", "solo.jsonl")).map((l) => l.round),
+      [9],
+      "a missing pointer falls back to the directory the process started with",
+    );
+  } finally {
+    if (previous === undefined) delete process.env.ERIS_RUN_DIR_POINTER;
+    else process.env.ERIS_RUN_DIR_POINTER = previous;
+  }
+});


### PR DESCRIPTION
A segmented period rolls the run directory while the agent processes keep going (ADR 0021 §6). `ERIS_RUN_DIR` is handed to a child once, at spawn, so the roll never reaches it: every line an operator-run agent writes for the rest of the period lands in segment 0, and every segment after the first has no `agents/` directory at all.

## Why it matters

`runsProvider.ts` is explicit that this distinction carries meaning:

> An empty log and an absent one are different facts, and the panel has to say which. A local agent with no lines means it never logged a decision; an external one means the log exists, on somebody else's disk (ADR 0021 §4).

From the second segment on, "it never logged a decision" is false for every agent the operator runs — and it is the one reading a viewer cannot check against the chain.

`config/practice.yaml` reaches this on its own: `segmentHours` is 24 and the `noop` baseline is spawned, not external. So a week-long practice period shows six days of a baseline that appears never to have decided anything.

## Repro

90 blocks cut into three segments, one spawned baseline and one operator-run arb agent. Before:

```
s00: blocks 861..896   agents/  noop[860..895] house-arb[860..868]
s01: blocks 897..933   (no agents/)
s02: blocks 934..949   (no agents/)
```

After:

```
s00: blocks 861..896   noop[860..895]
s01: blocks 897..933   noop[896..932]
s02: blocks 934..949   noop[933..949]
```

## The change

The run directory is resolved per write rather than captured.

- `SegmentedRun` writes the current segment's directory into `<competition>/current-segment`, on open and on every roll.
- The coordinator hands that path to each child as `ERIS_RUN_DIR_POINTER`, alongside the victim/vuln env it already merges.
- `createJsonlAppender` re-reads the pointer when its mtime moves, and keeps a per-directory `mkdir` guard so a roll costs one `mkdir` rather than one per line.

The pointer is an optimisation, not a requirement. With no pointer set, or an unreadable one, the appender keeps writing where the process was told to at spawn — today's behaviour exactly, which is what a non-segmented run and every existing test rely on. The added cost is one `stat` per log write, i.e. one per agent per block.

## Alternatives considered

- **Symlink each new segment's `agents/` at segment 0's.** Every reader works unchanged, but then each segment shows the whole period's log, which is wrong in the other direction — a segment is supposed to be a day.
- **Leave the writing alone and fix the viewer's empty state.** Honest, but it gives up on ever attributing a decision to the day it happened, and the log is the only place an operator-run agent's reasoning exists.

Happy to switch to either if you'd rather.

## Checks

- `npm run typecheck` clean
- `npm run check:boundaries` PASS
- `npm test` — 550 pass / 0 fail / 4 skipped (3 new)
- Verified end to end on a real segmented run (the repro above)

## Found while

Standing up the competition infrastructure on the host that will run it, and load-testing it. Two things turned up alongside this that are **not** part of this PR:

- `check:ordering --live` is INCONCLUSIVE against an automining node — every probe gets its own block, so nothing is ordered. The diagnostic says exactly that and what to do, so this is a documentation matter rather than a bug; `--block-time 2` gives 35/35 pairs in fee order, and `--order fifo` catches 35/35 as a control.
- `stress:rpc` at 100 agents: 2,997.8 observations/s, 60x headroom, 0 errors, `sequencer-only is sufficient`. It also reports `eth_call answered 256 blocks back` — the history limit that ADR 0021 §3 moved off, showing up as a measurement.
