### PR TITLE
coordinator: the epoch clock waits for the field, and V_0 marks every base (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,6 +680,14 @@ phantom value そのもの）。issue #27 でこれを 3 段階で外した:
 
 - **fair price はオンチェーン配布**（`contracts/PriceFeed.sol`。読取は `sdk/src/priceFeed.ts`、書込は
   `core/src/realtime/priceFeed.ts`）。書込 tx は次ブロック着弾なので情報は 1 ブロック遅れる（全員等しく作用。仕様）。
+  **全 base の開始 fair は setup で feed に載せる**（issue #94）。constructor は WETH だけで、WBTC は最初の
+  oracle tx（= 最初の境界の 1 ブロック後）で初めて載っていたので、V_0 が全員 WBTC 分（バスケットで 24k）短く
+  noop の `netPnlUsdc` が 0 にならなかった。`ctx.fairPrices` も同じ場所で確定するので whale endowment /
+  `initial_endowment` / Aave の WBTC aggregator 較正も全 base を見る。OU の walk はその値から始まる
+- **エポックの時計は場が揃うまで待つ**（issue #94 / #91 F5。`core/src/realtime/agentsReady.ts`）。automine を
+  切った後・interval mining の前に、起動した全 agent の `runtime_start` を `run.agentsReadyTimeoutSec`
+  （既定 60 秒、0 = 待たない）まで待ち `agents_ready` に ready/late/exited を残す。実測 docker 32 体で
+  `runtime_start` は +86〜99 秒なので、その検証では上げる。外部参加者は待たない
 - **採点は run 後再構成**（`core/src/realtime/reconstruct.ts`）: blockNumber 指定の Multicall3 で全 agent 同一断面の
   価値系列を events.jsonl に observation 形で書く（`runs/<id>/summary.json` に集計）。
   resetFork で歴史が消えるため**次 run の前に必ず再構成を終える**（anvil の保持深度 ~1,050 ブロックに注意）。

--- a/core/src/realtime/agentsReady.ts
+++ b/core/src/realtime/agentsReady.ts
@@ -1,0 +1,124 @@
+// The epoch clock waits for the field (issue #94, decided 2026-09-07 from #91 F5).
+//
+// The coordinator spawns the agent processes and used to switch to interval mining without
+// waiting for any of them. Measured 2026-09-07 with 32 docker agents on a saturated Docker Desktop
+// VM: `interval_mining_started` at +24 s, the agents' `runtime_start` at +86..99 s. The first ~45
+// blocks of a 360-block epoch went by with nobody watching, V_0 was marked at a boundary no agent
+// had observed, and a stress window planned at windowFrac 0.10 (block 36) opened before the field
+// existed -- so a hand check of that regime records "no agent reacted" for the environment's own
+// doing. Every agent misses the same blocks, so T is untouched; what is lost is the record. And a
+// participant whose container boots slower than the rest loses blocks that nothing writes down.
+//
+// So the run waits: every agent the coordinator started has to have written `runtime_start` to its
+// own log -- the line runtime/bot.ts writes once the preflight passed, the venue approvals are in
+// place and the block watcher is armed, i.e. everything that precedes its first observation --
+// before mining starts. Bounded, so a participant that never comes up cannot hold the epoch
+// hostage; who was ready when, who was still booting at the bound, and who had already exited are
+// on the record as `agents_ready`.
+//
+// Pure with respect to the chain: it reads files and a clock, both supplied by the coordinator.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const RUNTIME_START_EVENT = "runtime_start";
+
+export type ReadyProbe = {
+  id: string;
+  /** False once the process is known to be gone: nothing more will be written, so nothing to wait for. */
+  isAlive: () => boolean;
+};
+
+export type AgentsReadyReport = {
+  /** How long the wait held the clock. */
+  waitedMs: number;
+  timeoutMs: number;
+  /** Every agent that wrote `runtime_start`, with how long after the spawn it took. */
+  ready: Array<{ id: string; afterMs: number }>;
+  /** Alive at the bound but still without `runtime_start`: the epoch starts without them watching. */
+  late: string[];
+  /** Exited before writing `runtime_start` (preflight refusal, spawn error): not waited for. */
+  exited: string[];
+  /** True when the bound was reached with at least one agent still booting. */
+  timedOut: boolean;
+};
+
+// Path the runtime writes to: runs/<id>/agents/<agentId>.jsonl (example/agents/runtime/agentLog.ts).
+export function agentLogPath(runDir: string, agentId: string): string {
+  return join(runDir, "agents", `${agentId}.jsonl`);
+}
+
+// Whether the agent's log holds a `runtime_start` line. The file is a handful of lines at this
+// point, and the substring check keeps the common negative (no file yet, or preflight lines only)
+// from parsing anything. A line that merely mentions the word -- an error message quoting it --
+// is parsed and rejected rather than counted.
+export function agentLogHasRuntimeStart(file: string): boolean {
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return false;
+  }
+  if (!text.includes(RUNTIME_START_EVENT)) return false;
+  for (const line of text.split("\n")) {
+    if (!line.includes(RUNTIME_START_EVENT)) continue;
+    try {
+      const parsed = JSON.parse(line) as { event?: unknown };
+      if (parsed.event === RUNTIME_START_EVENT) return true;
+    } catch {
+      // a partial last line while the agent is mid-write; the next poll reads it whole
+    }
+  }
+  return false;
+}
+
+export async function waitForAgentsReady(opts: {
+  agents: ReadyProbe[];
+  runDir: string;
+  /** When the processes were spawned; `ready[].afterMs` is measured from here. */
+  spawnedAt: number;
+  timeoutMs: number;
+  pollMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<AgentsReadyReport> {
+  const now = opts.now ?? Date.now;
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const pollMs = opts.pollMs ?? 250;
+  const startedAt = now();
+  const deadline = startedAt + opts.timeoutMs;
+  const ready = new Map<string, number>();
+  const exited = new Set<string>();
+  const pending = new Set(opts.agents.map((a) => a.id));
+  const byId = new Map(opts.agents.map((a) => [a.id, a]));
+
+  const poll = (): void => {
+    for (const id of [...pending]) {
+      const agent = byId.get(id);
+      if (!agent) continue;
+      if (agentLogHasRuntimeStart(agentLogPath(opts.runDir, id))) {
+        ready.set(id, now() - opts.spawnedAt);
+        pending.delete(id);
+      } else if (!agent.isAlive()) {
+        // Checked after the log, not before: a process that wrote its line and then died is
+        // still one that was up when the clock started.
+        exited.add(id);
+        pending.delete(id);
+      }
+    }
+  };
+
+  poll();
+  while (pending.size > 0 && now() < deadline) {
+    await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
+    poll();
+  }
+  return {
+    waitedMs: now() - startedAt,
+    timeoutMs: opts.timeoutMs,
+    ready: [...ready].map(([id, afterMs]) => ({ id, afterMs })),
+    late: [...pending],
+    exited: [...exited],
+    timedOut: pending.size > 0,
+  };
+}

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -84,10 +84,13 @@ import {
 import { FlowProcess, type FlowOrderWire } from "../flowProcess.js";
 import { deployFlashArb, FLASH_ARB_ADDRESS } from "../flashArbDemo.js";
 import { RealtimeAgentProcess } from "./agentProcess.js";
+import { waitForAgentsReady } from "./agentsReady.js";
 import { agentStateRootFromEnv, prepareAgentState } from "./agentState.js";
 import { RealtimeFlowProcess } from "./flowProcess.js";
 import {
   deployPriceFeed,
+  setPriceFeedOpening,
+  setPriceFeedOpeningFor,
   updatePriceFeedForMempool,
   updatePriceFeedMempool,
   writePriceFeedStorage,
@@ -912,6 +915,22 @@ export async function runRealtimeSimulation(
     // The initial fair price is finalized here (used by the local oracle calibration and victim setup below).
     latestFairPrice = await initialFairPrice(ctx, enabledIds);
 
+    // Every other base's opening fair, settled here with WETH's rather than after mining starts
+    // (issue #94). Until this existed the extra bases were first read after `interval_mining_started`,
+    // so everything between here and the first block that valued a holding through
+    // `ctx.fairPrices ?? {}` saw WETH only: the Aave calibration below (the WBTC aggregator kept the
+    // deployer's seed price until the first oracle tx), the whale's endowment, `initial_endowment`,
+    // and -- the one that reached the score -- the PriceFeed's opening state, which is what the
+    // first epoch boundary marks V_0 against. `openingFair` is the number every one of those reads,
+    // and the OU walk in the block loop starts from it, so the mark and the walk agree.
+    const extraBaseSymbols = baseTokens()
+      .map((t) => t.symbol)
+      .filter((s) => s !== "WETH");
+    const openingFair: Record<string, number> = { WETH: latestFairPrice };
+    for (const b of extraBaseSymbols)
+      openingFair[b] = await initialFairPriceFor(ctx, b, enabledIds);
+    ctx.fairPrices = { ...openingFair };
+
     // [Calibration] Local deploy aligns the Aave oracle to the run's initial fair price. On a fork,
     // "oracle ≈ spot ≈ fair0" holds implicitly, but locally the deployer's seed price and fair0 can diverge (a
     // miscalibration measured where a victim's HF0 breaks at run start and it becomes liquidatable before the
@@ -1073,8 +1092,22 @@ export async function runRealtimeSimulation(
     }
 
     // ---- On-chain distribution path for the fair price (ADR 0006 §3). Kept permanent and written every block ----
+    // The constructor carries WETH's opening fair; the other bases are written right behind it,
+    // before the first boundary is marked (issue #94 -- see setPriceFeedOpeningFor for what V_0
+    // looked like when they were left to the first per-block oracle tx).
     const priceFeedAddress = await deployPriceFeed(ctx, latestFairPrice);
-    logger.event({ type: "price_feed_deployed", address: priceFeedAddress });
+    for (const b of extraBaseSymbols)
+      await setPriceFeedOpeningFor(
+        ctx,
+        priceFeedAddress,
+        tokenInfo(b).address,
+        openingFair[b],
+      );
+    logger.event({
+      type: "price_feed_deployed",
+      address: priceFeedAddress,
+      openingFair,
+    });
 
     // ---- agent-created markets (issue #40): the discovery registry and the lending singleton ----
     // Both are per-*run* contracts, like the PriceFeed: they are deployed here rather than living in
@@ -1297,8 +1330,26 @@ export async function runRealtimeSimulation(
         logger.runDir,
       );
       // Re-read the fair price to match the competition's starting point (reflects pools moved during warmup).
+      // And put the re-read numbers on the PriceFeed: the values written at deploy predate the
+      // warmup's trading, and the first boundary is marked against the feed (issue #94).
       latestFairPrice = await initialFairPrice(ctx, enabledIds);
-      logger.event({ type: "prewarm_completed", blocks: config.prewarmBlocks });
+      openingFair.WETH = latestFairPrice;
+      await setPriceFeedOpening(ctx, priceFeedAddress, latestFairPrice);
+      for (const b of extraBaseSymbols) {
+        openingFair[b] = await initialFairPriceFor(ctx, b, enabledIds);
+        await setPriceFeedOpeningFor(
+          ctx,
+          priceFeedAddress,
+          tokenInfo(b).address,
+          openingFair[b],
+        );
+      }
+      ctx.fairPrices = { ...openingFair };
+      logger.event({
+        type: "prewarm_completed",
+        blocks: config.prewarmBlocks,
+        openingFair,
+      });
     }
 
     // ---- LST venue (issue #38): align the deployed vault with this run's economic clock, and
@@ -1623,6 +1674,8 @@ export async function runRealtimeSimulation(
         );
       };
     }
+    // What `agents_ready` measures boot time from (issue #94).
+    const agentsSpawnedAt = Date.now();
 
     // ---- flow order handler: relay the bot's orders to the mempool via the flow wallets ----
     const handleFlowOrders = async (orders: FlowOrderWire[]): Promise<void> => {
@@ -1779,6 +1832,60 @@ export async function runRealtimeSimulation(
     if (config.localDeploy && !external) {
       await setAutomine(publicClient, false);
     }
+
+    // ---- the epoch clock waits for the field (issue #94; #91 F5) ----
+    // From here to interval mining no block is produced on anvil, and on an external chain the
+    // sequencer's blocks precede runStartBlock -- either way the epoch's first block, its first
+    // boundary (V_0) and its first stress window wait until every agent this coordinator launched
+    // has written `runtime_start`, bounded by run.agentsReadyTimeoutSec. Nothing an agent does
+    // before that line needs a new block: the preflight only reads, and the venue approvals were
+    // granted at funding (an agent that still has to send one mines its own on anvil). External
+    // participants are not waited for: nothing here started them. See agentsReady.ts.
+    {
+      const launched = agentRuntimes.filter((a) => a.process !== null);
+      if (launched.length > 0 && config.agentsReadyTimeoutSec > 0) {
+        console.error(
+          `[agents] waiting for ${launched.length} agent(s) to write runtime_start ` +
+            `before the first block (bound ${config.agentsReadyTimeoutSec} s)`,
+        );
+        const report = await waitForAgentsReady({
+          agents: launched.map((a) => ({
+            id: a.id,
+            isAlive: () =>
+              a.exitedEarly === undefined && (a.process?.isAlive() ?? false),
+          })),
+          runDir: logger.runDir,
+          spawnedAt: agentsSpawnedAt,
+          timeoutMs: config.agentsReadyTimeoutSec * 1000,
+        });
+        logger.event({
+          type: "agents_ready",
+          ...report,
+          launched: launched.length,
+          note: report.timedOut
+            ? "the bound was reached with agents still booting: the epoch starts without them " +
+              "watching, and the blocks they miss are on their own account"
+            : report.exited.length > 0
+              ? "every agent still running wrote runtime_start before the first block; the " +
+                "exited ones are in agent_process_exited"
+              : "every launched agent wrote runtime_start before the first block",
+        });
+        const slowest = report.ready.reduce(
+          (m, r) => Math.max(m, r.afterMs),
+          0,
+        );
+        console.error(
+          `[agents] ${report.ready.length}/${launched.length} ready ` +
+            `(slowest ${(slowest / 1000).toFixed(1)} s after spawn, waited ${(report.waitedMs / 1000).toFixed(1)} s)` +
+            (report.late.length > 0
+              ? `; still booting at the ${config.agentsReadyTimeoutSec} s bound: ${report.late.join(", ")}`
+              : "") +
+            (report.exited.length > 0
+              ? `; exited before runtime_start: ${report.exited.join(", ")}`
+              : ""),
+        );
+      }
+    }
     if (external) {
       // The sequencer has been producing blocks the whole time; there is no phase change to make.
       // What the environment does have to know is the real cadence, because the block loop's
@@ -1821,17 +1928,16 @@ export async function runRealtimeSimulation(
     const fairAnchor = baseFair;
     // ADR 0013: independent OU prices for extra bases (WBTC etc.). Each base advances with its own Rng, so the
     // WETH price path is unchanged (under the fork default, extraBaseSymbols=[] → exactly matches prior = byte-compatible).
-    const extraBaseSymbols = baseTokens()
-      .map((t) => t.symbol)
-      .filter((s) => s !== "WETH");
+    // `extraBaseSymbols` and each base's opening fair were settled at setup, next to WETH's, and
+    // are what the PriceFeed already carries (issue #94): the walk starts from the number V_0 was
+    // marked at, not from a re-read of the pool after the LST / Liquity setup traded on it.
     const extraPriceRng: Record<string, Rng> = {};
     const extraBaseFair: Record<string, number> = {};
     const extraAnchor: Record<string, number> = {};
     for (const b of extraBaseSymbols) {
       extraPriceRng[b] = priceRngForAsset(config.seed, b);
-      const p0 = await initialFairPriceFor(ctx, b, enabledIds);
-      extraBaseFair[b] = p0;
-      extraAnchor[b] = p0;
+      extraBaseFair[b] = openingFair[b];
+      extraAnchor[b] = openingFair[b];
     }
     let processedBlocks = 0;
     let processing = false;

--- a/core/src/realtime/priceFeed.ts
+++ b/core/src/realtime/priceFeed.ts
@@ -10,6 +10,7 @@ import {
 } from "viem";
 import {
   bigintToStorageWord,
+  sendAndMine,
   sendNoMine,
   setStorageAt,
 } from "@eris/sdk/chain.js";
@@ -34,6 +35,68 @@ export async function deployPriceFeed(
 
 // Fixed gas for a simple setter. Specifying it explicitly skips estimateGas (which waits on EVM execution).
 const SETTER_GAS = 300_000n;
+
+// ---------------------------------------------------------------------------
+// Setup-time writes: every base's opening fair is on the feed before the first boundary is marked
+// (issue #94, decided 2026-09-07 from #92's scorer row).
+//
+// The constructor carries WETH's opening fair, and every other base used to get its first value
+// from the per-block oracle write -- which lands one block *after* the first epoch boundary is
+// marked. Measured (calm, 60 blocks, 2026-09-07): noop's V_0 was 348,996 and V_K 365,839 on the
+// same holdings; the difference was 0.4 WBTC marked at 0 and then at ~60k. Every agent got the
+// same +24k in P, so T was untouched, but V_0 was short by the WBTC leg, noop's netPnlUsdc was
+// not the 0 the guide promises, `scoring_unpriced_holdings` listed spot WBTC for everyone at the
+// first boundary, and every value chart opened on a step.
+//
+// Ordinary mined setter transactions from the admin key: the same mechanism on anvil and on an
+// external chain (the storage write is a cheatcode, and updateOracles takes the same route for
+// Aave in external mode). Sent before any agent process exists, so nothing can front-run them.
+// ---------------------------------------------------------------------------
+
+// WETH's opening fair, re-written after a prewarm moved the pools (the constructor value predates it).
+export async function setPriceFeedOpening(
+  ctx: SimContext,
+  address: Address,
+  fairPrice: number,
+): Promise<Hex> {
+  return sendAndMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: address,
+      data: encodeFunctionData({
+        abi: priceFeedAbi,
+        functionName: "setPrice",
+        args: [toPriceFeedAnswer(fairPrice)],
+      }),
+    },
+  );
+}
+
+// An extra base's opening fair (setPriceFor), mined. The per-block path is updatePriceFeedForMempool.
+export async function setPriceFeedOpeningFor(
+  ctx: SimContext,
+  address: Address,
+  token: Address,
+  price: number,
+): Promise<Hex> {
+  return sendAndMine(
+    ctx.publicClient,
+    ctx.walletClient,
+    ctx.chain,
+    ctx.adminPk,
+    {
+      to: address,
+      data: encodeFunctionData({
+        abi: priceFeedAbi,
+        functionName: "setPriceFor",
+        args: [token, toPriceFeedAnswer(price)],
+      }),
+    },
+  );
+}
 
 // Per-block fair price write (mempool submit; like the oracle, placed first with a fee above the agent cap).
 export async function updatePriceFeedMempool(

--- a/docs/spec/02-runtime.md
+++ b/docs/spec/02-runtime.md
@@ -63,17 +63,17 @@
 
 | 順序 | 処理 | 備考 |
 |---|---|---|
-| 1 | `initialFairPrice` 確定 | 以降の較正・victim・whale が参照する |
+| 1 | `initialFairPrice` 確定 + 他 base の opening fair を `ctx.fairPrices` に | 以降の較正・victim・whale・`initial_endowment`・PriceFeed が参照する。**WBTC 等もここで確定する**（issue #94。以前は mining 開始後に初めて読んでいたので、ここから最初のブロックまでの評価は WETH だけを見ていた） |
 | 2 | Aave オラクル較正（localDeploy 時） | anvil なら storage 書き込み、external なら admin の mined tx。どちらも agent 起動前なので front-run 不可 |
 | 3 | whale endowment | サイズは fair price 建て。**venue が無効なら throw**（L904） |
 | 4 | stress victim 構築 | `aave` 必須 / fresh state 必須（下記） |
 | 5 | 各 agent の初期残高取得 + `initial_endowment` | 最大/最小が 2 倍超なら警告 |
-| 6 | PriceFeed デプロイ → `price_feed_deployed` | このアドレスだけは参加者が他から引けない |
+| 6 | PriceFeed デプロイ → 他 base の opening fair を `setPriceFor`（mined tx）→ `price_feed_deployed`（`openingFair` 付き） | このアドレスだけは参加者が他から引けない。**全 base の fair が最初の境界より前に feed に載る**（issue #94。以前は WBTC の値が最初の oracle tx = 最初の境界の 1 ブロック後に着き、V_0 が全員 WBTC 分（バスケットで 24k）短く、noop の `netPnlUsdc` が 0 にならなかった） |
 | 7 | FlashArb デプロイ（`run.flashArb` かつ aave+uniswap+balancer） | |
 | 8 | vuln pool デプロイ（ADR 0014） | 資金投入は窓が開くブロックで行う |
 | 9 | `agents_registered` emit | id / address / baseline / external |
 | 10 | **環境マニフェスト書き出し** | 鍵は入らない。→ [10](10-operations.md) |
-| 11 | prewarm（`run.prewarmBlocks > 0`） | flow bot だけの短いループで anvil の working set を温める。価格の主系列は消費しない（別 Rng） |
+| 11 | prewarm（`run.prewarmBlocks > 0`） | flow bot だけの短いループで anvil の working set を温める。価格の主系列は消費しない（別 Rng）。終わったら全 base の fair を読み直して PriceFeed にも書き直す（deploy 時の値は暖機前の価格） |
 | 12 | LST setup | 経済クロックの整合 + rate oracle 配線の検証（乖離 200bps 超で fail-fast） |
 | 13 | Liquity setup | オラクルアダプタを今回の PriceFeed に差し替え。Recovery Mode 開幕・デペグ済みチェーンは fail-fast |
 | 14 | deployer 鍵の衝突検査 | liquidityPull / depeg が deployer 口座で取引するため（下記） |
@@ -92,6 +92,7 @@
 
 - `external: true` または鍵なしのエントリは**起動しない**。代わりに `agent_external_registered` を emit する。これが無いと「参加者が接続しなかった run」と「coordinator が起動に失敗した run」が区別できない（どちらも無取引に見える）。
 - 起動したプロセスには `onExit` を付ける。**途中で死んだエージェントは黙って取引をやめる**ので、`summary.json` 上は「動かないことを選んだ」エージェントと見分けがつかない。`agent_process_exited` と `processExitedEarly` に残す。
+- **エポックの時計は場が揃うまで待つ**（issue #94。`core/src/realtime/agentsReady.ts`）。automine を切った後・interval mining を始める前に、起動した全 agent が自分のログに `runtime_start` を書くまで待つ（`run.agentsReadyTimeoutSec`、既定 60 秒）。実測（2026-09-07、docker 32 体）では `interval_mining_started` が +24 s、`runtime_start` が +86〜99 s で、360 ブロックのエポックの先頭 ~45 ブロックと `windowFrac 0.10` の窓が誰も見ていないうちに過ぎていた。待っている間 anvil はブロックを作らない（agent が `runtime_start` までに必要とするのは read だけ。approve は funding で済んでいる）。external チェーンではシーケンサのブロックが `runStartBlock` の前に流れるだけ。外部参加者は待たない（こちらが起動していない）。結果は `agents_ready`（`ready[].afterMs` / `late` / `exited` / `timedOut`）に残り、上限で打ち切ったときは late の agent が最初のブロックを見ていないことが記録になる
 
 ### [F] ブロックループ
 

--- a/docs/spec/07-configuration.md
+++ b/docs/spec/07-configuration.md
@@ -67,6 +67,7 @@ RPC URL や chain id が秘密情報側にあるのは、**それらが regime �
 | `markMedianBlocks` | 5 | G7 の median 窓 |
 | `agentSandbox` | `process` | `process` / `docker`。docker は `infra/docker-agent/run-agent.sh` 経由で規約 §2.3 の 2 vCPU / 4 GiB を掛ける唯一の経路。公式レジームは `docker`、ローカルは `--agent-sandbox process` |
 | `blockGasLimit` | 30000000 | setup 完了後・mining 開始前に coordinator が設定するブロックガスリミット（規約 §2.6。0 = ノードの値のまま） |
+| `agentsReadyTimeoutSec` | 60 | 起動した全 agent が `runtime_start` を書くまでエポックの時計を止めておく上限秒数（issue #94。0 = 待たない）。docker 32 体のローカル検証は 86〜99 秒かかるので上げる |
 | `reportDir` | `./runs` | 出力ルート |
 | `flashArb` | false | FlashArb コントラクトのデプロイ |
 | `localSnapshotFile` | `.local-snapshot` | snapshot id の置き場 |

--- a/docs/spec/08-artifacts.md
+++ b/docs/spec/08-artifacts.md
@@ -114,8 +114,9 @@ runs/
 | `agents_registered` | ロスター全体（id / address / baseline / description / external） |
 | `agent_external_registered` | 外部参加者の登録（環境は起動しない） |
 | `agent_process_exited` | エージェントプロセスの異常終了 |
-| `initial_endowment` | 各エージェントの初期価値と最大/最小比 |
-| `price_feed_deployed` / `flash_arb_deployed` | |
+| `agents_ready` | interval mining の前に場が揃ったか（issue #94）。`ready[]`（id と spawn からの `afterMs`）/ `late`（上限時点で `runtime_start` 未達）/ `exited`（`runtime_start` 前に死んだ）/ `waitedMs` / `timedOut` |
+| `initial_endowment` | 各エージェントの初期価値と最大/最小比（全 base を評価。issue #94） |
+| `price_feed_deployed` / `flash_arb_deployed` | 前者は `openingFair`（base ごとの開始 fair。最初の境界より前に feed に載っている値）を持つ |
 | `interval_mining_started` / `block_gas_limit_set` / `fork_reset_skipped` / `prewarm_completed` | |
 | `external_chain_block_time` / `external_chain_mint_guard` / `treasury_funded_roles` | external モード |
 | `economic_gas_enabled` / `fee_cap_enforcement_disabled` | economicGas プロファイル |

--- a/docs/spec/en/02-runtime.md
+++ b/docs/spec/en/02-runtime.md
@@ -61,17 +61,17 @@ Source: `core/src/realtime/coordinator.ts` (`runRealtimeSimulation`, L390–2761
 
 | # | Step | Note |
 |---|---|---|
-| 1 | Settle `initialFairPrice` | Everything below refers to it |
+| 1 | Settle `initialFairPrice`, and every other base's opening fair into `ctx.fairPrices` | Everything below refers to it: the calibration, the victims, the whale, `initial_endowment`, the PriceFeed. **WBTC and the rest are settled here too** (issue #94; they used to be read for the first time after mining started, so every valuation between here and the first block saw WETH only) |
 | 2 | Calibrate the Aave oracle (local deploy) | A storage write on anvil, a mined admin tx on external. Both land before any agent starts, so neither is front-runnable |
 | 3 | Endow the whale | Size is denominated against the fair price. **Throws if the venue is not enabled** (L904) |
 | 4 | Stage stress victims | Requires `aave` and fresh state (below) |
 | 5 | Read each agent's opening balance, emit `initial_endowment` | Warns when max/min exceeds 2× |
-| 6 | Deploy the PriceFeed → `price_feed_deployed` | The one address a participant cannot look up elsewhere |
+| 6 | Deploy the PriceFeed → write the other bases' opening fair with `setPriceFor` (mined) → `price_feed_deployed` (with `openingFair`) | The one address a participant cannot look up elsewhere. **Every base's fair is on the feed before the first boundary is marked** (issue #94: WBTC's used to land with the first oracle tx, one block after the first boundary, so V_0 was short by the WBTC leg — 24k at the basket — for everyone and noop's `netPnlUsdc` was not 0) |
 | 7 | Deploy FlashArb (`run.flashArb` with aave+uniswap+balancer) | |
 | 8 | Deploy vuln pools (ADR 0014) | Funding happens when each window opens |
 | 9 | Emit `agents_registered` | id / address / baseline / external |
 | 10 | **Write the environment manifest** | Holds no keys → [10](10-operations.md) |
-| 11 | Prewarm (`run.prewarmBlocks > 0`) | A short flow-bot-only loop that warms anvil's working set. It does not consume the price series (separate Rng) |
+| 11 | Prewarm (`run.prewarmBlocks > 0`) | A short flow-bot-only loop that warms anvil's working set. It does not consume the price series (separate Rng). Afterwards every base's fair is re-read and re-written to the PriceFeed (the values written at deploy predate the warmup's trading) |
 | 12 | LST setup | Aligns the economic clock and verifies the rate-oracle wiring (>200bps divergence fails fast) |
 | 13 | Liquity setup | Points the permanent oracle adapter at this run's PriceFeed. Opening in Recovery Mode or on a depegged pool fails fast |
 | 14 | Check for deployer-key collisions | liquidityPull and depeg trade as the deployer account (below) |
@@ -90,6 +90,7 @@ Source: `core/src/realtime/coordinator.ts` (`runRealtimeSimulation`, L390–2761
 
 - An entry that is `external: true`, or has no key, **is not started**. `agent_external_registered` is emitted instead. Without it, "the participants never connected" and "the coordinator failed to launch them" look identical — both are an agent that made no trades.
 - Launched processes get an `onExit` handler. **An agent that dies mid-run silently stops trading**, which in `summary.json` reads exactly like an agent that chose not to. It is recorded as `agent_process_exited` and `processExitedEarly`.
+- **The epoch clock waits for the field** (issue #94; `core/src/realtime/agentsReady.ts`). After automine is switched off and before interval mining starts, the coordinator waits until every agent it launched has written `runtime_start` to its own log (`run.agentsReadyTimeoutSec`, 60 s by default). Measured 2026-09-07 with 32 docker agents: `interval_mining_started` at +24 s, `runtime_start` at +86–99 s, so the first ~45 blocks of a 360-block epoch and a `windowFrac 0.10` window went by with nobody watching. Anvil produces no block while it waits (nothing an agent does before `runtime_start` needs one: the preflight reads, and the approvals were granted at funding); on an external chain the sequencer's blocks simply precede `runStartBlock`. External participants are not waited for — nothing here started them. The outcome is `agents_ready` (`ready[].afterMs` / `late` / `exited` / `timedOut`); when the bound cuts the wait short, the record says which agents did not see the first block.
 
 ### [F] The block loop
 

--- a/docs/spec/en/07-configuration.md
+++ b/docs/spec/en/07-configuration.md
@@ -67,6 +67,7 @@ Keys are **nested lowercase**, mapped to internal env names by `SCHEMA` (`sdk/sr
 | `markMedianBlocks` | 5 | The G7 median window |
 | `agentSandbox` | `process` | `process` / `docker`. docker launches through `infra/docker-agent/run-agent.sh`, the only path that applies the rules §2.3 caps (2 vCPU / 4 GiB). Official regimes say `docker`; locally pass `--agent-sandbox process` |
 | `blockGasLimit` | 30000000 | Block gas limit the coordinator sets after setup, before mining starts (rules §2.6; 0 = leave the node's) |
+| `agentsReadyTimeoutSec` | 60 | Longest the epoch clock is held for every launched agent to write `runtime_start` (issue #94; 0 = do not wait). A local check with 32 docker agents takes 86–99 s, so raise it there |
 | `reportDir` | `./runs` | Output root |
 | `flashArb` | false | Deploy the FlashArb contract |
 | `localSnapshotFile` | `.local-snapshot` | Where the snapshot id lives |

--- a/docs/spec/en/08-artifacts.md
+++ b/docs/spec/en/08-artifacts.md
@@ -114,8 +114,9 @@ One event per line, each carrying an ISO `ts`. The catalogue below is what the c
 | `agents_registered` | The whole roster (id / address / baseline / description / external) |
 | `agent_external_registered` | An external registration the environment did not start |
 | `agent_process_exited` | An agent process ending early |
-| `initial_endowment` | Each agent's opening value and the max/min ratio |
-| `price_feed_deployed` / `flash_arb_deployed` | |
+| `agents_ready` | Whether the field was up before interval mining (issue #94): `ready[]` (id and `afterMs` since the spawn) / `late` (no `runtime_start` at the bound) / `exited` (died before `runtime_start`) / `waitedMs` / `timedOut` |
+| `initial_endowment` | Each agent's opening value and the max/min ratio (every base valued; issue #94) |
+| `price_feed_deployed` / `flash_arb_deployed` | The former carries `openingFair` (each base's opening fair, on the feed before the first boundary) |
 | `interval_mining_started` / `block_gas_limit_set` / `fork_reset_skipped` / `prewarm_completed` | |
 | `external_chain_block_time` / `external_chain_mint_guard` / `treasury_funded_roles` | External mode |
 | `economic_gas_enabled` / `fee_cap_enforcement_disabled` | The economicGas profile |

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -197,6 +197,13 @@ export type SimConfig = {
   // carries that forward -- and the competition phase runs at the published block size, which is
   // what makes the priority-fee auction of §2.6 exist. 0 leaves the node's limit alone.
   blockGasLimit: number;
+  // How long the coordinator holds the epoch clock for the field (ERIS_AGENTS_READY_TIMEOUT_SEC /
+  // `run.agentsReadyTimeoutSec`; issue #94). Interval mining starts once every agent the
+  // coordinator launched has written `runtime_start`, or after this many seconds, whichever is
+  // first; who was still booting at the bound is recorded in `agents_ready`. 60 is the decided
+  // bound (2026-09-07). Measured on an 8-core Mac with 32 docker agents the field takes 86-99 s,
+  // so a local check of that size raises it; the production box is faster. 0 disables the wait.
+  agentsReadyTimeoutSec: number;
   seed: number;
   runDirRoot: string;
   agentTimeoutMs: number;
@@ -407,6 +414,10 @@ export function loadConfig(env = process.env): SimConfig {
     segmentName: env.ERIS_SEGMENT_NAME ?? "",
     markMedianBlocks: Math.max(0, intEnv(env.ERIS_MARK_MEDIAN_BLOCKS, 5)),
     blockGasLimit: Math.max(0, intEnv(env.ERIS_BLOCK_GAS_LIMIT, 30_000_000)),
+    agentsReadyTimeoutSec: Math.max(
+      0,
+      intEnv(env.ERIS_AGENTS_READY_TIMEOUT_SEC, 60),
+    ),
     seed: intEnv(env.SEED, 1),
     runDirRoot: env.REPORT_DIR ?? "./runs",
     agentTimeoutMs: intEnv(env.AGENT_TIMEOUT_MS, 5000),

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -96,6 +96,8 @@ const SCHEMA: Record<string, string> = {
   "run.markMedianBlocks": "ERIS_MARK_MEDIAN_BLOCKS",
   // Rules §2.6: the block gas limit the coordinator sets once setup is done (0 = leave the node's).
   "run.blockGasLimit": "ERIS_BLOCK_GAS_LIMIT",
+  // Issue #94: seconds the epoch clock waits for every launched agent's `runtime_start` (0 = no wait).
+  "run.agentsReadyTimeoutSec": "ERIS_AGENTS_READY_TIMEOUT_SEC",
   // process | docker: how the coordinator launches each agent (rules §2.3 caps apply only under docker).
   "run.agentSandbox": "ERIS_AGENT_SANDBOX",
   "run.reportDir": "REPORT_DIR",

--- a/test/agentsReady.test.ts
+++ b/test/agentsReady.test.ts
@@ -1,0 +1,167 @@
+// Issue #94: the epoch clock waits for the field. The chain-facing half (no block is produced
+// while the coordinator waits) is a property of where the wait sits in coordinator.ts; what is
+// checked here is the wait itself -- that it reads the runtime's own `runtime_start` line, that a
+// process which died is not waited for, that the bound holds, and that the report says who was
+// what.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  agentLogHasRuntimeStart,
+  agentLogPath,
+  waitForAgentsReady,
+} from "../core/src/realtime/agentsReady.js";
+
+function runDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "eris-agents-ready-"));
+  mkdirSync(join(dir, "agents"), { recursive: true });
+  return dir;
+}
+
+// The shape runtime/bot.ts writes through agentLog.ts: one JSON object per line, `event` on the
+// mempool self-reports, `runtime_start` once the preflight passed and the block watcher is armed.
+const preflightLine = (id: string): string =>
+  JSON.stringify({ ts: "t", agentId: id, event: "preflight", ok: true }) + "\n";
+const startLine = (id: string): string =>
+  JSON.stringify({
+    ts: "t",
+    agentId: id,
+    event: "runtime_start",
+    mode: "decide",
+    address: "0x1",
+  }) + "\n";
+
+test("agentLogHasRuntimeStart reads the runtime's line and nothing that merely mentions it", () => {
+  const dir = runDir();
+  const file = agentLogPath(dir, "a");
+  assert.equal(agentLogHasRuntimeStart(file), false, "no file yet");
+  writeFileSync(file, preflightLine("a"));
+  assert.equal(agentLogHasRuntimeStart(file), false, "preflight only");
+  // An error line quoting the word is not the event.
+  appendFileSync(
+    file,
+    JSON.stringify({ event: "submit_failed", error: "runtime_start missing" }) +
+      "\n",
+  );
+  assert.equal(agentLogHasRuntimeStart(file), false, "a mention is not the event");
+  // A partial last line (the agent mid-write) is skipped, not a crash.
+  appendFileSync(file, '{"event":"runtime_start"');
+  assert.equal(agentLogHasRuntimeStart(file), false, "partial line");
+  appendFileSync(file, ",\"mode\":\"decide\"}\n");
+  assert.equal(agentLogHasRuntimeStart(file), true);
+});
+
+test("waits until every launched agent has written runtime_start, and measures from the spawn", async () => {
+  const dir = runDir();
+  let t = 1_000;
+  const now = () => t;
+  const sleep = async (ms: number) => {
+    t += ms;
+    // b comes up at +300 ms, a at +800 ms.
+    if (t >= 1_300 && t < 1_800) writeFileSync(agentLogPath(dir, "b"), startLine("b"));
+    if (t >= 1_800) writeFileSync(agentLogPath(dir, "a"), preflightLine("a") + startLine("a"));
+  };
+  const report = await waitForAgentsReady({
+    agents: [
+      { id: "a", isAlive: () => true },
+      { id: "b", isAlive: () => true },
+    ],
+    runDir: dir,
+    spawnedAt: 500,
+    timeoutMs: 60_000,
+    pollMs: 100,
+    now,
+    sleep,
+  });
+  assert.equal(report.timedOut, false);
+  assert.deepEqual(report.late, []);
+  assert.deepEqual(report.exited, []);
+  assert.deepEqual(
+    report.ready.map((r) => r.id).sort(),
+    ["a", "b"],
+  );
+  const byId = Object.fromEntries(report.ready.map((r) => [r.id, r.afterMs]));
+  // afterMs is spawn-relative (spawnedAt 500): b seen at t=1300 -> 800, a at t=1800 -> 1300.
+  assert.equal(byId.b, 800);
+  assert.equal(byId.a, 1300);
+  assert.equal(report.waitedMs, 800);
+  // The wait released as soon as the last one was ready, well inside the bound.
+  assert.ok(report.waitedMs < report.timeoutMs);
+});
+
+test("a process that exited is not waited for, and one that wrote its line before dying counts as ready", async () => {
+  const dir = runDir();
+  writeFileSync(agentLogPath(dir, "wrote-then-died"), startLine("wrote-then-died"));
+  let t = 0;
+  const report = await waitForAgentsReady({
+    agents: [
+      // Preflight refused (exit 1) before writing anything.
+      { id: "refused", isAlive: () => false },
+      { id: "wrote-then-died", isAlive: () => false },
+      { id: "up", isAlive: () => true },
+    ],
+    runDir: dir,
+    spawnedAt: 0,
+    timeoutMs: 10_000,
+    pollMs: 100,
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+      if (t >= 200) writeFileSync(agentLogPath(dir, "up"), startLine("up"));
+    },
+  });
+  assert.equal(report.timedOut, false);
+  assert.deepEqual(report.exited, ["refused"]);
+  assert.deepEqual(report.ready.map((r) => r.id).sort(), ["up", "wrote-then-died"]);
+  assert.deepEqual(report.late, []);
+  // Released at the first poll that saw `up`, not held for `refused`.
+  assert.equal(report.waitedMs, 200);
+});
+
+test("the bound holds: whoever is still booting is late, and the clock is not held past it", async () => {
+  const dir = runDir();
+  writeFileSync(agentLogPath(dir, "fast"), startLine("fast"));
+  let t = 0;
+  let sleeps = 0;
+  const report = await waitForAgentsReady({
+    agents: [
+      { id: "fast", isAlive: () => true },
+      { id: "slow", isAlive: () => true },
+    ],
+    runDir: dir,
+    spawnedAt: 0,
+    timeoutMs: 1_000,
+    pollMs: 300,
+    now: () => t,
+    sleep: async (ms) => {
+      sleeps++;
+      // The last sleep is clipped to the deadline rather than overshooting it.
+      assert.ok(ms <= 300);
+      t += ms;
+    },
+  });
+  assert.equal(report.timedOut, true);
+  assert.deepEqual(report.late, ["slow"]);
+  assert.deepEqual(report.ready.map((r) => r.id), ["fast"]);
+  assert.equal(report.waitedMs, 1_000);
+  assert.equal(report.timeoutMs, 1_000);
+  assert.equal(sleeps, 4, "300 + 300 + 300 + 100");
+});
+
+test("nothing to wait for returns at once", async () => {
+  const dir = runDir();
+  const report = await waitForAgentsReady({
+    agents: [],
+    runDir: dir,
+    spawnedAt: 0,
+    timeoutMs: 60_000,
+    now: () => 0,
+    sleep: async () => {
+      assert.fail("must not sleep with no agents");
+    },
+  });
+  assert.equal(report.waitedMs, 0);
+  assert.equal(report.timedOut, false);
+});


### PR DESCRIPTION
The two fixes #94 lists under "Before the run", decided 2026-09-07 (#91 F5, #92 scorer row). Part of #94; does not close it (the matrix run and the four readings remain).

## The epoch clock waits for the field

After automine is switched off and before interval mining starts, the coordinator waits until every agent it launched has written `runtime_start` to its own log, bounded by the new `run.agentsReadyTimeoutSec` (60 s by default, the decided bound; `0` disables).

- Measured on 2026-09-07 with 32 docker agents: `interval_mining_started` at +24 s, `runtime_start` at +86–99 s, so the first ~45 blocks of a 360-block epoch and a `windowFrac 0.10` window went by with nobody watching.
- No block is produced on anvil while it waits: nothing an agent does before `runtime_start` needs one (the preflight reads; the venue approvals were granted at funding). On an external chain the sequencer's blocks simply precede `runStartBlock`. External participants are not waited for.
- The outcome is on the record as `agents_ready`: `ready[]` (id + ms since spawn), `late` (no `runtime_start` at the bound), `exited` (died before it), `waitedMs`, `timedOut`. A late agent's missed blocks are its own, and the record now says so.
- Pure logic in `core/src/realtime/agentsReady.ts`, covered by `test/agentsReady.test.ts`.

For the #91 fixture on the 8-core Mac the field takes 86–99 s, so that run should set `agentsReadyTimeoutSec: 120` (or so) in the regime override; the default stays at the decided 60.

## V_0 marks every base

The PriceFeed constructor carried WETH's opening fair and every other base got its first value from the per-block oracle tx, one block after the first boundary was marked. On the 9/7 calm run V_0 for noop was 348,996 and V_K 365,839 on the same holdings — 0.4 WBTC marked at 0 and then at ~60k — so V_0 was short by the WBTC leg for everyone, noop's `netPnlUsdc` was not 0, and spot WBTC was reported unpriced at the first boundary.

- Setup settles every base's opening fair right after `initialFairPrice`, into `ctx.fairPrices`, so the whale endowment, `initial_endowment` and the Aave WBTC aggregator calibration see every base too.
- The extra bases are written with a mined `setPriceFor` right behind the deploy (same mechanism on anvil and external; before any agent exists), re-written after a prewarm, and the OU walk starts from the same numbers. `price_feed_deployed` carries `openingFair`.
- The boundary definition does not move.

## Verified

- `npm run typecheck`, `npm run check:boundaries`, `npm test` (716 tests: 711 pass, 5 skipped, 0 fail).
- Four-venue local deploy (uniswap/balancer/curve/aave; this machine's deployer lacks the GMX/Liquity vendors), 30 blocks, noop + frozen venue-arb + frozen multi-arb, basket funding with 0.4 WBTC:
  - `agents_ready` precedes `interval_mining_started`, 3/3 ready at ~1 s (process sandbox)
  - `price_feed_deployed.openingFair = {WETH: 3000, WBTC: 60000}`
  - boundary 0 value 372,496 for every agent (108 ETH-equivalent + 0.4 WBTC + 25k USDC), no `scoring_unpriced_holdings`
  - noop `netPnlUsdc = 0`, `alphaUsdc = 0`; `epoch_series_agreement` max diff 0

## Notes

- Touches the coordinator right where #81 adds the automine-backlog flush (`waitForMiningToSettle`), so whichever lands second gets a small conflict around `interval_mining_started`. The wait sits before the mining switch; the flush sits after it — the two compose.
- Docs: spec 02-runtime / 07-configuration / 08-artifacts (ja + en) and CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U657JGwSzCHKdi4F2mdcet
