### PR TITLE
liquity: Recovery Mode reachable — a cohort sized to a target TCR (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ devnet）を指す。cheatcode 関数はそのまま残り、external では**�
 - `npm run build:contracts` — モックオラクル + PriceFeed を forge build（sim:realtime の前提。`out/` 未生成なら最低 1 回）
 - `npm run gen:local-constants` — deployments.json → `sdk/src/constants.local.ts` 生成（同梱 `deployer/` のローカルデプロイ出力を読む）
 - `npm run gen:state-dump` — 稼働中の deployer anvil から配布用 state dump + manifest（生成元コミット・deployments 同梱・fingerprint）を `backtest/state/` へ生成（ADR 0016。dump 前に `.local-snapshot` のクリーン断面へ revert し、constants.local.ts も同じ deployments から再生成）
+- **anvil はブロックごとの state を `~/.foundry/anvil/tmp/anvil-state-*/` に ~2 MB ずつ書く**（`--load-state` の run で実測: 360 ブロック run 1 本で 3,600 ファイル ≈ 7 GB、プロセス終了後も残る）。2026-09-10 にこれが 61 GB 溜まってディスクが満杯になり、run が `ENOSPC` で落ちた。run の後は `rm -rf ~/.foundry/anvil/tmp/anvil-state-*`（動いている anvil が無いとき）。本番 box でも同じ
 - `npm run backtest -- --regime <name> --seed <N>` — シナリオ 1 本を再生（ADR 0016 Phase 0 = B1 実時間再生）。state dump をロードした専用 anvil（既定 port 8547）で `config/regimes/<name>.yaml` + seed を再生する。**シナリオ = (regime, seed)** で regime YAML は seed を持たないので `--seed` は必須（ADR 0017 §1）。`--agents <roster>`（regime 既定ロスターの差し替え）/ `--protocols`/`--blocks`/`--score-every` 等の一回上書き。**override は実効 regime YAML に書き出されて agent プロセスにも伝播**（coordinator だけに効かせると agent が観測で死ぬ）。fingerprint 不一致は manifest 同梱 deployments から constants を自動再生成、genesis 不一致は fail-fast
 - `npm run backtest -- --scenarios config/scenarios/public.yaml` — シナリオ行列を 1 つの anvil 上で全部再生し順位を出す（ADR 0017）。`{regimes, seeds}` の直積（実行順が回次 s）か、`{k, epochs: [{s, regime, seed}]}` の順序付きプラン（`npm run competition -- plan` の出力）を受ける。シナリオ間は snapshot/revert。`runs/matrix-<id>/matrix.json`（schema 2: シナリオ × agent の P = `pnlUsdc` / `pnlSource` / `netPnlUsdc` / `alphaUsdc` / 端点 / `baseline` / `flags`）と `standings.json`（`computeStandings` の出力）を書く。順位は派生物で matrix.json から再計算できる。`--repeat N`（較正の診断用。採点は 1 回が既定。P の中央値の repeat を採る）
   - **`--resume <matrix-dir>` で同じ行列を続ける**（規約 §4.7.1。ライブ週の k エポックは複数回の起動にまたがる）。
@@ -550,10 +551,14 @@ ours なのは 2 つだけ（core は無改変）:
   対する防御）/ `sp-underwriter`（Stability Pool で清算を吸収し、自分で `liquidate` を叩いて担保を取る）。
   借り手の防御が効くかは**借りた eUSD を使ったかどうか**で決まる（`ERIS_TROVE_SPEND_DEBT`）。実測で
   200% 保持組は無傷、125% で全額 post して eUSD を売った組は清算され −13,140（担保 20 ETH を失い USDC を残す）
-- **Recovery Mode は現状の較正では到達不能**（実測: seed 501 で最小 TCR 2.244 対 CCR 1.5）。genesis Trove
-  が 250 ETH / 250k eUSD（300%）で TCR を支配するため。到達させるには system 債務を約 3 倍にする必要があり、
-  それは償還手数料カーブ（供給に反比例。250k で 5k 償還あたり +100bps → 700k なら +36bps）と SP の相対深度
-  （RM の清算は SP が債務を全額吸収できる場合のみ成立）を必ず薄める。**issue #59** に分離
+- **Recovery Mode は公式レジームの較正では到達不能**（実測: seed 501 で最小 TCR 2.244 対 CCR 1.5）。genesis Trove
+  が 250 ETH / 250k eUSD（300%）で TCR を支配するため。**到達させるのは victim cohort の仕事**（issue #59 →
+  `config/regimes/cdp-recovery.yaml`、公式セット外）: `stress.liquityRecoveryTcr` を書くと coordinator が seed の引いた
+  crash magnitude と現状の system から各 victim の担保を逆算し（`recoveryCohortCollateralWei`）、届かなければ setup で
+  fail-fast。RM の清算（MCR〜TCR 帯）は SP が債務を全額吸収できる場合しか執行されないので `stress.liquitySpSeedEusdWei`
+  で環境が deployer の eUSD を SP に入れる。genesis を下げないのは償還順序と SP 相対深度を全レジームで壊すから。
+  手数料カーブの希釈（供給に反比例）は不可避で、この regime の償還較正は別に測る。sp-underwriter は RM 帯でも
+  清算する分岐を持つ（SP が全額吸収できる Trove だけ）
 - **LQTY は意図どおり「値付けしないが見える」**: SP 預入で LQTY gain が付き、run 後に
   `scoring_unpriced_holdings` に `erc20-unaccounted` として 61.3 LQTY が報告された（黙って 0 にしていない）
 - 設定例は `config/liquity.yaml`、レジームは `config/regimes/liquity.yaml`（α 側）と

--- a/config/regimes/cdp-recovery.yaml
+++ b/config/regimes/cdp-recovery.yaml
@@ -1,0 +1,114 @@
+# config/regimes/cdp-recovery.yaml — the Liquity venue's Recovery Mode, reachable. Issue #59
+#
+# Outside the official set (like lst.yaml / liquity.yaml / liquity-crash.yaml): a venue-verification
+# regime, and the one place the CDP's system-wide mechanism can be watched. Promote it when the
+# field has agents that act inside Recovery Mode.
+# Run: npm run backtest -- --regime cdp-recovery --seed 101 [--agents <roster>]
+#
+# The genesis Trove (250 ETH / 250,000 eUSD, 300 %) dominates the system ratio, so no crash the
+# regimes use reaches CCR 1.5 (issue #59 measured a minimum TCR of 2.24 on a 15-22 % crash). Lowering
+# the genesis Trove would invert the redemption order and thin the Stability Pool for every regime
+# (the issue's three reasons), so the debt that breaks the system comes from the environment's
+# victim cohort instead (core/src/liquityVictims.ts), opt-in here:
+#   - `liquityRecoveryTcr` declares the TCR the system should hit at the bottom of the drawn crash.
+#     The coordinator sizes each victim's collateral from the crash magnitude the seed drew, the
+#     system as it stands and the cohort's ICR, and fails fast at setup if no cohort can (the
+#     cohort's own post-crash ICR must sit above the target -- it is what pulls the system down).
+#   - the cohort's ICR (1.35) is chosen so a 15-22 % crash leaves it *above* MCR (1.35 × 0.78 =
+#     1.053 at the worst draw is under; at 15 % it is 1.15): these Troves are meant to be
+#     liquidatable only because of Recovery Mode, not on their own.
+#   - `liquitySpSeedEusdWei` puts 100,000 eUSD of the deployer's surplus into the Stability Pool.
+#     Recovery Mode liquidates a Trove between MCR and TCR only when the pool can absorb its whole
+#     debt; with 8 victims sized for TCR 1.45 each holds ~113,000 eUSD of debt, so the seeded pool
+#     plus sp-underwriter's deposit covers one at a time.
+#   Fee-curve dilution is unavoidable (the issue says so): baseRate rises by redeemed/supply/2, and
+#   this regime roughly quadruples supply, so the redemption calibration of liquity.yaml does not
+#   transfer -- measure it here and state it separately.
+# The roster: sp-underwriter liquidates inside the band (its Recovery Mode branch is issue #59's
+# too), trove-manager clears CCR with a margin while it lasts, redemption-arb and venue-arb for the
+# rest of the venue.
+# Note: no `run.seed` here (ADR 0017 §1); blocks / blockTimeSec fixed to production values.
+run:
+  blocks: 360 # R: ADR 0017 §1 (crash window x3-4, ~72 LLM decisions, inside anvil's ~1050 history depth)
+  seconds: 1800 # a stress run auto-disables the time limit and ends by block count (ADR 0009)
+  blockTimeSec: 2 # fixed to the regime (ADR 0016 §2)
+  protocols: [uniswap, balancer, curve, gmx, aave, lst, liquity]
+  economicGas: false
+  localDeploy: true
+  reportDir: ./runs
+  # Rules §4.1: a mark is the median over the 5 blocks ending at the valuation block, so an
+  # agent cannot reprice a pool at the close and book the move. Unset means 0 = mark live off a
+  # single block, which leaves that open; the metric-* regimes have carried 5 all along.
+  markMedianBlocks: 5
+  # Rules §2.3: every agent runs in a 2 vCPU / 4 GiB container. Only the docker path applies the
+  # caps (infra/docker-agent/run-agent.sh), so the official regimes name it. A local run without
+  # docker: `--agent-sandbox process` (no caps, and it says so in events.jsonl as agent_sandbox).
+  agentSandbox: docker
+
+funding:
+  # An ETH/BTC/USDC basket rather than USDC only. The score is excess over the do-nothing
+  # baseline, which holds the same funding, so the basket's beta cancels out of the metric by
+  # construction (lp-provider's own comment says as much: "handed inventory is beta nobody chose
+  # and it cancels out of every score because the benchmark holds it too"). What USDC-only was
+  # protecting is netPnlUsdc, a reporting figure. What it cost was reachability: the LST vault and
+  # the Trove are WETH/ETH denominated, and the sell side of every arbitrage had no inventory
+  # behind it, so half of each strategy was structurally dead (issue #54).
+  wethWei: "8000000000000000000" # 8 WETH
+  base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
+  usdcUnits: "25000000000"
+
+flow:
+  uninformedMaxWethWei: "1000000000000000000"
+  informedMaxWethWei: "2000000000000000000"
+  balancerMaxWethWei: "1000000000000000000"
+  curveMaxWethWei: "1000000000000000000"
+  informedArbFeeBps: 30
+  uninformedArrivalRate: "0.9"
+  uninformedSizeSigma: "1.0"
+  gmxArrivalRate: "0.75"
+  gmxSizeSigma: "1.0"
+  aaveActorSizeSigma: "1.0"
+  # WBTC orderflow. Without it nothing exogenous moves the WBTC pools: the fair price walks and
+  # the pool sits still, so the funded WBTC leg is inventory nobody trades against (measured on a
+  # 60-block calm run: 390 WETH base-leg txs against 7 WBTC, all 7 from one agent, and a pool that
+  # moved +0.07% while its fair moved -1.17%). Sized to the WETH flow by notional; one value covers
+  # the uninformed and informed legs on all three venues, where WETH splits them 1x and 2x.
+  baseMax: { WBTC: "5000000" } # 0.05 BTC (8 decimals)
+
+stress:
+  events:
+    - {
+        type: crash,
+        magnitudeRange: [0.15, 0.22],
+        windowFrac: [0.3, 0.7],
+        rampBlocks: 3,
+        holdBlocks: 12,
+        decayBlocks: 12,
+      }
+  # Eight Troves at ICR 1.35, collateral sized at setup so the system's TCR lands on 1.45 at the
+  # crash bottom (issue #59); 100,000 eUSD into the Stability Pool so the Recovery Mode branch can
+  # execute.
+  liquityVictimCount: 8
+  liquityVictimIcr: 1.35
+  liquityRecoveryTcr: 1.45
+  liquitySpSeedEusdWei: "100000000000000000000000"
+agents:
+  - id: noop
+    wallet: AGENT1_PRIVATE_KEY
+    baseline: true
+    description: does nothing (baseline)
+  - id: venue-arb
+    wallet: AGENT2_PRIVATE_KEY
+    description: WETH-only cross-venue arbitrage
+  - id: redemption-arb
+    wallet: AGENT3_PRIVATE_KEY
+    description: buys eUSD below par and redeems it against the riskiest Trove (the victims)
+    env: { ERIS_AGENT_FROZEN: "1" }
+  - id: sp-underwriter
+    wallet: AGENT4_PRIVATE_KEY
+    description: Stability Pool depositor that liquidates the victims itself
+    env: { ERIS_AGENT_FROZEN: "1" }
+  - id: trove-manager
+    wallet: AGENT5_PRIVATE_KEY
+    description: a borrower defending its own Trove against the crash and the redemption path
+    env: { ERIS_AGENT_FROZEN: "1" }

--- a/config/regimes/liquity-crash.yaml
+++ b/config/regimes/liquity-crash.yaml
@@ -16,7 +16,8 @@
 # Funding is WETH-heavy because a Trove needs collateral. That reintroduces price drift into
 # netPnlUsdc; read alphaUsdc, and read scores within a run rather than across price paths.
 #
-# **Recovery Mode is not reachable here** and the regime does not pretend otherwise. The genesis
+# **Recovery Mode is not reachable here** and the regime does not pretend otherwise (it is in
+# config/regimes/cdp-recovery.yaml, where the environment's victim cohort supplies the debt -- issue #59). The genesis
 # Trove is 250 ETH against 250k eUSD (300% ICR) and dwarfs anything agents can open with this
 # funding: measured at seed 501, the system TCR bottoms at 2.244 against a CCR of 1.5. Reaching it
 # needs the system's debt roughly tripled, which dilutes the redemption fee curve and the Stability

--- a/core/src/liquityVictims.ts
+++ b/core/src/liquityVictims.ts
@@ -12,8 +12,14 @@
 // and are never scored (not in agentRuntimes). The same hard requirement as the Aave cohort applies
 // -- fresh state per run, checked by the caller -- because a Trove that lingers from a previous run
 // would sit in the sorted list at an ICR nobody configured.
-import { keccak256, stringToBytes, type Address, type Hex } from "viem";
-import { troveManagerAbi } from "@eris/sdk/abis.js";
+import {
+  encodeFunctionData,
+  keccak256,
+  stringToBytes,
+  type Address,
+  type Hex,
+} from "viem";
+import { stabilityPoolAbi, troveManagerAbi } from "@eris/sdk/abis.js";
 import { accountAddress, fundWallet, sendAndMine } from "@eris/sdk/chain.js";
 import { LIQUITY } from "@eris/sdk/constants.js";
 import { liquityAdapter } from "@eris/sdk/protocols/liquity.js";
@@ -59,6 +65,56 @@ export function victimDebtForIcr(input: {
   const totalDebt = (input.collWei * input.priceWad) / icrWad;
   if (totalDebt <= input.gasCompensationWei) return 0n;
   return ((totalDebt - input.gasCompensationWei) * WAD) / (WAD + input.borrowingRateWad);
+}
+
+// Issue #59: the collateral per victim that drags the system TCR to `targetTcr` at the bottom of
+// a crash of magnitude m, given the system as it stands (the genesis Trove and whatever else is
+// open) and a cohort of `count` Troves opened at ICR₀. Every Trove's collateral is ETH, so at the
+// bottom the numerator is (G_c + N·c)·P·(1 − m) and the denominator G_d + N·c·P/ICR₀; solving
+// TCR' = target for c:
+//   c = (target·G_d − P(1 − m)·G_c) / (N·P·((1 − m) − target/ICR₀))
+// Both sides are negative when the cohort's own post-crash ICR (ICR₀(1 − m)) is under the target --
+// which is the normal case: the cohort is what pulls the system down -- and the quotient is what
+// the run needs. null when no finite cohort reaches the target: the system is already there, or
+// the cohort's post-crash ICR is above the target so adding it can only raise TCR.
+export function recoveryCohortCollateralWei(input: {
+  systemCollWei: bigint;
+  systemDebtWei: bigint;
+  priceWad: bigint;
+  crashMagnitude: number;
+  icr0: number;
+  count: number;
+  targetTcr: number;
+}): bigint | null {
+  const { systemCollWei: gc, systemDebtWei: gd, priceWad: p, count: n } = input;
+  if (n <= 0 || input.crashMagnitude <= 0 || input.crashMagnitude >= 1) return null;
+  const SCALE = 1_000_000n;
+  const oneMinusM = BigInt(Math.round((1 - input.crashMagnitude) * 1e6)); // ×1e6
+  const target = BigInt(Math.round(input.targetTcr * 1e6)); // ×1e6
+  const icr0 = BigInt(Math.round(input.icr0 * 1e6)); // ×1e6
+  // numerator ×1e6·WAD·? -- keep everything in (1e6-scaled) × wei units
+  const num = target * gd - ((p * oneMinusM) / WAD) * gc; // ×1e6 · wei-of-debt
+  // denominator: N · P · ((1−m) − target/ICR₀), ×1e6 scale on the ratio
+  const ratio = oneMinusM - (target * SCALE) / icr0; // ×1e6
+  const den = (BigInt(n) * p * ratio) / WAD; // ×1e6 · (USD per ETH)
+  if (den === 0n) return null;
+  // num is (1e6 · wei-USD), den is (1e6 · USD per ETH): the quotient is ETH × 1e18 = wei.
+  const c = num / den;
+  if (c <= 0n) return null;
+  return c;
+}
+
+// The system TCR at the bottom of a crash once a cohort is in, for the calibration record.
+export function tcrAtCrashBottom(input: {
+  systemCollWei: bigint;
+  systemDebtWei: bigint;
+  priceWad: bigint;
+  crashMagnitude: number;
+}): number {
+  const coll = Number(input.systemCollWei) / 1e18;
+  const debt = Number(input.systemDebtWei) / 1e18;
+  const price = (Number(input.priceWad) / 1e18) * (1 - input.crashMagnitude);
+  return debt > 0 ? (coll * price) / debt : Number.POSITIVE_INFINITY;
 }
 
 // The crash magnitude that puts a Trove opened at ICR₀ below MCR: ICR₀·(1 − m) < MCR ⇔ m > 1 − MCR/ICR₀.
@@ -248,6 +304,46 @@ export async function openLiquityVictimTroves(
         "would open in Recovery Mode. Fewer or smaller victims, or a higher ICR (issue #107; Recovery Mode is #59)",
     );
   return { troves: out, mcr, ccr, tcr };
+}
+
+// The system as it stands, for sizing a Recovery Mode cohort (issue #59).
+export async function readLiquitySystem(
+  ctx: SimContext,
+): Promise<{ collWei: bigint; debtWei: bigint }> {
+  const d = LIQUITY!;
+  const [collWei, debtWei] = (await Promise.all([
+    ctx.publicClient.readContract({
+      address: d.troveManager,
+      abi: troveManagerAbi,
+      functionName: "getEntireSystemColl",
+    }),
+    ctx.publicClient.readContract({
+      address: d.troveManager,
+      abi: troveManagerAbi,
+      functionName: "getEntireSystemDebt",
+    }),
+  ])) as [bigint, bigint];
+  return { collWei, debtWei };
+}
+
+// Issue #59: eUSD the environment puts into the Stability Pool at setup, from the deployer (the
+// holder of the genesis Trove's surplus). Recovery Mode liquidates a Trove between MCR and TCR
+// only when the pool can absorb its whole debt, so a cohort sized for Recovery Mode needs a pool
+// sized for at least one of its Troves, or the branch never executes.
+export async function seedStabilityPool(
+  ctx: SimContext,
+  fromPk: Hex,
+  amountWei: bigint,
+): Promise<void> {
+  const d = LIQUITY!;
+  await sendAndMine(ctx.publicClient, ctx.walletClient, ctx.chain, fromPk, {
+    to: d.stabilityPool,
+    data: encodeFunctionData({
+      abi: stabilityPoolAbi,
+      functionName: "provideToSP",
+      args: [amountWei, "0x0000000000000000000000000000000000000000"],
+    }),
+  });
 }
 
 // The env name the cohort's addresses travel under, for symmetry with ERIS_LIQUIDATION_VICTIMS.

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -94,8 +94,12 @@ import {
   liquityBreachMagnitude,
   LIQUITY_VICTIM_ENV,
   openLiquityVictimTroves,
+  readLiquitySystem,
   readLiquityVictimTroves,
+  recoveryCohortCollateralWei,
+  seedStabilityPool,
   setupLiquityVictims,
+  tcrAtCrashBottom,
   type LiquityVictim,
   type LiquityVictimTrove,
 } from "../liquityVictims.js";
@@ -1397,6 +1401,15 @@ export async function runRealtimeSimulation(
     );
     let minLiquityVictimIcr0: number | null = null;
     let liquityVictimMcr: number | null = null;
+    // Issue #59: when the regime declares the TCR it wants at the crash bottom, the cohort's
+    // collateral is sized from the drawn crash rather than taken from config, and the record
+    // says what that sizing expects.
+    let liquityRecovery: {
+      targetTcr: number;
+      crashMagnitude: number;
+      collWei: bigint;
+      expectedTcrAtBottom: number;
+    } | null = null;
     if (liquityVictims.length > 0) {
       if (!liquityRuntime)
         throw new Error(
@@ -1410,16 +1423,58 @@ export async function runRealtimeSimulation(
             "and do not set ERIS_SKIP_RESET -- a Trove left over from a previous run sits in the sorted " +
             "list at an ICR nobody configured (issue #107; ADR 0009 §4 / ADR 0016 §2)",
         );
-      await setupLiquityVictims(
-        ctx,
-        liquityVictims,
-        config.stressLiquityVictimCollWethWei,
-      );
+      let victimCollWei = config.stressLiquityVictimCollWethWei;
+      if (config.stressLiquityRecoveryTcr > 0) {
+        const crash = schedule.events.find((e) => e.type === "crash");
+        if (!crash)
+          throw new Error(
+            "stress.liquityRecoveryTcr needs a crash event: the cohort is sized from its drawn magnitude (issue #59)",
+          );
+        const system = await readLiquitySystem(ctx);
+        const priceWad =
+          BigInt(Math.round(latestFairPrice * 1e6)) * (10n ** 18n / 1_000_000n);
+        const sized = recoveryCohortCollateralWei({
+          systemCollWei: system.collWei,
+          systemDebtWei: system.debtWei,
+          priceWad,
+          crashMagnitude: crash.magnitude,
+          icr0: config.stressLiquityVictimIcr,
+          count: liquityVictims.length,
+          targetTcr: config.stressLiquityRecoveryTcr,
+        });
+        if (sized === null)
+          throw new Error(
+            `no cohort of ${liquityVictims.length} Troves at ICR ${config.stressLiquityVictimIcr} reaches ` +
+              `TCR ${config.stressLiquityRecoveryTcr} on a ${(crash.magnitude * 100).toFixed(1)} % crash: the ` +
+              "cohort's own post-crash ICR has to be above the target and the system above it before the " +
+              "cohort (issue #59). Lower the target, raise the ICR, or widen the crash",
+          );
+        victimCollWei = sized;
+        const debtEach = (sized * priceWad) / (BigInt(Math.round(config.stressLiquityVictimIcr * 1e6)) * (10n ** 18n / 1_000_000n));
+        liquityRecovery = {
+          targetTcr: config.stressLiquityRecoveryTcr,
+          crashMagnitude: crash.magnitude,
+          collWei: sized,
+          expectedTcrAtBottom: tcrAtCrashBottom({
+            systemCollWei: system.collWei + BigInt(liquityVictims.length) * sized,
+            systemDebtWei: system.debtWei + BigInt(liquityVictims.length) * debtEach,
+            priceWad,
+            crashMagnitude: crash.magnitude,
+          }),
+        };
+      }
+      await setupLiquityVictims(ctx, liquityVictims, victimCollWei);
       const cohort = await openLiquityVictimTroves(ctx, liquityVictims, {
         icr0: config.stressLiquityVictimIcr,
-        collWei: config.stressLiquityVictimCollWethWei,
+        collWei: victimCollWei,
         priceUsd: latestFairPrice,
       });
+      if (config.stressLiquitySpSeedEusdWei > 0n)
+        await seedStabilityPool(
+          ctx,
+          DEFAULT_ANVIL_PRIVATE_KEYS[0],
+          config.stressLiquitySpSeedEusdWei,
+        );
       liquityVictimMcr = cohort.mcr;
       for (const t of cohort.troves)
         if (
@@ -1433,6 +1488,17 @@ export async function runRealtimeSimulation(
         mcr: cohort.mcr,
         ccr: cohort.ccr,
         tcr: cohort.tcr,
+        collWeiPerVictim: victimCollWei.toString(),
+        spSeedEusdWei: config.stressLiquitySpSeedEusdWei.toString(),
+        ...(liquityRecovery
+          ? {
+              recovery: {
+                targetTcr: liquityRecovery.targetTcr,
+                crashMagnitude: liquityRecovery.crashMagnitude,
+                expectedTcrAtBottom: liquityRecovery.expectedTcrAtBottom,
+              },
+            }
+          : {}),
         victims: cohort.troves.map((t) => ({
           id: t.id,
           address: t.address,
@@ -2324,7 +2390,18 @@ export async function runRealtimeSimulation(
       }
       // The same check for the Liquity cohort (issue #107): a Trove at ICR₀ goes under MCR at
       // m > 1 − MCR/ICR₀.
-      if (minLiquityVictimIcr0 !== null && liquityVictimMcr !== null) {
+      if (liquityRecovery !== null) {
+        // The cohort was sized so the drawn crash lands the system on the target; the warning here
+        // is for a target that is not Recovery Mode at all (issue #59).
+        if (liquityRecovery.expectedTcrAtBottom >= 1.5)
+          logger.event({
+            type: "stress_calibration_warning",
+            reason: "crash magnitude may not reach Recovery Mode",
+            targetTcr: liquityRecovery.targetTcr,
+            expectedTcrAtBottom: liquityRecovery.expectedTcrAtBottom,
+            crashMagnitude: liquityRecovery.crashMagnitude,
+          });
+      } else if (minLiquityVictimIcr0 !== null && liquityVictimMcr !== null) {
         const breachThreshold = liquityBreachMagnitude(
           minLiquityVictimIcr0,
           liquityVictimMcr,

--- a/docs/guide/stress-events.md
+++ b/docs/guide/stress-events.md
@@ -224,6 +224,19 @@ never trade; they are not scored.
 aligned to it: liquidation for the Stability Pool, redemption against the victims for redemption arb,
 and a redemption path a borrower has to stay out of.
 
+### Recovery Mode (issue #59)
+
+`liquityRecoveryTcr` makes the same cohort the thing that breaks the *system*: the regime declares the
+TCR it wants at the bottom of its crash, and the coordinator sizes each victim's collateral from the
+crash magnitude the seed drew, the system as it stands and the cohort's ICR (`recoveryCohortCollateralWei`),
+failing fast at setup when no cohort can reach it. The record (`stress_liquity_victims_setup.recovery`)
+says what the sizing expects, and `liquity_block` shows `recoveryMode` / `tcr` as it happens. Recovery
+Mode liquidates a Trove between MCR and TCR only when the Stability Pool can absorb its whole debt, so
+`liquitySpSeedEusdWei` lets the environment put the deployer's eUSD surplus into the pool. The genesis
+Trove is left alone on purpose: lowering it would invert the redemption order and thin the pool for
+every regime (the issue's three reasons). `config/regimes/cdp-recovery.yaml` is the worked example,
+outside the official set.
+
 ## Events emitted
 
 `stress_schedule` (the resolved schedule, once) / `stress_victims_setup` / `stress_victim_hf` /

--- a/docs/spec/07-configuration.md
+++ b/docs/spec/07-configuration.md
@@ -149,6 +149,7 @@ USDC-only を維持しているのは **`metric-*` レジームだけ**で、こ
 | `stress.events` | [] | イベント配列（[04](04-stress-events.md)） |
 | `stress.victimCount` / `victimHf0` / `victimWethWei` | 0 / 1.10 / 5 WETH | 清算 victim |
 | `stress.liquityVictimCount` / `liquityVictimIcr` / `liquityVictimCollWethWei` | 0 / 1.20 / 5 WETH | Liquity victim Trove（issue #107。`liquity` 必須、fresh state 必須） |
+| `stress.liquityRecoveryTcr` / `liquitySpSeedEusdWei` | 0（無効）/ 0 | 暴落の底で system TCR をこの値に落とすよう cohort の担保を setup で逆算する（届かなければ fail-fast）/ 環境が Stability Pool に入れる eUSD（issue #59） |
 | `vuln.events` / `poolLiquidityUsdcUnits` / `poolFeeBps` / `llm` | [] / 2M USDC / 30 / "0" | 脆弱性イベント（ADR 0014） |
 | `lst.simulatedSecondsPerBlock` | 3600 | 経済クロック（1 ブロック = 1 時間） |
 | `lst.apyBps` | 300 | 3%/yr |

--- a/docs/spec/en/07-configuration.md
+++ b/docs/spec/en/07-configuration.md
@@ -149,6 +149,7 @@ The template (`config/example.yaml`) hands out WETH for the same reason — it i
 | `stress.events` | [] | The event list ([04](04-stress-events.md)) |
 | `stress.victimCount` / `victimHf0` / `victimWethWei` | 0 / 1.10 / 5 WETH | Liquidation victims |
 | `stress.liquityVictimCount` / `liquityVictimIcr` / `liquityVictimCollWethWei` | 0 / 1.20 / 5 WETH | Liquity victim Troves (issue #107; needs `liquity` and fresh state) |
+| `stress.liquityRecoveryTcr` / `liquitySpSeedEusdWei` | 0 (off) / 0 | Size the cohort's collateral at setup so the system TCR lands on this value at the crash bottom (fail-fast if unreachable) / eUSD the environment puts into the Stability Pool (issue #59) |
 | `vuln.events` / `poolLiquidityUsdcUnits` / `poolFeeBps` / `llm` | [] / 2M USDC / 30 / "0" | Vulnerability events (ADR 0014) |
 | `lst.simulatedSecondsPerBlock` | 3600 | The economic clock (one block = one hour) |
 | `lst.apyBps` | 300 | 3%/yr |

--- a/example/agents/sp-underwriter/agent.ts
+++ b/example/agents/sp-underwriter/agent.ts
@@ -93,8 +93,18 @@ export function decideUnderwriting(input: {
   // 1. Somebody is under water. Nothing in the pool pays out until this call is made, and whoever
   //    makes it also takes the gas compensation.
   const riskiest = l.riskiestTrove;
-  if (riskiest && riskiest.icr < l.mcr - LIQUIDATION_MARGIN) {
-    return { kind: "liquidate", borrower: riskiest.owner, icr: riskiest.icr };
+  if (riskiest) {
+    // Normal mode: under MCR. Recovery Mode (issue #59): every Trove under the system TCR is
+    // liquidatable too, but Liquity executes that band only when the pool can absorb the Trove's
+    // whole debt (gas compensation included) -- otherwise the call reverts and pays gas for it.
+    const underMcr = riskiest.icr < l.mcr - LIQUIDATION_MARGIN;
+    const entireDebt = BigInt(riskiest.netDebtEusdWei) + 200n * 10n ** 18n;
+    const underTcrInRecovery =
+      l.recoveryMode &&
+      riskiest.icr < l.tcr - LIQUIDATION_MARGIN &&
+      entireDebt <= BigInt(l.spTotalDepositsEusdWei);
+    if (underMcr || underTcrInRecovery)
+      return { kind: "liquidate", borrower: riskiest.owner, icr: riskiest.icr };
   }
 
   // 2. Convert what the last liquidation paid back into the unit this is scored in.

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -101,6 +101,16 @@ export type SimConfig = {
   stressLiquityVictimCount: number;
   stressLiquityVictimIcr: number;
   stressLiquityVictimCollWethWei: bigint;
+  // Issue #59: a regime declares the system TCR it wants at the bottom of its crash
+  // (ERIS_STRESS_LIQUITY_RECOVERY_TCR, 0 = off). The coordinator then sizes each victim's
+  // collateral from the drawn crash magnitude so the cohort drags TCR under that value -- under
+  // CCR (1.5) is Recovery Mode -- and fails fast at setup if no cohort can. Overrides
+  // stressLiquityVictimCollWethWei.
+  stressLiquityRecoveryTcr: number;
+  // Issue #59: eUSD the environment (the deployer, holder of the genesis Trove's surplus) puts
+  // into the Stability Pool at setup (ERIS_STRESS_LIQUITY_SP_SEED_EUSD_WEI, 0 = none). Recovery
+  // Mode liquidates a Trove between MCR and TCR only when the pool can absorb its whole debt.
+  stressLiquitySpSeedEusdWei: bigint;
   // Approximate one-sided liquidity to seed each vuln pool with (in USDC-denominated units). The deeper it is,
   // the less an agent's trade moves the price, so the bait becomes realized profit. ERIS_VULN_POOL_LIQUIDITY_USDC_UNITS (default 2,000,000 USDC).
   vulnPoolLiquidityUsdcUnits: bigint;
@@ -391,6 +401,11 @@ export function loadConfig(env = process.env): SimConfig {
     stressLiquityVictimCollWethWei: bigintEnv(
       env.ERIS_STRESS_LIQUITY_VICTIM_COLL_WETH_WEI,
       5_000_000_000_000_000_000n,
+    ),
+    stressLiquityRecoveryTcr: floatEnv(env.ERIS_STRESS_LIQUITY_RECOVERY_TCR, 0),
+    stressLiquitySpSeedEusdWei: bigintEnv(
+      env.ERIS_STRESS_LIQUITY_SP_SEED_EUSD_WEI,
+      0n,
     ),
     vulnPoolLiquidityUsdcUnits: bigintEnv(
       env.ERIS_VULN_POOL_LIQUIDITY_USDC_UNITS,

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -160,6 +160,9 @@ const SCHEMA: Record<string, string> = {
   "stress.liquityVictimCount": "ERIS_STRESS_LIQUITY_VICTIM_COUNT",
   "stress.liquityVictimIcr": "ERIS_STRESS_LIQUITY_VICTIM_ICR",
   "stress.liquityVictimCollWethWei": "ERIS_STRESS_LIQUITY_VICTIM_COLL_WETH_WEI",
+  // Issue #59: the TCR the cohort has to reach at the crash bottom, and an environment SP seed.
+  "stress.liquityRecoveryTcr": "ERIS_STRESS_LIQUITY_RECOVERY_TCR",
+  "stress.liquitySpSeedEusdWei": "ERIS_STRESS_LIQUITY_SP_SEED_EUSD_WEI",
   // lst (issue #38: liquid staking venue)
   "lst.simulatedSecondsPerBlock": "ERIS_LST_SIMULATED_SECONDS_PER_BLOCK",
   "lst.apyBps": "ERIS_LST_APY_BPS",

--- a/test/liquityAgent.test.ts
+++ b/test/liquityAgent.test.ts
@@ -270,3 +270,35 @@ test("a rising fee curve closes the trade that was open a moment ago", () => {
   );
   assert.equal(d.kind, "hold");
 });
+
+// Issue #59: sp-underwriter liquidates inside Recovery Mode's band (MCR ≤ ICR < TCR) -- but only
+// when the Stability Pool can absorb the Trove's whole debt, because Liquity executes that branch
+// on no other condition and a call that cannot is a reverted transaction.
+test("sp-underwriter: Recovery Mode liquidates under the TCR when the pool covers the debt, and not otherwise", async () => {
+  const { decideUnderwriting } = await import("../example/agents/sp-underwriter/agent.js");
+  const base = {
+    usdcUnits: 25_000n * USDC,
+    wethWei: 8n * WAD,
+    ethWei: WAD,
+    ethBaselineWei: WAD,
+    wethBaselineWei: 8n * WAD,
+    canSellEth: true,
+  };
+  const riskiest = {
+    owner: "0x1111111111111111111111111111111111111111",
+    icr: 1.3,
+    netDebtEusdWei: (40_000n * WAD).toString(),
+  };
+  // Normal mode, ICR 1.3 above MCR: nothing to liquidate.
+  const normal = decideUnderwriting({ ...base, liquity: liquity({ riskiestTrove: riskiest, spDepositEusdWei: (10_000n * WAD).toString() }) });
+  assert.notEqual(normal.kind, "liquidate");
+  // Recovery Mode with TCR 1.45 and a pool of 50,000 eUSD: the 40,200 eUSD Trove is liquidatable.
+  const recovery = decideUnderwriting({ ...base, liquity: liquity({ recoveryMode: true, tcr: 1.45, riskiestTrove: riskiest, spDepositEusdWei: (10_000n * WAD).toString() }) });
+  assert.equal(recovery.kind, "liquidate");
+  // The same Trove with a pool too small for its whole debt: the branch would revert, so no call.
+  const thin = decideUnderwriting({ ...base, liquity: liquity({ recoveryMode: true, tcr: 1.45, riskiestTrove: riskiest, spTotalDepositsEusdWei: (30_000n * WAD).toString(), spDepositEusdWei: (10_000n * WAD).toString() }) });
+  assert.notEqual(thin.kind, "liquidate");
+  // Under MCR the pool size does not matter (offset plus redistribution).
+  const underMcr = decideUnderwriting({ ...base, liquity: liquity({ recoveryMode: true, tcr: 1.45, riskiestTrove: { ...riskiest, icr: 1.05 }, spTotalDepositsEusdWei: (30_000n * WAD).toString(), spDepositEusdWei: (10_000n * WAD).toString() }) });
+  assert.equal(underMcr.kind, "liquidate");
+});

--- a/test/liquityVictims.test.ts
+++ b/test/liquityVictims.test.ts
@@ -48,3 +48,30 @@ test("the breach threshold is 1 − MCR/ICR₀, and the official regime's crash 
   assert.ok(m < 0.12, "cdp-incident's crash floor (12 %) breaches a 1.20 Trove");
   assert.ok(liquityBreachMagnitude(1.1, 1.1) === 0);
 });
+
+// Issue #59: the cohort that reaches Recovery Mode. The genesis Trove (250 ETH / 250,000 eUSD) holds
+// the system at 300 %; a crash of 15 % leaves it at 2.55, far above CCR 1.5. The sizing has to find
+// the collateral per victim -- at ICR₀ -- that brings the system TCR to the target at the bottom.
+test("recoveryCohortCollateralWei sizes a cohort that lands the system on the target TCR", async () => {
+  const { recoveryCohortCollateralWei, tcrAtCrashBottom } = await import("../core/src/liquityVictims.js");
+  const gc = 250n * WAD;
+  const gd = 250_000n * WAD;
+  const priceWad = 3000n * WAD;
+  const c = recoveryCohortCollateralWei({ systemCollWei: gc, systemDebtWei: gd, priceWad, crashMagnitude: 0.15, icr0: 1.35, count: 8, targetTcr: 1.45 });
+  assert.ok(c !== null && c > 0n);
+  // Put the cohort in (debt = c·P/ICR₀ each) and read the TCR at the bottom: it is the target.
+  const n = 8n;
+  const debtEach = (c! * priceWad) / (BigInt(Math.round(1.35 * 1e6)) * (WAD / 1_000_000n));
+  const tcr = tcrAtCrashBottom({ systemCollWei: gc + n * c!, systemDebtWei: gd + n * debtEach, priceWad, crashMagnitude: 0.15 });
+  assert.ok(Math.abs(tcr - 1.45) < 1e-3, `TCR at the bottom ${tcr}`);
+  // Below CCR, i.e. Recovery Mode; and the cohort itself is still above MCR there (1.35 × 0.85 = 1.1475).
+  assert.ok(tcr < 1.5 && 1.35 * 0.85 > 1.1);
+  // Unreachable: a target *below* the cohort's own post-crash ICR (1.35 × 0.85 = 1.1475) cannot be
+  // produced by adding Troves at that ICR -- the system's TCR converges on the cohort's ICR from above.
+  assert.equal(recoveryCohortCollateralWei({ systemCollWei: gc, systemDebtWei: gd, priceWad, crashMagnitude: 0.15, icr0: 1.35, count: 8, targetTcr: 1.1 }), null);
+  // Any target between the two is reachable, with more collateral the closer it sits to the cohort's ICR.
+  const c13 = recoveryCohortCollateralWei({ systemCollWei: gc, systemDebtWei: gd, priceWad, crashMagnitude: 0.15, icr0: 1.35, count: 8, targetTcr: 1.3 });
+  assert.ok(c13 !== null && c13 > c!);
+  // Already there: the system is under the target without a cohort.
+  assert.equal(recoveryCohortCollateralWei({ systemCollWei: 100n * WAD, systemDebtWei: 250_000n * WAD, priceWad, crashMagnitude: 0.15, icr0: 1.35, count: 8, targetTcr: 1.45 }), null);
+});


### PR DESCRIPTION
Closes #59.

Builds on the Liquity victim cohort of #110. The genesis Trove is left alone (the issue's three reasons); the debt that breaks the system is staged by the environment, opt-in per regime.

**Environment**
- `stress.liquityRecoveryTcr` (0 = off): the TCR the system should hit at the bottom of the drawn crash. The coordinator sizes each victim's collateral from the crash magnitude the seed drew, the system as it stands (`getEntireSystemColl/Debt`) and the cohort's ICR — `recoveryCohortCollateralWei` in `core/src/liquityVictims.ts`, the reachability calculation the issue asked for as a unit test — records the expectation in `stress_liquity_victims_setup.recovery`, and fails fast at setup when no cohort can reach it (a target below the cohort's own post-crash ICR, or a system already there).
- `stress.liquitySpSeedEusdWei` (0 = none): eUSD the deployer's surplus puts into the Stability Pool at setup, because Recovery Mode liquidates a Trove between MCR and TCR only when the pool can absorb its whole debt.
- The calibration warning becomes "crash magnitude may not reach Recovery Mode" when a target is declared.
- `sp-underwriter` liquidates inside the MCR–TCR band when the pool covers the Trove's debt, and not otherwise (the call would revert) — unit-tested.

**Regime** — `config/regimes/cdp-recovery.yaml`, **outside the official set** (a venue-verification regime beside `liquity-crash.yaml`, which now points here): crash 15–22 % (0.3–0.7, ramp 3 / hold 12 / decay 12), eight Troves at ICR 1.35 sized for TCR 1.45, 100,000 eUSD seeded into the pool. Promote it when the field has agents that act inside Recovery Mode.

**Measured** (90-block smoke, seed 101, noop + frozen sp-underwriter / trove-manager / redemption-arb):

| | |
|---|---|
| cohort | 8 × 48.4 WETH at ICR 1.35 (debt 107,636 eUSD each), TCR 1.72 at open, pool 150,000 |
| crash | 15.6 %, idx 42–69 |
| Recovery Mode | TCR 1.61 → **1.42** (target 1.45, the OU walk adds a little), `recoveryMode: true` for 14 blocks (idx 44–57), back above CCR at idx 58 |
| liquidation | sp-underwriter liquidated victim-0 at **ICR 1.116 — above MCR, inside the band** — the first Recovery Mode liquidation this venue has executed; pool 162k → 55k, which could not cover a second Trove (the issue's SP point, observed) |
| agents | sp-underwriter +3,619 net · trove-manager −37 (defended with `adjustTrove`) · noop 0; no `stress_calibration_warning` |

**Open points from the issue, as they stand**: fee-curve dilution is real and unmeasured here (no depeg in this regime; `cdp-incident`'s eusdDepeg would need its own calibration at this supply); the pool scales by the seed knob rather than at deploy time; no separate state dump is needed (the cohort is staged per run, ~1 min for eight Troves).

**Also**: CLAUDE.md gains an operations note found on the way — anvil leaves ~2 MB per block of state cache under `~/.foundry/anvil/tmp/anvil-state-*` after every run (61 GB after the fixture week filled this Mac's disk mid-run). `npm test`: 744 tests, 739 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U657JGwSzCHKdi4F2mdcet
