### PR TITLE
flowTrend: the lean is delivered on every venue, from wallets that can carry it (#112)

### DIFF
--- a/config/regimes/calm.yaml
+++ b/config/regimes/calm.yaml
@@ -48,10 +48,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/cdp-incident.yaml
+++ b/config/regimes/cdp-incident.yaml
@@ -61,10 +61,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/cex-drift.yaml
+++ b/config/regimes/cex-drift.yaml
@@ -52,10 +52,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/crash.yaml
+++ b/config/regimes/crash.yaml
@@ -48,10 +48,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/depeg-persist.yaml
+++ b/config/regimes/depeg-persist.yaml
@@ -61,10 +61,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/depeg.yaml
+++ b/config/regimes/depeg.yaml
@@ -53,10 +53,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/informed-flow.yaml
+++ b/config/regimes/informed-flow.yaml
@@ -48,18 +48,28 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 
 flow:
   uninformedMaxWethWei: "1000000000000000000" # calm's. The episodes below multiply it while open
   informedMaxWethWei: "2000000000000000000" # unchanged: this is the force pushing back
-  balancerMaxWethWei: "1000000000000000000" # one cap for both legs on this venue -- see the caveat above
-  curveMaxWethWei: "1000000000000000000" # ditto
+  # One configured cap for both legs on these two venues. The flowTrend windows scale the uninformed
+  # leg's copy of it, not the informed leg's (issue #112: until then the lean reached uniswap only).
+  balancerMaxWethWei: "1000000000000000000"
+  curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
   uninformedArrivalRate: "0.9"
   uninformedSizeSigma: "1.0"

--- a/config/regimes/lending-incident.yaml
+++ b/config/regimes/lending-incident.yaml
@@ -48,10 +48,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/spike.yaml
+++ b/config/regimes/spike.yaml
@@ -55,10 +55,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/vuln.yaml
+++ b/config/regimes/vuln.yaml
@@ -55,10 +55,18 @@ funding:
   # The same ETH/BTC/USDC basket as every other regime (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/config/regimes/whale.yaml
+++ b/config/regimes/whale.yaml
@@ -48,10 +48,18 @@ funding:
   # behind it, so half of each strategy was structurally dead (issue #54).
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
-  # The flow wallets' own WBTC, so the informed flow can sell the base as well as buy it. Without it
-  # every WBTC sell was submitted against a zero balance (~90 % of the WBTC informed rows reverted,
-  # and the WBTC pools sat ~110 bps above fair for the whole epoch; issue #99). WETH is not funded
-  # here on purpose: the flow buys it first, and that path was measured clean (1,012/1,012).
+  # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
+  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
+  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
+  # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
+  # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
+  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
+  # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
+  flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
+  flowUsdcUnits: "450000000000" # 450,000 USDC per flow wallet (= 150 WETH at $3,000)
   flowBase: { WBTC: "50000000" } # 0.5 WBTC per flow wallet
   usdcUnits: "25000000000"
 

--- a/core/src/coordinator.ts
+++ b/core/src/coordinator.ts
@@ -205,6 +205,17 @@ export async function buildFlowContext(
       informedFlowMaxWethWei: ctx.config.informedFlowMaxWethWei.toString(),
       balancerFlowMaxWethWei: ctx.config.balancerFlowMaxWethWei.toString(),
       curveFlowMaxWethWei: ctx.config.curveFlowMaxWethWei.toString(),
+      // The same window scales the uninformed leg on the two venues whose cap is shared by both
+      // legs (issue #112). Without these the lean reached uniswap only, and the measured size in a
+      // declared x2-3 window was x1.3: one venue at x3, two at x1.
+      balancerUninformedFlowMaxWethWei: scaleWei(
+        ctx.config.balancerFlowMaxWethWei,
+        flowTrend?.sizeMult ?? 1,
+      ).toString(),
+      curveUninformedFlowMaxWethWei: scaleWei(
+        ctx.config.curveFlowMaxWethWei,
+        flowTrend?.sizeMult ?? 1,
+      ).toString(),
       gmxFlowMaxSizeUsd: ctx.config.gmxFlowMaxSizeUsd.toString(),
       gmxFlowActivityProb: String(ctx.config.gmxFlowActivityProb),
       gmxFlowMaxBurst: String(ctx.config.gmxFlowMaxBurst),

--- a/core/src/flow/logic.ts
+++ b/core/src/flow/logic.ts
@@ -35,6 +35,14 @@ export type FlowLimits = {
   informedFlowMaxWethWei: bigint;
   balancerFlowMaxWethWei: bigint;
   curveFlowMaxWethWei: bigint;
+  // The uninformed leg's cap on the two venues that otherwise share one cap for both legs. A
+  // flowTrend window scales the uninformed size (issue #56), and until issue #112 that scaling only
+  // reached uniswap, whose uninformed leg reads `uninformedFlowMaxWethWei`: balancer and curve read
+  // their shared cap, which the coordinator sent unscaled, so two of the three venues sat at x1.0
+  // through every window (measured: uniswap x2.98, balancer x1.05, curve x1.00). Defaults to the
+  // venue cap when the wire omits it.
+  balancerUninformedFlowMaxWethWei: bigint;
+  curveUninformedFlowMaxWethWei: bigint;
   gmxFlowMaxSizeUsd: bigint;
   // Per-block probability of emitting gmx flow (0..1, default 0.5). Decided by rng each block and sent sporadically.
   gmxFlowActivityProb: number;
@@ -108,6 +116,10 @@ export type FlowContextWire = {
     informedFlowMaxWethWei: string;
     balancerFlowMaxWethWei: string;
     curveFlowMaxWethWei: string;
+    // Issue #112: the uninformed leg's cap on balancer/curve, scaled by the flowTrend window like
+    // uninformedFlowMaxWethWei. Absent = the venue cap (the pre-#112 wire).
+    balancerUninformedFlowMaxWethWei?: string;
+    curveUninformedFlowMaxWethWei?: string;
     gmxFlowMaxSizeUsd: string;
     gmxFlowActivityProb?: string;
     gmxFlowMaxBurst?: string;
@@ -760,6 +772,12 @@ export function decodeFlowLimits(wire: FlowContextWire["limits"]): FlowLimits {
     informedFlowMaxWethWei: BigInt(wire.informedFlowMaxWethWei),
     balancerFlowMaxWethWei: BigInt(wire.balancerFlowMaxWethWei),
     curveFlowMaxWethWei: BigInt(wire.curveFlowMaxWethWei),
+    balancerUninformedFlowMaxWethWei: BigInt(
+      wire.balancerUninformedFlowMaxWethWei ?? wire.balancerFlowMaxWethWei,
+    ),
+    curveUninformedFlowMaxWethWei: BigInt(
+      wire.curveUninformedFlowMaxWethWei ?? wire.curveFlowMaxWethWei,
+    ),
     gmxFlowMaxSizeUsd: BigInt(wire.gmxFlowMaxSizeUsd),
     gmxFlowActivityProb: clampProb(wire.gmxFlowActivityProb, 0.5),
     gmxFlowMaxBurst: Math.max(1, Number(wire.gmxFlowMaxBurst ?? "1")),
@@ -792,11 +810,15 @@ export function buildFlowOrders(
   };
 
   // [uninformedMax, informedMax] per AMM (uniswap/balancer/curve).
-  // balancer/curve use a single cap for both.
+  // balancer/curve configure a single cap for both legs; the uninformed leg reads its own copy so
+  // a flowTrend window can scale it without scaling the informed leg (issue #112).
   const ammMax: Record<"uniswap" | "balancer" | "curve", [bigint, bigint]> = {
     uniswap: [limits.uninformedFlowMaxWethWei, limits.informedFlowMaxWethWei],
-    balancer: [limits.balancerFlowMaxWethWei, limits.balancerFlowMaxWethWei],
-    curve: [limits.curveFlowMaxWethWei, limits.curveFlowMaxWethWei],
+    balancer: [
+      limits.balancerUninformedFlowMaxWethWei,
+      limits.balancerFlowMaxWethWei,
+    ],
+    curve: [limits.curveUninformedFlowMaxWethWei, limits.curveFlowMaxWethWei],
   };
 
   for (const protocol of ctx.protocols) {

--- a/core/src/realtime/coordinator.ts
+++ b/core/src/realtime/coordinator.ts
@@ -877,6 +877,10 @@ export async function runRealtimeSimulation(
       // they are machinery, and a dry flow bot removes market activity from everyone.
       const gasBuffer = isFlow ? undefined : 0n;
       const ethWei = isFlow ? config.flowEthWei : config.initialEthWei;
+      // Both sides of the flow's inventory are the regime's to size (issue #112): a flowTrend hold
+      // that leans one way for 30 blocks spends the wallet's whole balance on that side, and a
+      // wallet funded like an agent delivers x1.4 of a declared x2-3 lean.
+      const usdcUnits = isFlow ? config.flowUsdcUnits : config.initialUsdcUnits;
       if (!t.privateKey) {
         // A participant's own address (ADR 0021 §2). Same endowment, reached without signing as
         // them -- and therefore without the venue approvals below, which only they can grant.
@@ -887,7 +891,7 @@ export async function runRealtimeSimulation(
           t.address,
           ethWei,
           wethWei,
-          config.initialUsdcUnits,
+          usdcUnits,
           baseAmounts,
           gasBuffer,
         );
@@ -900,7 +904,7 @@ export async function runRealtimeSimulation(
         t.privateKey,
         ethWei,
         wethWei,
-        config.initialUsdcUnits,
+        usdcUnits,
         baseAmounts,
         gasBuffer,
       );

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -24,7 +24,7 @@ Committed templates in `config/`: `example.yaml` (the default roster) / `lst.yam
 |---|---|---|
 | `run` | run knobs (SEED, block count, realtime cap, enabled venues, mode, world reset unit) | `protocols: [uniswap, balancer, curve]` |
 | `market` | the fair-price OU parameters (volatility / kappa / drift, and their per-base forms) | `kappa: "0.004"` |
-| `funding` | initial distribution (a USDC-only distribution can eliminate initial directional exposure); `flowBase` is the flow wallets' own inventory of the non-WETH bases, so the background flow can sell them as well as buy them | `wethWei: "0"`, `flowBase: { WBTC: "50000000" }` |
+| `funding` | initial distribution (a USDC-only distribution can eliminate initial directional exposure); `flowWethWei` / `flowUsdcUnits` / `flowBase` are the flow wallets' own inventory, sized so a `flowTrend` hold can be delivered on either side (issue #112) and so the background flow can sell the non-WETH bases as well as buy them | `wethWei: "0"`, `flowBase: { WBTC: "50000000" }` |
 | `limits` | per-round caps for agents | `agentWethWei: "1000000000000000000"` |
 | `flow` | orderflow bot intensity (how much it moves the market) | `uninformedMaxWethWei: "1000000000000000000"` |
 | `stress` | market stress events (default off) | [stress-events.md](stress-events.md) |

--- a/docs/guide/stress-events.md
+++ b/docs/guide/stress-events.md
@@ -154,6 +154,21 @@ The other `process` event: while the window is open, uninformed order flow is sc
 ramp" is not a weaker version of the regime, it is a different regime. Calibrated from
 `config/regimes/informed-flow.yaml`: size 3x, persist 12, correlation 1.0.
 
+**The lean is only as large as the flow wallets' inventory.** An uninformed sell larger than the
+wallet's base balance flips to a buy, and a buy is capped at the wallet's USDC, so a 30-block hold in
+one direction spends whatever the wallet holds on that side: a x3 hold is ~51 WETH of one-way flow
+per venue wallet (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks). With the wallets
+funded like agents (0 WETH / 25k USDC) the measured lean on `informed-flow#101` was x1.37 for 3 blocks
+against the declared x2-3 for 12; with 10 WETH, x1.67 for 8.6 blocks (issue #112). The official
+regimes therefore give every flow wallet `funding.flowWethWei` 150 WETH and `funding.flowUsdcUnits`
+450,000 USDC -- two same-direction windows with margin, 7.5 % of a venue's depth -- and a regime that
+declares a `flowTrend` without that inventory delivers a smaller, shorter lean than it says.
+
+The size multiplier reaches every AMM venue. Balancer and curve configure one cap for both flow legs
+(`flow.balancerMaxWethWei` / `curveMaxWethWei`); the window scales the uninformed leg's copy of it and
+leaves the informed leg -- the force pushing back -- where it was. Until issue #112 only uniswap's leg
+was scaled (measured x2.98 / x1.05 / x1.00 across the three venues).
+
 ## Options that cut across types
 
 | key | applies to | what it does |

--- a/docs/spec/02-runtime.md
+++ b/docs/spec/02-runtime.md
@@ -52,8 +52,8 @@
    | 対象 | ETH | base | stable |
    |---|---|---|---|
    | agent | `funding.ethWei`（**ガスバッファ 0**） | `funding.wethWei` / `funding.base` | `funding.usdcUnits` |
-   | flow ウォレット | `funding.flowEthWei` | `funding.flowWethWei` / `funding.flowBase` | 同上 |
-   | aave actor | 同上 | `flow.aaveMaxWethWei × 6` | 同上 |
+   | flow ウォレット | `funding.flowEthWei` | `funding.flowWethWei` / `funding.flowBase` | `funding.flowUsdcUnits`（既定は agent と同額） |
+   | aave actor | 同上 | `flow.aaveMaxWethWei × 6` | `funding.flowUsdcUnits` |
 
    エージェントのガスバッファを 0 にするのは、既定バッファが**選んでいない β** としてエポック系列に乗るため（ADR 0019 §6）。flow ウォレットは機械なのでバッファを持つ。
    鍵を持たない登録参加者へは `fundAddress` で配る（approve は本人しか出せないので付かない）。

--- a/docs/spec/07-configuration.md
+++ b/docs/spec/07-configuration.md
@@ -94,7 +94,8 @@ RPC URL や chain id が秘密情報側にあるのは、**それらが regime �
 | `usdcUnits` | 25,000 USDC | 初期 USDC |
 | `base` | `{WETH: wethWei}` | 追加 base の初期在庫 |
 | `flowEthWei` | 1,000 ETH | flow ウォレットの native |
-| `flowWethWei` | 0 | flow ウォレットの WETH |
+| `flowWethWei` | 0 | flow ウォレットの WETH（公式レジームは 150 WETH。`flowTrend` の hold に売り側の在庫を持たせる。issue #112） |
+| `flowUsdcUnits` | `usdcUnits` | flow ウォレットの USDC（公式レジームは 450,000 USDC = $3,000 換算で 150 WETH。同じ hold の買い側） |
 | `flowBase` | {} | flow ウォレットの追加 base |
 
 **公式レジームは ETH / BTC / USDC のバスケットを配る**（8 WETH + 0.4 WBTC + 25k USDC。issue #54）。当初は USDC-only（`wethWei: "0"`）で初期 β を消していたが（ADR 0017 §4）、**LST vault と Trove は WETH/ETH 建てなので、USDC-only では各戦略の売り側に在庫が無く構造的に死ぬ**ことが分かった。β はベンチマークも同じ配布を持つので M9 からは相殺される — USDC-only が守っていたのは報告値である `netPnlUsdc` の方だった。

--- a/docs/spec/en/02-runtime.md
+++ b/docs/spec/en/02-runtime.md
@@ -50,8 +50,8 @@ Source: `core/src/realtime/coordinator.ts` (`runRealtimeSimulation`, L390–2761
    | Target | ETH | base | stable |
    |---|---|---|---|
    | agent | `funding.ethWei` (**no gas buffer**) | `funding.wethWei` / `funding.base` | `funding.usdcUnits` |
-   | flow wallet | `funding.flowEthWei` | `funding.flowWethWei` / `funding.flowBase` | same |
-   | aave actor | same | `flow.aaveMaxWethWei × 6` | same |
+   | flow wallet | `funding.flowEthWei` | `funding.flowWethWei` / `funding.flowBase` | `funding.flowUsdcUnits` (defaults to the agents') |
+   | aave actor | same | `flow.aaveMaxWethWei × 6` | `funding.flowUsdcUnits` |
 
    Agents get no gas buffer because the default buffer would ride the epoch series as **β nobody chose** (ADR 0019 §6). Flow wallets keep theirs — they are machinery, and a dry flow bot removes market activity from everyone.
    A registered address with no key is funded through `fundAddress` (it gets no approvals, since only the holder can grant them).

--- a/docs/spec/en/07-configuration.md
+++ b/docs/spec/en/07-configuration.md
@@ -94,7 +94,8 @@ Keys are **nested lowercase**, mapped to internal env names by `SCHEMA` (`sdk/sr
 | `usdcUnits` | 25,000 USDC | Opening USDC |
 | `base` | `{WETH: wethWei}` | Opening inventory for other bases |
 | `flowEthWei` | 1,000 ETH | Flow wallets' native balance |
-| `flowWethWei` | 0 | Flow wallets' WETH |
+| `flowWethWei` | 0 | Flow wallets' WETH (the official regimes: 150 WETH, so a `flowTrend` hold has a sell side; issue #112) |
+| `flowUsdcUnits` | `usdcUnits` | Flow wallets' USDC (the official regimes: 450,000 USDC = 150 WETH at $3,000, the buy side of the same hold) |
 | `flowBase` | {} | Flow wallets' other bases |
 
 **The official regimes hand out an ETH/BTC/USDC basket** (8 WETH + 0.4 WBTC + 25k USDC, issue #54). They began as USDC-only (`wethWei: "0"`) to remove opening β (ADR 0017 §4), until it turned out that **the LST vault and the Trove are WETH/ETH denominated, so under USDC-only the sell side of every strategy had no inventory behind it**. The β cancels out of M9 because the benchmark holds the same funding — what USDC-only was protecting was `netPnlUsdc`, a reporting figure.

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -232,6 +232,11 @@ export type SimConfig = {
   // Default 0 = as before (flow also has no base).
   flowWethWei: bigint;
   flowBaseAmounts: Record<string, bigint>;
+  // The flow wallets' USDC. Used to be the agents' `initialUsdcUnits` with no knob of its own,
+  // which capped the buy side of a flowTrend hold the same way a missing WETH balance capped the
+  // sell side (issue #112: 25k USDC is ~8 WETH at $3,000, and a x3 hold buys ~50 WETH per venue).
+  // Default = initialUsdcUnits, so a config that does not set it funds the flow as before.
+  flowUsdcUnits: bigint;
   initialWethWei: bigint;
   // ADR 0013: base symbol -> initial distribution amount (token units). WETH equals initialWethWei
   // for compatibility. Additional bases are read from INITIAL_<SYM>_<UNIT> (e.g. INITIAL_WBTC_SATS),
@@ -455,6 +460,10 @@ export function loadConfig(env = process.env): SimConfig {
       WETH: initialWethWei,
     }),
     initialUsdcUnits: bigintEnv(env.INITIAL_USDC_UNITS, 25_000_000_000n),
+    flowUsdcUnits: bigintEnv(
+      env.FLOW_USDC_UNITS,
+      bigintEnv(env.INITIAL_USDC_UNITS, 25_000_000_000n),
+    ),
     defaultPriorityFeeWei: bigintEnv(
       env.DEFAULT_PRIORITY_FEE_WEI,
       100_000_000n,

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -119,6 +119,7 @@ const SCHEMA: Record<string, string> = {
   "funding.usdcUnits": "INITIAL_USDC_UNITS",
   "funding.flowEthWei": "ERIS_FLOW_ETH_WEI",
   "funding.flowWethWei": "FLOW_WETH_WEI",
+  "funding.flowUsdcUnits": "FLOW_USDC_UNITS",
   // fees. What used to be the `limits` section -- per-order size caps for every venue, plus the
   // bundle-length and open-position counts -- is gone: the competition has no order-size cap, and
   // a knob that only ever reads "unlimited" is a knob someone will eventually set.

--- a/test/flowTrendInventory.test.ts
+++ b/test/flowTrendInventory.test.ts
@@ -1,0 +1,98 @@
+// Issue #112: a flowTrend lean is delivered by the flow wallets' inventory, not by the event alone.
+// An uninformed sell larger than the wallet's base balance flips to a buy (core/src/flow/logic.ts,
+// baseHeld) and a buy is capped at the wallet's USDC (capUsdc), so a hold that leans one way for 30
+// blocks spends the wallet's whole balance on that side. Measured on informed-flow#101 with the
+// wallets funded like agents (0 WETH / 25k USDC): x1.37 for 3 blocks against a declared x2-3 for 12.
+//
+// This test derives, from each official regime's own flow and stress sections, how much one-way
+// flow the largest possible lean sends through one venue wallet, and requires the regime to fund
+// both sides of it. It also pins the eleven regimes to one funding: the flow is machinery shared by
+// the set, and a regime whose wallets behave differently is a second answer to what the flow is.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+const OFFICIAL = [
+  "calm",
+  "cex-drift",
+  "crash",
+  "depeg",
+  "depeg-persist",
+  "informed-flow",
+  "lending-incident",
+  "spike",
+  "vuln",
+  "whale",
+  "cdp-incident",
+];
+
+// The state dump's opening fair (backtest/state, market.json `fair.WETH`); the USDC side of a
+// lean is its WETH side at this price.
+const FAIR_USDC_PER_WETH = 3000;
+
+type Doc = {
+  funding: { flowWethWei?: string; flowUsdcUnits?: string; usdcUnits: string };
+  flow: { uninformedMaxWethWei: string; uninformedArrivalRate: string };
+  stress?: {
+    events?: {
+      type: string;
+      magnitudeRange?: [number, number];
+      rampBlocks?: number;
+      holdBlocks?: number;
+      decayBlocks?: number;
+    }[];
+  };
+};
+
+function load(name: string): Doc {
+  return parse(readFileSync(`config/regimes/${name}.yaml`, "utf8")) as Doc;
+}
+
+// One-way WETH a venue wallet sends through the sum of the regime's flowTrend windows, every window
+// drawn at its largest magnitude and all of them leaning the same way. The uninformed size is
+// lognormal with mean uninformedMax x 0.5 (logic.ts), arrivals are Poisson(rate) per block, and the
+// trapezoid's ramp and decay count half.
+function worstCaseOneWayWeth(doc: Doc): number {
+  const meanWeth = (Number(doc.flow.uninformedMaxWethWei) / 1e18) * 0.5;
+  const rate = Number(doc.flow.uninformedArrivalRate);
+  let total = 0;
+  for (const e of doc.stress?.events ?? []) {
+    if (e.type !== "flowTrend") continue;
+    const mag = Math.max(...(e.magnitudeRange ?? [1, 1]));
+    const blocks = (e.rampBlocks ?? 0) / 2 + (e.holdBlocks ?? 0) + (e.decayBlocks ?? 0) / 2;
+    total += meanWeth * mag * rate * blocks;
+  }
+  return total;
+}
+
+test("informed-flow's two x3 windows are ~103 WETH of one-way flow per venue wallet", () => {
+  const w = worstCaseOneWayWeth(load("informed-flow"));
+  assert.ok(w > 100 && w < 106, `one-way WETH ${w}`);
+});
+
+for (const name of OFFICIAL) {
+  test(`config/regimes/${name}.yaml funds both sides of its largest flowTrend lean`, () => {
+    const doc = load(name);
+    const need = worstCaseOneWayWeth(doc);
+    const weth = Number(doc.funding.flowWethWei ?? "0") / 1e18;
+    const usdc = Number(doc.funding.flowUsdcUnits ?? doc.funding.usdcUnits) / 1e6;
+    assert.ok(
+      weth >= need,
+      `${name}: flowWethWei ${weth} WETH < ${need.toFixed(1)} WETH the lean's sell side spends`,
+    );
+    assert.ok(
+      usdc >= need * FAIR_USDC_PER_WETH,
+      `${name}: flowUsdcUnits ${usdc} USDC < ${(need * FAIR_USDC_PER_WETH).toFixed(0)} the lean's buy side spends`,
+    );
+  });
+}
+
+test("the official regimes fund the flow wallets identically", () => {
+  const funding = OFFICIAL.map((n) => {
+    const f = load(n).funding;
+    return `${f.flowWethWei}/${f.flowUsdcUnits}`;
+  });
+  assert.equal(new Set(funding).size, 1, `flow funding differs across regimes: ${funding.join(" ")}`);
+  assert.equal(funding[0], "150000000000000000000/450000000000");
+});

--- a/test/flowTrendVenueSize.test.ts
+++ b/test/flowTrendVenueSize.test.ts
@@ -1,0 +1,102 @@
+// Issue #112: a flowTrend window scales the uninformed order size on every AMM venue, not only on
+// uniswap. Balancer and curve configure one cap for both legs, and the coordinator used to send
+// that cap unscaled, so the uninformed leg on two of the three venues sat at x1.0 through every
+// window (measured on informed-flow#101: uniswap x2.98, balancer x1.05, curve x1.00 -- x1.3 overall
+// against a declared x2-3). The wire now carries the uninformed leg's own copy of the venue cap,
+// which the coordinator scales the way it scales uninformedFlowMaxWethWei.
+process.env.ERIS_LOCAL_DEPLOY = "1";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { Rng } = await import("@eris/sdk/rng.js");
+const { buildFlowOrders } = await import("../core/src/flow/logic.js");
+type FlowContextWire = import("../core/src/flow/logic.js").FlowContextWire;
+
+const ONE = 1_000_000_000_000_000_000n;
+const MULT = 3n;
+
+function wire(scaled: boolean, round = 4): FlowContextWire {
+  return {
+    round,
+    fairPriceUsdcPerWeth: 3000,
+    protocols: ["uniswap", "balancer", "curve"],
+    poolPrices: { uniswap: 3000, balancer: 3000, curve: 3000 },
+    flowSeed: 101,
+    limits: {
+      uninformedFlowMaxWethWei: (scaled ? ONE * MULT : ONE).toString(),
+      informedFlowMaxWethWei: (ONE * 2n).toString(),
+      balancerFlowMaxWethWei: ONE.toString(),
+      curveFlowMaxWethWei: ONE.toString(),
+      ...(scaled
+        ? {
+            balancerUninformedFlowMaxWethWei: (ONE * MULT).toString(),
+            curveUninformedFlowMaxWethWei: (ONE * MULT).toString(),
+          }
+        : {}),
+      gmxFlowMaxSizeUsd: "0",
+      aaveFlowMaxWethWei: "0",
+      aaveFlowBorrowUsdcUnits: "0",
+      defaultPriorityFeeWei: "100000000",
+      uninformedArrivalRate: "2",
+      uninformedSizeSigma: "1.0",
+      uninformedFlowPersistBlocks: "12",
+      uninformedFlowTrendCorrelation: "1",
+    },
+  };
+}
+
+function ammOrders(scaled: boolean) {
+  // The same Rng position on both sides: the size is a fraction of the cap, drawn from a stream that
+  // does not depend on the cap, so order i on both sides is the same draw against a different cap.
+  // Several rounds, because arrivals are Poisson and one round can leave a venue with none.
+  const rng = new Rng(2024);
+  return [1, 2, 3, 4, 5, 6, 7, 8].flatMap((round) =>
+    buildFlowOrders(rng, wire(scaled, round)).filter((o) =>
+      ["uniswap", "balancer", "curve"].includes(o.protocol),
+    ),
+  );
+}
+
+test("a scaled window multiplies the uninformed size on all three AMM venues by the same factor", () => {
+  const base = ammOrders(false);
+  const lean = ammOrders(true);
+  assert.equal(base.length, lean.length, "the window changes sizes, not the number of orders");
+  const seen = new Set<string>();
+  for (let i = 0; i < base.length; i++) {
+    const a = base[i];
+    const b = lean[i];
+    assert.equal(a.protocol, b.protocol);
+    assert.equal(a.kind, b.kind);
+    const amtA = BigInt((a.action as { amountIn: string }).amountIn);
+    const amtB = BigInt((b.action as { amountIn: string }).amountIn);
+    if (a.kind !== "uninformed") {
+      assert.equal(amtB, amtA, `${a.protocol} informed leg is not scaled by the window`);
+      continue;
+    }
+    seen.add(a.protocol);
+    // USDC-side amounts go through an integer conversion, so allow its rounding.
+    const ratio = Number(amtB) / Number(amtA);
+    assert.ok(
+      Math.abs(ratio - Number(MULT)) < 1e-6,
+      `${a.protocol} uninformed order ${i}: x${ratio.toFixed(6)} (expected x${MULT})`,
+    );
+  }
+  assert.deepEqual([...seen].sort(), ["balancer", "curve", "uniswap"], "every venue emitted an uninformed order");
+});
+
+test("a wire without the per-venue uninformed caps reads the venue cap (the pre-#112 wire)", () => {
+  const w = wire(false);
+  const withExplicit = {
+    ...w,
+    limits: {
+      ...w.limits,
+      balancerUninformedFlowMaxWethWei: w.limits.balancerFlowMaxWethWei,
+      curveUninformedFlowMaxWethWei: w.limits.curveFlowMaxWethWei,
+    },
+  };
+  assert.deepEqual(
+    buildFlowOrders(new Rng(2024), w),
+    buildFlowOrders(new Rng(2024), withExplicit),
+  );
+});


### PR DESCRIPTION
Closes #112.

## What was wrong

Issue #112 measured that `informed-flow`'s declared x2–3 lean held for 12 blocks arrived as **x1.37 for 3 blocks**. Two causes, both fixed here:

1. **The flow wallets could not carry the lean.** No WETH and an agent's 25k USDC (~8 WETH at $3,000). An uninformed sell larger than the wallet's base balance flips to a buy, a buy is capped at the wallet's USDC, so a 30-block hold in one direction spent the wallet within the ramp on either side.
2. **The size multiplier only reached uniswap.** Balancer and curve configure one cap for both flow legs and the coordinator sent it unscaled, so two of the three venues sat at x1.0 through every window (measured x2.98 / x1.05 / x1.00).

## What changed

- **All eleven official regimes** fund each flow wallet with **150 WETH + 450,000 USDC** (`funding.flowWethWei`, new `funding.flowUsdcUnits`). A x3 hold is ~51 WETH of one-way flow per venue wallet and informed-flow holds two windows, so this covers two same-direction windows with margin; it is 7.5 % of a venue's depth, and the flow is machinery, unscored.
- `funding.flowUsdcUnits` defaults to the agents' `usdcUnits`, so older configs fund the flow as before.
- The flow wire carries `balancerUninformedFlowMaxWethWei` / `curveUninformedFlowMaxWethWei`, scaled by the window like `uninformedFlowMaxWethWei`. The informed leg (the force pushing back) is untouched; a wire without the fields reads the venue cap as before.
- Docs: `docs/guide/stress-events.md` (`flowTrend`), spec 02/07 (ja/en), guide configuration table.
- Tests: `test/flowTrendInventory.test.ts` (every official regime funds both sides of its largest possible lean, derived from its own `flow` / `stress` sections, and all fund the flow identically) and `test/flowTrendVenueSize.test.ts` (a scaled window multiplies the uninformed size on all three AMM venues by the same factor, informed leg unchanged, absent fields fall back).

## Measured (`informed-flow#101`, 360 blocks, process sandbox — the issue's table)

| flow wallets | swaps inside / outside | mean size inside vs outside | majority-direction run length inside (mean / max) | flow reverts |
|---|---|---|---|---|
| 0 WETH / 25k USDC (before) | 188 / 694 | **x1.37** | **3.0** / 13 | 3 |
| 10 WETH probe (issue) | 162 / 738 | x1.67 | 8.6 / 20 | 3 |
| 150 WETH / 450k USDC, funding only | 242 / 770 | x1.33 (hold x1.29) | 12.8 / 39 (hold 18.0) | 1 |
| **+ per-venue scaling (this PR)** | 242 / 700 | **x2.02 (hold x2.41)** | **12.1 / 32 (hold 19.0 / 34)** | **0** |

Declared windows on this seed: x2.09 and x2.97, `persistBlocks: 12`. Per venue in the holds, before → after: uniswap x2.98 → x2.87, balancer x1.05 → x2.10, curve x1.00 → x2.10. In the x2.97 hold each wallet bought ~40 WETH (~$120k), inside the 450k USDC.

Not in scope: `flowTrend` has no per-base semantics (`flowTrendAt` ignores `base`), so the WBTC flow's `baseMax` is not scaled by a window. Left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
