### PR TITLE
config: the pre-9/23 check fixture (roster, commitments, 8-epoch plan) (#91, #94)

### DIFF
--- a/config/competition/check-hidden.yaml
+++ b/config/competition/check-hidden.yaml
@@ -1,0 +1,13 @@
+# The pre-9/23 check's "hidden" set (#91 / #94): the eight official regimes at seed 101, the
+# seed whose windows CLAUDE.md already records. Not secret -- it is the fixture, committed so the
+# check can be re-run on the same plan.
+salt: check-2026-09
+regimes:
+  calm: [101]
+  cex-drift: [101]
+  informed-flow: [101]
+  whale: [101]
+  lending-incident: [101]
+  crash: [101]
+  depeg: [101]
+  vuln: [101]

--- a/config/competition/check-lottery.yaml
+++ b/config/competition/check-lottery.yaml
@@ -1,0 +1,3 @@
+# The pre-9/23 check's lottery seed (#91 / #94). Not secret; see check-hidden.yaml.
+salt: check-2026-09
+lotterySeed: check-2026-09-lottery

--- a/config/competition/check-plan.yaml
+++ b/config/competition/check-plan.yaml
@@ -1,0 +1,37 @@
+schema: 1
+k: 8
+hiddenSetCommitment: sha256:925c4425e8fffc1601db00f7bfb1482c91f5a7b92ba93547b38ee6a9b42dd15f
+lotterySeedCommitment: sha256:9288752fab601561d4ab54661f4fab5511c2597ac43099d61eafecad998c60c2
+epochs:
+  - s: 1
+    regime: cex-drift
+    seed: 101
+    startsAt: 2026-09-08T11:02:46.000Z
+  - s: 2
+    regime: crash
+    seed: 101
+    startsAt: 2026-09-08T11:22:46.000Z
+  - s: 3
+    regime: lending-incident
+    seed: 101
+    startsAt: 2026-09-08T11:42:46.000Z
+  - s: 4
+    regime: vuln
+    seed: 101
+    startsAt: 2026-09-08T12:02:46.000Z
+  - s: 5
+    regime: whale
+    seed: 101
+    startsAt: 2026-09-08T12:22:46.000Z
+  - s: 6
+    regime: informed-flow
+    seed: 101
+    startsAt: 2026-09-08T12:42:46.000Z
+  - s: 7
+    regime: depeg
+    seed: 101
+    startsAt: 2026-09-08T13:02:46.000Z
+  - s: 8
+    regime: calm
+    seed: 101
+    startsAt: 2026-09-08T13:22:46.000Z

--- a/config/rosters/check-all-examples.yaml
+++ b/config/rosters/check-all-examples.yaml
@@ -1,0 +1,42 @@
+# config/rosters/check-all-examples.yaml — the fixture roster for the pre-9/23 hand checks (#91, #94).
+#
+# Every directory under example/agents/ except lib/ and runtime/, every wallet AUTO, and the nine
+# that ship a prompt.md frozen (ERIS_AGENT_FROZEN: "1") so the run reads the rule strategies and
+# not what a model wrote. bench-max stays in on purpose: its own header says it must never be in a
+# production roster, and this run is where that gets confirmed (#93).
+#
+# #91 lists 32 ids. `starter-template` is not in the tree (no example/agents/starter-template/ on
+# main and none in the history), so it is left out here rather than failing the launch -- the
+# coordinator refuses a roster id with no directory. Recorded as a finding on #91.
+agents:
+  - { id: adaptive-arb, wallet: AUTO }
+  - { id: arb-bot, wallet: AUTO }
+  - { id: basis-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: bench-max, wallet: AUTO }
+  - { id: clean-arb, wallet: AUTO }
+  - { id: cross-venue-arb, wallet: AUTO }
+  - { id: discovery-arb, wallet: AUTO }
+  - { id: discovery-arb-verify, wallet: AUTO }
+  - { id: exploit-hunter, wallet: AUTO }
+  - { id: flash-arb, wallet: AUTO }
+  - { id: levered-long, wallet: AUTO }
+  - { id: liquidator, wallet: AUTO }
+  - { id: lp-mint, wallet: AUTO }
+  - { id: lp-provider, wallet: AUTO }
+  - { id: lst-carry, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: market-launcher, wallet: AUTO }
+  - { id: market-taker, wallet: AUTO }
+  - { id: max-profit-arb, wallet: AUTO }
+  - { id: multi-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: my-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: noop, wallet: AUTO, baseline: true }
+  - { id: peg-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: random, wallet: AUTO }
+  - { id: redemption-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: simple-rule, wallet: AUTO }
+  - { id: sp-underwriter, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: stat-arb, wallet: AUTO }
+  - { id: trap-launcher, wallet: AUTO }
+  - { id: trove-manager, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }
+  - { id: vault-keeper, wallet: AUTO }
+  - { id: venue-arb, wallet: AUTO, env: { ERIS_AGENT_FROZEN: "1" } }


### PR DESCRIPTION
The fixture #91 specifies, as it was run on 2026-09-08 (record and deviations in #94; findings in #91 / #92 / #93):

- `config/rosters/check-all-examples.yaml` — every example agent, the nine with a `prompt.md` frozen. `starter-template` is not in the tree (deleted in 0110058), so it is left out; #91's roster text is stale by that one id.
- `config/competition/check-hidden.yaml` / `check-lottery.yaml` — the eight official regimes at seed 101 and the lottery seed. Not secret: this is the check's fixture.
- `config/competition/check-plan.yaml` — `competition plan --k 8` from the two (hidden `sha256:925c4425…`, lottery `sha256:9288752f…`), with the `startsAt` stamps of the 2026-09-08 run. Order: cex-drift, crash, lending-incident, vuln, whale, informed-flow, depeg, calm.

Run it as #91 says (on a box that has docker and nothing else running):

```sh
ERIS_LOCAL_DEPLOY=1 npm run backtest -- --scenarios config/competition/check-plan.yaml \
  --agents config/rosters/check-all-examples.yaml --agent-sandbox docker
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U657JGwSzCHKdi4F2mdcet
