### PR TITLE
feat: GMX funding observation + basis-arb wire (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,15 @@ LP 建玉 10、bundle 内 action 5 — 全部消した。**引き上げではな
   よって**レートは実物・符号も偏り追随**だが、**数百ブロックで積む額は小さい**（Aave の利息と同じ理由。EVM 時間は warp しない）
 - **これ以前に焼いた state dump は旧設定を持つ**ので、そこからの replay は今も 0 を返す。
   その 0 は「板が均衡している」ではなく「この deploy に funding が無い」。`npm run gen:state-dump` で焼き直す
+- **observation にも出る**（issue #78）。`protocols.gmx` の `longOiUsd` / `shortOiUsd` / `fundingPerHourBps`
+  （正 = long が short に払う）/ `fundingModeled`、建玉があれば `position.fundingOwedUsd`。
+  以前は「チェーン上にも market.json にもあるのに、どの agent からも見えない」状態だった。
+  DataStore のキー導出は **`sdk/src/protocols/gmxKeys.ts` が単一の出典**で、marketSeries（報告）と
+  gmx アダプタ（観測）が同じキー・同じ式を読む（`example → sdk ← core` なのでアダプタは core を読めない）。
+  **読取失敗は 0 ではなく欠落**、`fundingModeled: false` が「この deploy に funding が無い」側の 0。
+  **額は取引にならない**: 360 ブロック(2s/block = 12 分)で 100% スキューでも建玉の 0.14bps、
+  実測スキューなら ~0.02bps で、AMM 側の 30bps に対して 3 桁小さい。**符号付きのコスト項と偏りシグナル**であって
+  carry ではない（`basis-arb` の `fundingCarryBpsPerBlock` がヘッジ側の符号で cost gate に入れる）
 
 ### `run.resetUnit` — world のリセット単位（ADR 0020）
 

--- a/core/src/realtime/marketSeries.ts
+++ b/core/src/realtime/marketSeries.ts
@@ -9,7 +9,7 @@
 // This is a reporting artifact, not scoring: a failed read degrades a sample instead of failing the
 // run, and failedReads/failedReadTargets carry the same accountability as valueSeries.
 import type { Address, Hex, PublicClient } from "viem";
-import { encodeAbiParameters, keccak256, parseAbi, zeroAddress } from "viem";
+import { parseAbi, zeroAddress } from "viem";
 import {
   balancerQueriesAbi,
   curveTricryptoAbi,
@@ -35,6 +35,12 @@ import {
   tokenInfoByAddress,
 } from "@eris/sdk/markets.js";
 import { aaveReserveDataAbi } from "@eris/sdk/protocols/aave.js";
+import {
+  gmxDataStoreReadAbi,
+  gmxFundingFields,
+  gmxOpenInterestKey,
+  gmxSavedFundingKey,
+} from "@eris/sdk/protocols/gmxKeys.js";
 import { twoSidedQuote } from "@eris/sdk/protocols/marketHelpers.js";
 import {
   decodeStableProbes,
@@ -210,11 +216,6 @@ export function marketSeriesMeta(a: MarketSeriesArtifact): MarketSeriesMeta {
 // ---------------------------------------------------------------------------
 // ABIs / GMX DataStore keys
 
-const dataStoreReadAbi = parseAbi([
-  "function getUint(bytes32 key) view returns (uint256)",
-  "function getInt(bytes32 key) view returns (int256)",
-]);
-
 const vaultAbi = parseAbi([
   "function getPoolTokens(bytes32 poolId) view returns (address[] tokens, uint256[] balances, uint256 lastChangeBlock)",
 ]);
@@ -284,41 +285,8 @@ const aavePoolAccountAbi = parseAbi([
   "function getUserAccountData(address user) view returns (uint256 totalCollateralBase, uint256 totalDebtBase, uint256 availableBorrowsBase, uint256 currentLiquidationThreshold, uint256 ltv, uint256 healthFactor)",
 ]);
 
-// Keys.sol derivations (deployer/vendor/gmx-src/contracts/data/Keys.sol).
-function hashString(s: string): Hex {
-  return keccak256(encodeAbiParameters([{ type: "string" }], [s]));
-}
-const OPEN_INTEREST = hashString("OPEN_INTEREST");
-const SAVED_FUNDING_FACTOR_PER_SECOND = hashString(
-  "SAVED_FUNDING_FACTOR_PER_SECOND",
-);
-
-export function gmxOpenInterestKey(
-  market: Address,
-  collateralToken: Address,
-  isLong: boolean,
-): Hex {
-  return keccak256(
-    encodeAbiParameters(
-      [
-        { type: "bytes32" },
-        { type: "address" },
-        { type: "address" },
-        { type: "bool" },
-      ],
-      [OPEN_INTEREST, market, collateralToken, isLong],
-    ),
-  );
-}
-
-function gmxSavedFundingKey(market: Address): Hex {
-  return keccak256(
-    encodeAbiParameters(
-      [{ type: "bytes32" }, { type: "address" }],
-      [SAVED_FUNDING_FACTOR_PER_SECOND, market],
-    ),
-  );
-}
+// The GMX DataStore key derivations live in the sdk (sdk/src/protocols/gmxKeys.ts) so that the
+// agent-facing observation reads the same keys as this reporter (issue #78).
 
 // ---------------------------------------------------------------------------
 // multicall plumbing (mirrors reconstruct.ts, kept local: this artifact must degrade, not fail)
@@ -1021,14 +989,14 @@ async function sampleBlock(opts: {
     ].map((key) =>
       batch.push({
         address: GMX.DataStore,
-        abi: dataStoreReadAbi,
+        abi: gmxDataStoreReadAbi,
         functionName: "getUint",
         args: [key],
       }),
     ),
     funding: batch.push({
       address: GMX.DataStore,
-      abi: dataStoreReadAbi,
+      abi: gmxDataStoreReadAbi,
       functionName: "getInt",
       args: [gmxSavedFundingKey(m.marketToken)],
     }),
@@ -1209,31 +1177,35 @@ async function sampleBlock(opts: {
 
   const gmx: NonNullable<MarketSeriesRow["gmx"]> = {};
   for (const entry of gmxIdx) {
-    const oi = entry.oi.map((idx) => stage0[idx]);
-    if (oi.some((v) => typeof v !== "bigint")) continue;
-    const [longA, longB, shortA, shortB] = oi as bigint[];
     const fundingRaw = stage0[entry.funding];
-    // OI is stored in USD with 30 decimals; savedFundingFactorPerSecond is a per-second fraction
-    // at 30 decimals (sign = longs pay shorts when positive). A failed funding read leaves the
-    // field absent rather than printing 0.00bps — a zero here is not a measurement (issue #44's
-    // discipline applies to reporting too).
+    // Decoded by the sdk's shared formula so this artifact and the agent-facing observation cannot
+    // drift apart (issue #78). OI is USD at 30 decimals; savedFundingFactorPerSecond is a
+    // per-second fraction at 30 decimals, positive when longs pay shorts. A failed funding read
+    // leaves the field absent rather than printing 0.00bps — a zero here is not a measurement
+    // (issue #44's discipline applies to reporting too).
     //
-    // savedFundingFactorPerSecond is the *adaptive* funding path's stored state: MarketUtils
-    // returns early and never writes it when fundingIncreaseFactorPerSecond is 0, so on a GMX
-    // deploy without adaptive funding this key reads 0 forever no matter how skewed the book is.
-    // That was true of every run before the localhost market config gained funding parameters
-    // (deployer/vendor/gmx-localhost.patch), and it is still true of any run replayed from a state
-    // dump baked before that — a 0 from such a dump means "this deploy has no funding", not
-    // "the book is balanced". Rebake the dump (`npm run gen:state-dump`) to get a real rate.
-    gmx[entry.market.base] = {
-      longOiUsd: round2(Number(longA + longB) / 1e30),
-      shortOiUsd: round2(Number(shortA + shortB) / 1e30),
+    // savedFundingFactorPerSecond is the *adaptive* funding path's stored state, so it reads 0
+    // forever on a deploy whose fundingIncreaseFactorPerSecond is 0 — every run before
+    // deployer/vendor/gmx-localhost.patch gained funding parameters, and any run replayed from a
+    // state dump baked before it. Such a 0 means "this deploy has no funding", not "the book is
+    // balanced"; rebake the dump (`npm run gen:state-dump`) to get a real rate. The observation
+    // says which it is with fundingModeled; this row does not carry the flag, so the dashboard
+    // reads the same 0 either way.
+    const fields = gmxFundingFields({
+      openInterest: entry.oi.map((idx) => stage0[idx]) as (
+        bigint | undefined
+      )[],
       ...(typeof fundingRaw === "bigint"
-        ? {
-            fundingPerHourBps: round6(
-              (Number(fundingRaw) / 1e30) * 3600 * 10_000,
-            ),
-          }
+        ? { savedFundingFactorPerSecond: fundingRaw }
+        : {}),
+    });
+    if (fields.longOiUsd === undefined || fields.shortOiUsd === undefined)
+      continue;
+    gmx[entry.market.base] = {
+      longOiUsd: fields.longOiUsd,
+      shortOiUsd: fields.shortOiUsd,
+      ...(fields.fundingPerHourBps !== undefined
+        ? { fundingPerHourBps: fields.fundingPerHourBps }
         : {}),
     };
   }

--- a/example/agents/basis-arb/agent.ts
+++ b/example/agents/basis-arb/agent.ts
@@ -15,10 +15,14 @@
  *     That is why the hedge is checked *before* looking for a new opportunity: an unhedged delta is
  *     a risk the agent is already carrying, and a new opportunity is one it merely might take.
  *
- * The funding leg of issue #30 is not implemented: the deployment leaves fundingFactor and
- * borrowingFactor at zero, so there is no funding to harvest and no carry to price. Holding the
- * cheap side costs nothing and earns nothing. When the environment models funding, it belongs on
- * top of the hedge sizing below rather than as a separate strategy.
+ * The funding leg of issue #30 is wired but is not a carry trade (issue #78). The environment now
+ * models GMX funding and the observation carries the rate and the skew that sets it, so the hedge's
+ * carry is priced from what the venue actually charges instead of from a constant. What it is not
+ * is income: funding accrues on EVM time and EVM time is not warped here, so a 360-block epoch at
+ * 2s/block is twelve minutes and the deployed factor (~63%/yr at a 100% skew) accrues ~0.14bps of
+ * notional over all of it -- ~0.02bps at a realistic skew, against the 30bps the spot leg pays the
+ * pool. Holding the paid side to collect is not a strategy on this clock. What the number is good
+ * for is the sign on the cost gate and the skew it reveals.
  *
  * Baseline (what "delta-neutral" is measured against):
  *   The run hands every agent an inventory basket. That beta is not a position anyone chose, and
@@ -42,16 +46,17 @@
  *   ERIS_BASIS_HEDGE_LEVERAGE    perp size / collateral (default 2). The perp is liquidated on its
  *                                own numbers -- GMX cannot see that the spot leg offsets it.
  *   ERIS_BASIS_HEDGE_INVENTORY   "1" = also hedge the funded basket, not just what was acquired
+ *   ERIS_BASIS_BLOCK_SECONDS     seconds per block, for the funding rate conversion (default 2)
  */
 import type { AgentAction, AgentObservation } from "@eris/sdk";
 import { marketViews, type MarketView } from "../lib/markets.js";
 
 // Safety margin on top of the *measured* costs below, for what the cost model does not name.
 const SAFETY_BPS = Number(process.env.ERIS_BASIS_EDGE_BPS ?? "15");
-// The GMX round trip, in bps of notional. Read off the chain rather than assumed: the deployer
-// writes no market config beyond the oracle, so POSITION_FEE_FACTOR, POSITION_IMPACT_FACTOR,
-// FUNDING_FACTOR and BORROWING_FACTOR are all 0 in the DataStore. Opening and closing the perp
-// costs nothing but the execution fee, which is priced separately because it is flat.
+// The GMX round trip, in bps of notional. Read off the chain rather than assumed: POSITION_FEE_FACTOR
+// and POSITION_IMPACT_FACTOR are 0 in the DataStore, so opening and closing the perp costs nothing
+// but the execution fee, which is priced separately because it is flat. (FUNDING_FACTOR is no
+// longer 0 -- it is priced per block by fundingCarryBpsPerBlock, not here, because it is a rate.)
 const GMX_ROUNDTRIP_BPS = Number(process.env.ERIS_BASIS_GMX_COST_BPS ?? "0");
 // What one GMX order actually costs, in ETH. The order carries a 0.03 ETH execution fee, but
 // GasUtils.payExecutionFee pays the keeper only its gas and refunds the remainder, so almost none
@@ -197,15 +202,38 @@ type Quote = {
 /**
  * Funding carry on the side the hedge holds, in bps per block. Positive = the hedge is paid.
  *
- * Zero by construction today: the deployment leaves fundingFactor and borrowingFactor at 0, and
- * GmxObservation carries no funding or open-interest fields, so there is nothing to read. This is
- * the seam issue #30 asks for -- the one place to change when the environment models funding. It
- * feeds the cost gate, so a carry that pays the hedge lowers the edge needed to open a pair and one
- * that charges it raises the bar, which is what an FR signal has to do to be worth anything.
+ * The seam issue #30 asked for, now reading a real rate (issue #78). obs.protocols.gmx publishes
+ * fundingPerHourBps signed so that positive means longs pay shorts, so the hedge is paid whenever
+ * it sits on the thin side of the book. It feeds the cost gate: a carry that pays the hedge lowers
+ * the edge needed to open a pair, and one that charges it raises the bar.
+ *
+ * Three ways this returns 0, and only one of them is a measurement:
+ *   - the observed perp is flat: there is no side to be paid on. The gate runs before a leg is
+ *     chosen, so the sign the *next* hedge would carry is not known yet; charging a guessed one
+ *     would let the gate open a pair on a carry that never existed.
+ *   - fundingModeled === false: this deploy does not model funding at all (any state dump baked
+ *     before deployer/vendor/gmx-localhost.patch). The 0 says nothing about the book.
+ *   - the field is absent: the read failed. Not the same as a flat book either.
+ * All three are treated the same way -- charge nothing, credit nothing -- because on this clock the
+ * term is worth ~0.02bps over an epoch and guessing at it would be worse than dropping it.
  */
-function fundingCarryBpsPerBlock(): number {
-  return 0;
+export function fundingCarryBpsPerBlock(obs: AgentObservation): number {
+  const gmx = obs.protocols?.gmx;
+  if (!gmx || gmx.fundingModeled === false) return 0;
+  const perHourBps = gmx.fundingPerHourBps;
+  if (perHourBps === undefined || !Number.isFinite(perHourBps)) return 0;
+  const signedUsd = perpSignedUsd(obs);
+  if (signedUsd === 0) return 0;
+  // Positive rate = longs pay shorts, so a short is paid and a long pays.
+  const paid = signedUsd < 0 ? perHourBps : -perHourBps;
+  return (paid * BLOCK_SECONDS) / 3600;
 }
+
+// Seconds per block, for turning an hourly rate into a per-block one. The observation does not
+// carry the run's block time (nothing else needed it), so this mirrors run.blockTimeSec's default
+// and is overridable for a run configured otherwise. The conversion is not worth more precision
+// than that: the whole term is ~0.02bps over an epoch.
+const BLOCK_SECONDS = Number(process.env.ERIS_BASIS_BLOCK_SECONDS ?? "2");
 
 /**
  * What it costs to run this pair, in bps of the leg's notional, beyond the AMM quote.
@@ -218,7 +246,9 @@ function fundingCarryBpsPerBlock(): number {
  *   - the keeper delay: the hedge lands about two blocks after the AMM leg, and the fair price
  *     moves in between. Estimated from the run's own recent fair prices rather than assumed, so a
  *     quiet regime does not pay a volatile regime's premium
- *   - funding over the blocks the pair is expected to be held (0 today, see above)
+ *   - funding on the hedged side over the blocks between the legs. Signed: it subtracts when the
+ *     hedge sits on the paid side of the skew and adds when it sits on the crowded one. Tiny on
+ *     this clock (see fundingCarryBpsPerBlock) -- correctness, not edge
  */
 function costBps(
   obs: AgentObservation,
@@ -228,7 +258,7 @@ function costBps(
   const execBps =
     notionalUsd > 0 ? ((ORDER_COST_ETH * fair) / notionalUsd) * 10_000 : 0;
   const delayBps = keeperDelayBps(obs) * DELAY_MULT;
-  const carryBps = fundingCarryBpsPerBlock() * HEDGE_DELAY_BLOCKS;
+  const carryBps = fundingCarryBpsPerBlock(obs) * HEDGE_DELAY_BLOCKS;
   return GMX_ROUNDTRIP_BPS + execBps + delayBps - carryBps + SAFETY_BPS;
 }
 

--- a/example/agents/basis-arb/prompt.md
+++ b/example/agents/basis-arb/prompt.md
@@ -79,13 +79,15 @@ Three intervals where the right revision is none:
   code is wrong.
 - **Too little happened.** A handful of decisions and no gaps in the history is noise.
 
-Three more that are this strategy's own:
+Four more that are this strategy's own:
 
 - **The fair price moved and the strategy was carrying a hedge.** That is what the hedge is for.
 - **`protocols.gmx` is absent.** A run without the venue leaves no hedge instrument, and `noop` with
   a reason is the honest action, not an unhedged spot trade.
 - **Mostly hedge adjustments and few opportunities.** Read `HEDGE_TOL_USD` before the edge
   threshold: a band that is too tight spends the strategy's rounds on maintenance.
+- **The funding rate or the skew changed.** Both are now in the observation, and neither is worth a
+  revision on this clock — see "Funding is observable now" below for the magnitude.
 
 ## What you are shown, and where to look
 
@@ -142,6 +144,21 @@ the threshold is the failure mode that loses to a frozen strategy.
   than how wide the code assumes it is.
 - **The dust loop reads as many small settled trades.** If `MIN_LEG_USD` is too low the aggregate
   shows a high `sent` with a settled figure near zero.
+- **Funding is observable now, and it is not a trade.** `protocols.gmx` carries `longOiUsd` /
+  `shortOiUsd` (the skew) and `fundingPerHourBps` (the rate, positive when longs pay shorts), and
+  the position carries `fundingOwedUsd`. The cost model already reads the rate: it credits the hedge
+  when it sits on the thin side and charges it when it sits on the crowded one. **Do not build a
+  carry trade on top of it.** Funding accrues on EVM time and EVM time is not warped here, so a
+  360-block round is twelve minutes: a fully one-sided book pays ~0.14 bps of notional over all of
+  it, and a realistic skew ~0.02 bps, against the ~30 bps the AMM leg pays the pool. There is no
+  interval in which holding the paid side pays for a pool fee. Deciding *which side to hedge on*
+  from funding is the same mistake wearing a hat — the side is set by the delta the AMM leg created,
+  and that is invariant 1.
+- **A zero funding rate has two meanings and the observation tells them apart.**
+  `fundingModeled: false` means this deploy does not model funding at all (a state dump baked before
+  the environment gained funding parameters), so the 0 says nothing about the book. `true` with a 0
+  rate means the book is flat. An absent field means the read failed. None of the three is evidence
+  for a code change.
 
 ## Constraints
 

--- a/sdk/src/protocols/gmx.ts
+++ b/sdk/src/protocols/gmx.ts
@@ -22,6 +22,16 @@ import {
 } from "../markets.js";
 import { baseFairPrice } from "./marketHelpers.js";
 import {
+  gmxDataStoreReadAbi,
+  gmxFundingFeeAmount,
+  gmxFundingFeeAmountPerSizeKey,
+  gmxFundingFields,
+  gmxFundingIncreaseFactorKey,
+  gmxOpenInterestKey,
+  gmxSavedFundingKey,
+  type GmxFundingFields,
+} from "./gmxKeys.js";
+import {
   accountAddress,
   increaseTime,
   isExternalChain,
@@ -33,6 +43,7 @@ import {
 import type {
   AgentObservation,
   BalanceSnapshot,
+  GmxMarketObservation,
   GmxObservation,
   GmxPositionObservation,
   LeafAction,
@@ -406,6 +417,10 @@ type Position = {
     sizeInUsd: bigint;
     sizeInTokens: bigint;
     collateralAmount: bigint;
+    // The position's snapshot of the market's funding accumulator. Decoded by the ABI all along;
+    // named here since issue #78, because the difference against the market's current value is
+    // what the position has accrued.
+    fundingFeeAmountPerSize: bigint;
   };
   flags: { isLong: boolean };
 };
@@ -778,6 +793,195 @@ function gmxPositionObservation(
 }
 
 // ---------------------------------------------------------------------------
+// Funding / open interest (issue #78)
+//
+// GMX charges the crowded side and pays the thin one, and it publishes both the rate and the skew
+// that sets it in the DataStore. Until now none of that reached an agent: GmxObservation carried
+// the mark and the agent's own position, so a strategy hedging on this venue had to price its carry
+// at a constant. The keys are derived in the sdk (gmxKeys.ts) and read here at the same block as
+// the rest of the observation, so the agent and the post-run market series see one number.
+//
+// On magnitude, so nobody builds a carry trade on this: funding runs on EVM time, which is not
+// warped. At the deployed factor a whole 360-block epoch accrues ~0.14bps of notional on a fully
+// one-sided book and ~0.02bps at a realistic skew, against the 30bps a spot leg pays the pool. It
+// is a cost term and a skew signal, not income.
+
+// Market.Props is immutable for a deployment, so the long/short token lookup is resolved once per
+// process — the same treatment aave gives its reserve token addresses. Only successes are cached:
+// a market that has not resolved yet costs one read per block, and caching the miss instead would
+// silently drop funding for the rest of a run that merely observed a block too early.
+const marketPropsCache = new Map<string, MarketProps>();
+
+async function resolveMarketProps(
+  publicClient: PublicClient,
+  markets: readonly Address[],
+): Promise<Map<string, MarketProps>> {
+  const missing = markets.filter(
+    (m) => !marketPropsCache.has(m.toLowerCase()) && m !== zeroAddress,
+  );
+  if (missing.length > 0) {
+    const results = (await publicClient.multicall({
+      contracts: missing.map((market) => ({
+        address: GMX.Reader,
+        abi: readerAbi,
+        functionName: "getMarket",
+        args: [GMX.DataStore, market],
+      })) as never,
+      allowFailure: true,
+    })) as Array<{ status: "success" | "failure"; result?: unknown }>;
+    missing.forEach((market, i) => {
+      const r = results[i];
+      if (r?.status === "success")
+        marketPropsCache.set(market.toLowerCase(), r.result as MarketProps);
+    });
+  }
+  const out = new Map<string, MarketProps>();
+  for (const market of markets) {
+    const props = marketPropsCache.get(market.toLowerCase());
+    if (props) out.set(market.toLowerCase(), props);
+  }
+  return out;
+}
+
+/**
+ * Open interest, funding rate and whether this deploy models funding at all, per market.
+ *
+ * Reads never throw out of here. The observation is what an agent trades on every block, and a
+ * transport hiccup on a reporting field must not take the mark and the position down with it — the
+ * fields are simply absent, which is exactly what they mean (issue #44: a zero is a measurement).
+ */
+async function readMarketFunding(
+  publicClient: PublicClient,
+  markets: readonly Address[],
+): Promise<Map<string, GmxFundingFields>> {
+  const out = new Map<string, GmxFundingFields>();
+  let props: Map<string, MarketProps>;
+  try {
+    props = await resolveMarketProps(publicClient, markets);
+  } catch {
+    return out;
+  }
+  const layout: Array<{ market: Address; props: MarketProps }> = [];
+  for (const market of markets) {
+    const p = props.get(market.toLowerCase());
+    if (p) layout.push({ market, props: p });
+  }
+  if (layout.length === 0) return out;
+  // Six reads per market, in this order: the four open-interest cells, the saved funding factor,
+  // and the increase factor that says whether the saved one is even written.
+  const contracts = layout.flatMap(({ props: p }) => [
+    ...[
+      gmxOpenInterestKey(p.marketToken, p.longToken, true),
+      gmxOpenInterestKey(p.marketToken, p.shortToken, true),
+      gmxOpenInterestKey(p.marketToken, p.longToken, false),
+      gmxOpenInterestKey(p.marketToken, p.shortToken, false),
+    ].map((key) => ({
+      address: GMX.DataStore,
+      abi: gmxDataStoreReadAbi,
+      functionName: "getUint",
+      args: [key],
+    })),
+    {
+      address: GMX.DataStore,
+      abi: gmxDataStoreReadAbi,
+      functionName: "getInt",
+      args: [gmxSavedFundingKey(p.marketToken)],
+    },
+    {
+      address: GMX.DataStore,
+      abi: gmxDataStoreReadAbi,
+      functionName: "getUint",
+      args: [gmxFundingIncreaseFactorKey(p.marketToken)],
+    },
+  ]);
+  let results: Array<{ status: "success" | "failure"; result?: unknown }>;
+  try {
+    results = (await publicClient.multicall({
+      contracts: contracts as never,
+      allowFailure: true,
+    })) as Array<{ status: "success" | "failure"; result?: unknown }>;
+  } catch {
+    return out;
+  }
+  const value = (i: number): bigint | undefined => {
+    const r = results[i];
+    return r?.status === "success" && typeof r.result === "bigint"
+      ? r.result
+      : undefined;
+  };
+  layout.forEach(({ market }, i) => {
+    const at = i * 6;
+    const saved = value(at + 4);
+    const increase = value(at + 5);
+    out.set(
+      market.toLowerCase(),
+      gmxFundingFields({
+        openInterest: [value(at), value(at + 1), value(at + 2), value(at + 3)],
+        ...(saved !== undefined ? { savedFundingFactorPerSecond: saved } : {}),
+        ...(increase !== undefined
+          ? { fundingIncreaseFactorPerSecond: increase }
+          : {}),
+      }),
+    );
+  });
+  return out;
+}
+
+/**
+ * What each of the agent's open positions has accrued in funding, in USD, keyed by market.
+ *
+ * A second stage because the key needs the position's own (collateral, side) — but only when there
+ * is a position at all, so an agent holding no perp pays nothing for this.
+ */
+async function readPositionFundingOwed(
+  publicClient: PublicClient,
+  positions: readonly Position[],
+  wethPrice: number,
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const open = positions.filter((p) => p.numbers.sizeInUsd > 0n);
+  if (open.length === 0) return out;
+  let results: Array<{ status: "success" | "failure"; result?: unknown }>;
+  try {
+    results = (await publicClient.multicall({
+      contracts: open.map((p) => ({
+        address: GMX.DataStore,
+        abi: gmxDataStoreReadAbi,
+        functionName: "getUint",
+        args: [
+          gmxFundingFeeAmountPerSizeKey(
+            p.addresses.market,
+            p.addresses.collateralToken,
+            p.flags.isLong,
+          ),
+        ],
+      })) as never,
+      allowFailure: true,
+    })) as Array<{ status: "success" | "failure"; result?: unknown }>;
+  } catch {
+    return out;
+  }
+  open.forEach((p, i) => {
+    const r = results[i];
+    if (r?.status !== "success" || typeof r.result !== "bigint") return;
+    const amount = gmxFundingFeeAmount(
+      r.result,
+      p.numbers.fundingFeeAmountPerSize ?? 0n,
+      p.numbers.sizeInUsd,
+    );
+    // The fee is denominated in the position's collateral token.
+    const isWeth =
+      p.addresses.collateralToken.toLowerCase() ===
+      TOKENS.WETH.address.toLowerCase();
+    const usd = isWeth
+      ? (Number(amount) / 1e18) * wethPrice
+      : Number(amount) / 1e6;
+    out.set(p.addresses.market.toLowerCase(), usd);
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Historical-block reconstruction (ADR 0006 §4): the read descriptor used by the blockNumber-pinned
 // multicall, plus a pure function that derives position value from its result using the same formula as valueUsdc.
 // ---------------------------------------------------------------------------
@@ -882,30 +1086,61 @@ export const gmxAdapter: ProtocolAdapter = {
   },
 
   async observe(ctx, _state, agent, fairPrice): Promise<GmxObservation> {
-    const positions = await getAccountPositions(ctx.publicClient, agent);
+    const entries = gmxMarketEntries(ctx);
+    const wethPrice = baseFairPrice(ctx, "WETH", fairPrice);
+    // The venue state (skew, funding rate) rides the same block and the same batch as the
+    // positions: an agent comparing its own position against the book must not be told about the
+    // two at different blocks.
+    const [positions, funding] = await Promise.all([
+      getAccountPositions(ctx.publicClient, agent),
+      readMarketFunding(
+        ctx.publicClient,
+        entries.map((e) => e.market),
+      ),
+    ]);
+    const owed = await readPositionFundingOwed(
+      ctx.publicClient,
+      positions,
+      wethPrice,
+    );
+
+    const positionObs = (
+      pos: Position,
+      market: Address,
+      price: number,
+      base: TokenSymbol,
+    ): GmxPositionObservation => {
+      const fundingOwedUsd = owed.get(market.toLowerCase());
+      return {
+        ...gmxPositionObservation(pos, price, base),
+        ...(fundingOwedUsd !== undefined ? { fundingOwedUsd } : {}),
+      };
+    };
+
     // Keep the WETH (ETH/USD) market at the top level as before (byte-compatible).
     const wethMarketAddr = resolveGmxMarket(ctx, "WETH");
     const wethPos = positionForMarket(positions, wethMarketAddr);
     const obs: GmxObservation = {
       marketPriceUsd: fairPrice,
       ...(wethPos
-        ? { position: gmxPositionObservation(wethPos, fairPrice, "WETH") }
+        ? {
+            position: positionObs(wethPos, wethMarketAddr, fairPrice, "WETH"),
+          }
         : {}),
+      ...(funding.get(wethMarketAddr.toLowerCase()) ?? {}),
     };
 
     // Add non-WETH index markets (WBTC etc.) to markets. Empty on the default fork.
-    const extra: Record<
-      string,
-      { marketPriceUsd: number; position?: GmxPositionObservation }
-    > = {};
-    for (const { base, market } of gmxMarketEntries(ctx)) {
+    const extra: Record<string, GmxMarketObservation> = {};
+    for (const { base, market } of entries) {
       if (base === "WETH") continue;
       const price = baseFairPrice(ctx, base, fairPrice);
       const pos = positionForMarket(positions, market);
       const key = marketFor("gmx", base)?.key ?? `${base}/USDC`;
       extra[key] = {
         marketPriceUsd: price,
-        ...(pos ? { position: gmxPositionObservation(pos, price, base) } : {}),
+        ...(pos ? { position: positionObs(pos, market, price, base) } : {}),
+        ...(funding.get(market.toLowerCase()) ?? {}),
       };
     }
     if (Object.keys(extra).length > 0) obs.markets = extra;

--- a/sdk/src/protocols/gmxKeys.ts
+++ b/sdk/src/protocols/gmxKeys.ts
@@ -1,0 +1,202 @@
+// GMX DataStore key derivations, and the funding/open-interest fields they unlock (issue #78).
+//
+// Two readers want the same numbers at the same block and must not disagree:
+//   - the post-run market series (core/src/realtime/marketSeries.ts), which materializes GMX open
+//     interest and the funding rate into market.json for the dashboard, and
+//   - the agent-facing observation (sdk/src/protocols/gmx.ts `observe`), which is new here: the
+//     value existed on chain and in the report, and no agent could see it.
+// The derivations used to live privately in the reporter. `example -> sdk <- core` forbids the
+// adapter importing core, so the sdk is the only place both readers can reach -- which is the
+// reason this module exists rather than an export from either caller.
+//
+// Everything here is pure: keys in, keys out; raw reads in, observation fields out. The chain IO is
+// the caller's, because the two callers batch differently (a blockNumber-pinned Multicall3 after
+// the run, versus the agent's per-block batch).
+import { encodeAbiParameters, keccak256, type Address, type Hex } from "viem";
+
+// Keys.sol derivations (gmx-synthetics contracts/data/Keys.sol).
+function hashString(s: string): Hex {
+  return keccak256(encodeAbiParameters([{ type: "string" }], [s]));
+}
+
+const OPEN_INTEREST = hashString("OPEN_INTEREST");
+const SAVED_FUNDING_FACTOR_PER_SECOND = hashString(
+  "SAVED_FUNDING_FACTOR_PER_SECOND",
+);
+const FUNDING_INCREASE_FACTOR_PER_SECOND = hashString(
+  "FUNDING_INCREASE_FACTOR_PER_SECOND",
+);
+const FUNDING_FEE_AMOUNT_PER_SIZE = hashString("FUNDING_FEE_AMOUNT_PER_SIZE");
+
+/** Keys.openInterestKey: open interest in USD (30 decimals), per (market, collateral, side). */
+export function gmxOpenInterestKey(
+  market: Address,
+  collateralToken: Address,
+  isLong: boolean,
+): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        { type: "bytes32" },
+        { type: "address" },
+        { type: "address" },
+        { type: "bool" },
+      ],
+      [OPEN_INTEREST, market, collateralToken, isLong],
+    ),
+  );
+}
+
+/** Keys.savedFundingFactorPerSecondKey: int256, positive = longs pay shorts. */
+export function gmxSavedFundingKey(market: Address): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }],
+      [SAVED_FUNDING_FACTOR_PER_SECOND, market],
+    ),
+  );
+}
+
+/**
+ * Keys.fundingIncreaseFactorPerSecondKey: how fast adaptive funding ramps.
+ *
+ * Read only to tell two zeros apart. savedFundingFactorPerSecond is the *adaptive* funding path's
+ * stored state, and MarketUtils returns early without ever writing it when this factor is 0 -- so
+ * on a deploy without adaptive funding the saved rate reads 0 forever no matter how skewed the book
+ * is. That was every local deploy before deployer/vendor/gmx-localhost.patch gained funding
+ * parameters, and it is still true of any run replayed from a state dump baked before it.
+ */
+export function gmxFundingIncreaseFactorKey(market: Address): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: "bytes32" }, { type: "address" }],
+      [FUNDING_INCREASE_FACTOR_PER_SECOND, market],
+    ),
+  );
+}
+
+/**
+ * Keys.fundingFeeAmountPerSizeKey: the running per-size funding accumulator for the *paying* side.
+ *
+ * A position stores its own snapshot of this (Position.numbers.fundingFeeAmountPerSize); the
+ * difference against the latest value is what it has accrued since it was last touched.
+ */
+export function gmxFundingFeeAmountPerSizeKey(
+  market: Address,
+  collateralToken: Address,
+  isLong: boolean,
+): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        { type: "bytes32" },
+        { type: "address" },
+        { type: "address" },
+        { type: "bool" },
+      ],
+      [FUNDING_FEE_AMOUNT_PER_SIZE, market, collateralToken, isLong],
+    ),
+  );
+}
+
+/** The DataStore getters both readers use. Kept here so neither has to redeclare them. */
+export const gmxDataStoreReadAbi = [
+  {
+    type: "function",
+    name: "getUint",
+    stateMutability: "view",
+    inputs: [{ name: "key", type: "bytes32" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getInt",
+    stateMutability: "view",
+    inputs: [{ name: "key", type: "bytes32" }],
+    outputs: [{ type: "int256" }],
+  },
+] as const;
+
+/**
+ * Raw DataStore reads for one market. `undefined` means the read failed, which is not the same as
+ * a zero -- see gmxFundingFields.
+ */
+export type GmxFundingReads = {
+  // OPEN_INTEREST for the four (side, collateral) cells, in this order:
+  // [long/longToken, long/shortToken, short/longToken, short/shortToken].
+  openInterest?: readonly (bigint | undefined)[];
+  savedFundingFactorPerSecond?: bigint;
+  fundingIncreaseFactorPerSecond?: bigint;
+};
+
+export type GmxFundingFields = {
+  longOiUsd?: number;
+  shortOiUsd?: number;
+  // savedFundingFactorPerSecond expressed per hour, in bps of notional. Positive = longs pay shorts.
+  fundingPerHourBps?: number;
+  // Whether this deploy models funding at all (adaptive funding enabled for the market).
+  fundingModeled?: boolean;
+};
+
+// GMX carries USD at 30 decimals.
+const USD_1E30 = 1e30;
+const SECONDS_PER_HOUR = 3600;
+
+/**
+ * Decode the reads into observation/report fields.
+ *
+ * Every field is *absent* when its read failed rather than 0: a zero funding rate is a measurement
+ * ("the book is balanced") and must not be forgeable by a dropped read (issue #44's discipline).
+ * fundingModeled carries the other half of that distinction — a real 0 from a deploy that models
+ * funding means the skew is flat, and a 0 from one that does not means the venue has no funding.
+ */
+export function gmxFundingFields(reads: GmxFundingReads): GmxFundingFields {
+  const out: GmxFundingFields = {};
+  const oi = reads.openInterest;
+  if (oi && oi.length === 4 && oi.every((v) => typeof v === "bigint")) {
+    const [longA, longB, shortA, shortB] = oi as bigint[];
+    out.longOiUsd = round2(Number(longA + longB) / USD_1E30);
+    out.shortOiUsd = round2(Number(shortA + shortB) / USD_1E30);
+  }
+  if (typeof reads.savedFundingFactorPerSecond === "bigint")
+    out.fundingPerHourBps = round6(
+      (Number(reads.savedFundingFactorPerSecond) / USD_1E30) *
+        SECONDS_PER_HOUR *
+        10_000,
+    );
+  if (typeof reads.fundingIncreaseFactorPerSecond === "bigint")
+    out.fundingModeled = reads.fundingIncreaseFactorPerSecond > 0n;
+  return out;
+}
+
+// MarketUtils.getFundingAmount stores the per-size accumulators scaled by
+// FLOAT_PRECISION * FLOAT_PRECISION_SQRT = 1e30 * 1e15.
+const FUNDING_PER_SIZE_PRECISION = 10n ** 45n;
+
+/**
+ * What a position has accrued since its snapshot, in units of its collateral token.
+ *
+ * Positive = owed by the position. Only the crowded side accumulates here; the paid side's credit
+ * goes to the claimable-funding accumulators, which are separate keys and are not read (a position
+ * on the paid side therefore reads 0, not a negative). GMX rounds this up when it charges — a user
+ * must not be able to dodge the fee by touching the position — and down when it credits; the
+ * truncation here is immaterial because this is a report, not a charge.
+ */
+export function gmxFundingFeeAmount(
+  latestPerSize: bigint,
+  positionPerSize: bigint,
+  sizeInUsd: bigint,
+): bigint {
+  if (latestPerSize <= positionPerSize) return 0n;
+  return (
+    (sizeInUsd * (latestPerSize - positionPerSize)) / FUNDING_PER_SIZE_PRECISION
+  );
+}
+
+function round2(v: number): number {
+  return Math.round(v * 100) / 100;
+}
+
+function round6(v: number): number {
+  return Math.round(v * 1e6) / 1e6;
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -538,16 +538,41 @@ export type GmxPositionObservation = {
   collateralAmount: string;
   entryPriceUsd: number;
   pnlUsd: number;
+  // Funding this position has accrued since it was last touched, in USD, as a *cost*: positive
+  // means it owes that much. Only the crowded side accrues here — GMX credits the paid side
+  // through separate claimable accumulators, which are not read — so a 0 on the paid side is not
+  // a statement that funding is zero. Absent when the read failed (issue #78).
+  fundingOwedUsd?: number;
 };
 
-export type GmxObservation = {
+// One GMX market as an agent sees it: the mark, its own position, and the venue-wide state that
+// decides who pays whom (issue #78).
+export type GmxMarketObservation = {
   marketPriceUsd: number;
   position?: GmxPositionObservation;
+  // Open interest on each side, USD. The skew between them is what sets the funding rate's sign
+  // and size, and it is public state no agent could see before.
+  longOiUsd?: number;
+  shortOiUsd?: number;
+  // The current funding rate per hour, in bps of notional. Positive = longs pay shorts.
+  //
+  // Read the magnitude before building anything on it: funding runs on EVM time and EVM time is
+  // not warped here, so a 360-block epoch at 2s/block is 12 minutes. At the deployed factor
+  // (2e-8/s, ~63%/yr at a 100% skew) that is 0.14bps of notional over a whole epoch on a
+  // one-sided book, and ~0.02bps at a realistic skew — three orders of magnitude under the 30bps
+  // pool fee a spot leg pays. It is a cost/credit term and a skew signal, not a carry to harvest.
+  fundingPerHourBps?: number;
+  // Whether this deploy models funding at all. `false` means the rate is structurally 0 (adaptive
+  // funding disabled) and reads nothing about the book; `true` with a 0 rate means the book is
+  // flat. Absent means the read failed. Without this the two zeros are indistinguishable, and a
+  // strategy — or the revision loop — would draw the wrong conclusion from a pre-funding state
+  // dump.
+  fundingModeled?: boolean;
+};
+
+export type GmxObservation = GmxMarketObservation & {
   // ADR 0013: non-WETH index markets (BTC/USD etc.).
-  markets?: Record<
-    string,
-    { marketPriceUsd: number; position?: GmxPositionObservation }
-  >;
+  markets?: Record<string, GmxMarketObservation>;
 };
 
 export type AaveObservation = {

--- a/test/gmxFunding.test.ts
+++ b/test/gmxFunding.test.ts
@@ -1,0 +1,205 @@
+// GMX funding and open interest, from the DataStore key to the strategy that prices it (issue #78).
+//
+// The environment has charged funding since deployer/vendor/gmx-localhost.patch, and the post-run
+// market series has reported it, but no agent could see it. These pin the three things that made
+// the value trustworthy once it reached the observation: the keys are the ones Keys.sol derives, a
+// failed read is absent rather than zero, and a zero rate from a deploy without funding is
+// distinguishable from a zero rate on a balanced book.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Address } from "viem";
+import {
+  gmxFundingFeeAmount,
+  gmxFundingFeeAmountPerSizeKey,
+  gmxFundingFields,
+  gmxFundingIncreaseFactorKey,
+  gmxOpenInterestKey,
+  gmxSavedFundingKey,
+} from "@eris/sdk/protocols/gmxKeys.js";
+import { fundingCarryBpsPerBlock } from "../example/agents/basis-arb/agent.js";
+import type { AgentObservation, GmxObservation } from "@eris/sdk/types.js";
+
+const MARKET = "0x1111111111111111111111111111111111111111" as Address;
+const COLLATERAL = "0x2222222222222222222222222222222222222222" as Address;
+
+// GMX carries USD at 30 decimals.
+const usd30 = (usd: number) => BigInt(Math.round(usd)) * 10n ** 30n;
+
+// ---------------------------------------------------------------------------
+// keys
+
+test("gmxOpenInterestKey matches the Keys.sol derivation", () => {
+  // Expected values computed independently with `cast keccak` / `cast abi-encode`
+  // over gmx-synthetics contracts/data/Keys.sol's formula.
+  assert.equal(
+    gmxOpenInterestKey(MARKET, COLLATERAL, true),
+    "0xe9b069bb2833eb4c6757fe3e2aec8f60b75f0f7a3b89a787f90542c579dd5e0b",
+  );
+});
+
+test("the funding keys are distinct per market, per side and per accumulator", () => {
+  // Not a hash fixture: what would actually break is two keys colliding or a side being ignored,
+  // which is exactly what reading the wrong cell of the DataStore looks like from the outside.
+  const keys = [
+    gmxSavedFundingKey(MARKET),
+    gmxFundingIncreaseFactorKey(MARKET),
+    gmxFundingFeeAmountPerSizeKey(MARKET, COLLATERAL, true),
+    gmxFundingFeeAmountPerSizeKey(MARKET, COLLATERAL, false),
+    gmxOpenInterestKey(MARKET, COLLATERAL, true),
+    gmxOpenInterestKey(MARKET, COLLATERAL, false),
+  ];
+  assert.equal(new Set(keys).size, keys.length);
+  // A different market must not read another market's state.
+  assert.notEqual(
+    gmxSavedFundingKey(MARKET),
+    gmxSavedFundingKey(COLLATERAL as Address),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// decode
+
+test("the fields are present and correctly signed on a deploy with funding", () => {
+  // The measured skew from the 485-block run that showed funding was structurally zero:
+  // 74,651 USD long against 54,752 short, all of it collateralized in the short token.
+  const fields = gmxFundingFields({
+    openInterest: [0n, usd30(74_651), 0n, usd30(54_752)],
+    // 2e-8 per second (the deployed factor at a 100% skew) as a 30-decimal fraction.
+    savedFundingFactorPerSecond: 20_000_000_000_000_000_000_000n,
+    fundingIncreaseFactorPerSecond: 1n,
+  });
+  assert.equal(fields.longOiUsd, 74_651);
+  assert.equal(fields.shortOiUsd, 54_752);
+  assert.equal(fields.fundingModeled, true);
+  // 2e-8/s * 3600 s * 1e4 bps = 0.72 bps per hour. Over a 12-minute epoch that is 0.144 bps of
+  // notional -- the magnitude that keeps this a cost term rather than a carry trade.
+  assert.equal(fields.fundingPerHourBps, 0.72);
+  assert.ok((fields.fundingPerHourBps ?? 0) * 0.2 < 0.15);
+});
+
+test("a negative saved factor keeps its sign: shorts pay longs", () => {
+  const fields = gmxFundingFields({
+    openInterest: [0n, usd30(10_000), 0n, usd30(40_000)],
+    savedFundingFactorPerSecond: -20_000_000_000_000_000_000_000n,
+    fundingIncreaseFactorPerSecond: 1n,
+  });
+  assert.equal(fields.fundingPerHourBps, -0.72);
+  // ...and the sign agrees with the skew that produced it: the short side is the crowded one.
+  assert.ok((fields.shortOiUsd ?? 0) > (fields.longOiUsd ?? 0));
+});
+
+test("a failed read leaves the field absent, never 0", () => {
+  const noFunding = gmxFundingFields({
+    openInterest: [0n, usd30(1_000), 0n, usd30(1_000)],
+  });
+  assert.equal(noFunding.longOiUsd, 1_000);
+  assert.ok(!("fundingPerHourBps" in noFunding));
+  assert.ok(!("fundingModeled" in noFunding));
+
+  // One failed OI cell drops the whole skew: half a skew is not a smaller skew, it is a wrong one.
+  const noOi = gmxFundingFields({
+    openInterest: [0n, usd30(1_000), undefined, usd30(1_000)],
+    savedFundingFactorPerSecond: 0n,
+  });
+  assert.ok(!("longOiUsd" in noOi));
+  assert.ok(!("shortOiUsd" in noOi));
+  assert.equal(noOi.fundingPerHourBps, 0);
+
+  // Nothing read at all is every field absent, not a zeroed venue.
+  assert.deepEqual(gmxFundingFields({}), {});
+});
+
+test("a pre-patch state dump reports fundingModeled: false, not a balanced book", () => {
+  // What every deploy looked like before the localhost market config gained funding parameters:
+  // a skewed book, and savedFundingFactorPerSecond stuck at 0 because MarketUtils never writes it
+  // when fundingIncreaseFactorPerSecond is 0.
+  const fields = gmxFundingFields({
+    openInterest: [0n, usd30(74_651), 0n, usd30(54_752)],
+    savedFundingFactorPerSecond: 0n,
+    fundingIncreaseFactorPerSecond: 0n,
+  });
+  assert.equal(fields.fundingPerHourBps, 0);
+  assert.equal(fields.fundingModeled, false);
+  // The skew is real and the rate is not. That pair is the whole point of the flag: without it a
+  // reader would conclude from `0` that the book was flat, with 20k USD of skew sitting next to it.
+  assert.notEqual(fields.longOiUsd, fields.shortOiUsd);
+});
+
+test("the position's accrued funding is the per-size delta scaled by 1e45", () => {
+  // MarketUtils.getFundingAmount: sizeInUsd * (latest - snapshot) / (FLOAT_PRECISION *
+  // FLOAT_PRECISION_SQRT) = /1e45. A 10,000 USD position (1e34) against a per-size delta of 1e18
+  // owes 1e7 collateral units -- 10 USDC, since the fee is denominated in the collateral token.
+  const size = usd30(10_000);
+  assert.equal(gmxFundingFeeAmount(10n ** 18n, 0n, size), 10n ** 7n);
+  // Nothing accrued since the snapshot.
+  assert.equal(gmxFundingFeeAmount(10n ** 18n, 10n ** 18n, size), 0n);
+  // The paid side never accumulates here (its credit goes to the claimable keys), so a snapshot
+  // above the latest value is a floor at zero rather than a negative fee.
+  assert.equal(gmxFundingFeeAmount(0n, 10n ** 18n, size), 0n);
+});
+
+// ---------------------------------------------------------------------------
+// basis-arb's carry term
+
+function obsWith(gmx: GmxObservation | undefined): AgentObservation {
+  // Only the fields fundingCarryBpsPerBlock reads; an AgentObservation carries thirty more that
+  // would be noise here.
+  return { protocols: gmx ? { gmx } : {} } as unknown as AgentObservation;
+}
+
+const shortPosition = {
+  isLong: false,
+  sizeUsd: (10_000n * 10n ** 30n).toString(),
+  sizeInTokens: "0",
+  collateral: "USDC" as const,
+  collateralAmount: "0",
+  entryPriceUsd: 3000,
+  pnlUsd: 0,
+};
+const longPosition = { ...shortPosition, isLong: true };
+
+test("the carry credits a hedge on the thin side and charges one on the crowded side", () => {
+  const rate = { marketPriceUsd: 3000, fundingPerHourBps: 0.72 };
+  // Positive rate = longs pay shorts, so the short hedge is paid.
+  const short = fundingCarryBpsPerBlock(
+    obsWith({ ...rate, fundingModeled: true, position: shortPosition }),
+  );
+  const long = fundingCarryBpsPerBlock(
+    obsWith({ ...rate, fundingModeled: true, position: longPosition }),
+  );
+  assert.ok(short > 0, "a short hedge is paid when longs pay shorts");
+  assert.equal(long, -short);
+  // 0.72 bps/hour at 2s blocks = 0.0004 bps per block. Over the two-block hedge delay the cost
+  // model charges 0.0008 bps -- which is the point: it has the right sign and no weight.
+  assert.ok(Math.abs(short - 0.0004) < 1e-9);
+});
+
+test("the carry is zero whenever the rate is not a measurement", () => {
+  const withPos = (extra: Partial<GmxObservation>) =>
+    fundingCarryBpsPerBlock(
+      obsWith({
+        marketPriceUsd: 3000,
+        position: shortPosition,
+        ...extra,
+      } as GmxObservation),
+    );
+  // A deploy that does not model funding: the 0 rate says nothing about the book.
+  assert.equal(withPos({ fundingPerHourBps: 0, fundingModeled: false }), 0);
+  // ...and neither does a nonzero rate read off such a deploy, if one ever appeared.
+  assert.equal(withPos({ fundingPerHourBps: 0.72, fundingModeled: false }), 0);
+  // A failed read.
+  assert.equal(withPos({ fundingModeled: true }), 0);
+  // The venue is not in this run at all.
+  assert.equal(fundingCarryBpsPerBlock(obsWith(undefined)), 0);
+  // A flat perp has no side to be paid on, so there is no carry to price yet.
+  assert.equal(
+    fundingCarryBpsPerBlock(
+      obsWith({
+        marketPriceUsd: 3000,
+        fundingPerHourBps: 0.72,
+        fundingModeled: true,
+      }),
+    ),
+    0,
+  );
+});

--- a/test/marketSeries.test.ts
+++ b/test/marketSeries.test.ts
@@ -3,10 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { Address } from "viem";
 import { TOKENS } from "@eris/sdk/constants.js";
-import {
-  gmxOpenInterestKey,
-  summarizeTransfers,
-} from "../core/src/realtime/marketSeries.js";
+import { summarizeTransfers } from "../core/src/realtime/marketSeries.js";
 
 const AGENT = "0x00000000000000000000000000000000000a9e17" as Address;
 const OTHER = "0x000000000000000000000000000000000000beef" as Address;
@@ -19,18 +16,8 @@ const FAIR = { WETH: 3000 };
 const weth = (units: number) => BigInt(Math.round(units * 1e6)) * 10n ** 12n;
 const usdc = (units: number) => BigInt(Math.round(units * 1e6));
 
-test("gmxOpenInterestKey matches the Keys.sol derivation", () => {
-  // Expected values computed independently with `cast keccak` / `cast abi-encode`
-  // over deployer/vendor/gmx-src/contracts/data/Keys.sol's formula.
-  assert.equal(
-    gmxOpenInterestKey(
-      "0x1111111111111111111111111111111111111111",
-      "0x2222222222222222222222222222222222222222",
-      true,
-    ),
-    "0xe9b069bb2833eb4c6757fe3e2aec8f60b75f0f7a3b89a787f90542c579dd5e0b",
-  );
-});
+// The GMX DataStore key derivations moved to the sdk (issue #78); they are covered by
+// test/gmxFunding.test.ts, alongside the funding fields that read them.
 
 test("summarizeTransfers: a sell swap reports side/base and the larger leg in USD", () => {
   const notional = summarizeTransfers({


### PR DESCRIPTION
## Summary
Fixes #78.

Expose GMX funding/OI on GmxObservation, wire basis-arb carry, include fundingOwedUsd.

## TODO
- gen:state-dump on a35cf3e deploy
- calm live validation follow-up
