### PR TITLE
dashboard: one rule for why an agent's log is absent, for operator-run agents too (#69)

### DIFF
--- a/dashboard/src/components/WorldPanels.tsx
+++ b/dashboard/src/components/WorldPanels.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { agentIcon, WorldIcon } from "@/components/WorldGlyphs";
+import { decisionLogAbsence } from "@/data/logVisibility";
 import { t } from "@/i18n/messages";
 import { formatCompactUsd, formatPnlUsdc } from "@/lib/format";
 import { navigate } from "@/navigation";
@@ -56,6 +57,8 @@ export function AgentLogPanel({
 }) {
   const listRef = useRef<HTMLDivElement>(null);
   const node = agents.find((a) => a.id === agent);
+  // Which reason to give when there is nothing to list: the same rule as the agent page (#69).
+  const absence = decisionLogAbsence(node?.external === true, withheld);
 
   // Only what has happened by the head. A log scrolled past the block the board is showing would
   // be telling the viewer what the agent is about to do.
@@ -130,10 +133,10 @@ export function AgentLogPanel({
       >
         {!agent ? (
           <Empty text={t("world.pickAgent")} />
-        ) : withheld ? (
+        ) : absence === "audience" ? (
           <Empty text={t("world.logsWithheld")} />
-        ) : node?.external ? (
-          <Empty text={t("world.logExternal", { id: node.id })} />
+        ) : absence === "self-hosted" ? (
+          <Empty text={t("world.logExternal", { id: node?.id ?? "" })} />
         ) : upToHead.length === 0 ? (
           <Empty
             text={

--- a/dashboard/src/data/logVisibility.ts
+++ b/dashboard/src/data/logVisibility.ts
@@ -1,0 +1,25 @@
+// Why an agent's decision log (and the mempool self-reports written to the same file) is absent
+// from a page, so the page can say it instead of rendering an empty list (issue #69).
+//
+// Two reasons exist and they are not the same claim:
+//
+//   - "audience": the server is not serving `agents/<id>.jsonl` to anyone because the competition
+//     is running (server/runsApi.ts audience mode). The log is a participant's own reasoning, and
+//     its mempool rows are bids not yet included in a block (rules §2.6). This applies to every
+//     agent, operator-run or not, so it takes precedence: in the public view the fact that a log
+//     was never written here is not the reason it is absent.
+//   - "self-hosted": the agent runs on its owner's machine (practice devnet, ADR 0021), so nothing
+//     was ever written under runs/ for it. Only true of `external` agents.
+//
+// Both callers -- the agent page and the board's log panel -- used to derive this inline, and
+// disagreed on the precedence. `null` means the log is there to show.
+export type LogAbsence = "audience" | "self-hosted" | null;
+
+export function decisionLogAbsence(
+  external: boolean,
+  audience: boolean,
+): LogAbsence {
+  if (audience) return "audience";
+  if (external) return "self-hosted";
+  return null;
+}

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -21,6 +21,7 @@ import { useAgentDetailSnapshot } from "@/data/useAgentDetailSnapshot";
 import { useCompetitionSnapshot } from "@/data/useCompetitionSnapshot";
 import { useCursor } from "@/data/roundCursor";
 import { useMode } from "@/data/mode";
+import { decisionLogAbsence } from "@/data/logVisibility";
 import { useScenarioLabel } from "@/data/useScenarioLabel";
 import { t } from "@/i18n/messages";
 import {
@@ -681,10 +682,12 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
   const mode = useMode();
   const scenario = useScenarioLabel();
   const external = data?.agent.external === true;
-  // No decision log to show: it is on the participant's machine (self-hosted), or the server does
-  // not serve it while the competition runs (audience mode -- it is the participant's reasoning and
-  // their pending bids). Either way the tab goes, with the reason said in its place.
-  const hideLog = external || mode.audience;
+  // No decision log to show: the server does not serve it while the competition runs (audience
+  // mode -- it is the participant's reasoning and their pending bids), or it is on the participant's
+  // machine (self-hosted). Either way the tab goes, with the reason said in its place; which reason
+  // is one rule shared with the board (data/logVisibility.ts, issue #69).
+  const logAbsence = decisionLogAbsence(external, mode.audience);
+  const hideLog = logAbsence !== null;
   // Rules §4.7: where standings are not posted, this page posts none either — not the tab, not the
   // header badge, not the score card, not the per-round rank column (issue #84 B). The page opens
   // on Overview instead, and everything the chain says about the agent stays.
@@ -1082,10 +1085,10 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
                     marginBottom: "10px",
                   }}
                 >
-                  {external
-                    ? t("agent.selfHosted")
-                    : mode.audience
-                      ? t("agent.audienceLog")
+                  {logAbsence === "audience"
+                    ? t("agent.audienceLog")
+                    : logAbsence === "self-hosted"
+                      ? t("agent.selfHosted")
                       : t("agent.decisionLive")}
                 </span>
                 {hideLog ? (
@@ -1097,9 +1100,9 @@ export function AgentDetailPage({ agentId }: { agentId: string }) {
                       color: "var(--text-secondary)",
                     }}
                   >
-                    {external
-                      ? t("agent.selfHostedLog")
-                      : t("agent.audienceLogNote")}
+                    {logAbsence === "audience"
+                      ? t("agent.audienceLogNote")
+                      : t("agent.selfHostedLog")}
                   </p>
                 ) : (
                   <LogStream lines={agent.recentLog} height={320} />

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -382,7 +382,9 @@ With `ERIS_DASHBOARD_AUDIENCE=1` the runs API (`dashboard/server/runsApi.ts`):
   competition is in progress; that comes from the plan's epoch count, not from finding a live run
 
 `/runs/mode.json` reports the switches, and the pages say what is absent rather than rendering it
-empty: the decision-log tab and the mempool feed are replaced by a sentence, the scenario list's
+empty: the decision-log tab and the mempool feed are replaced by a sentence (for operator-run agents
+too — in the live week nothing is `external`, and the withholding is the audience switch's, not the
+agent's; issue #69, rule in `dashboard/src/data/logVisibility.ts`), the scenario list's
 episode column carries a note, the regime columns are gone, and live mode stops reading the chain
 (the RPC an audience would need is the competition node itself). Until that endpoint answers, the
 pages hold **both** restrictions on: a browser that could not reach it must not render what either

--- a/test/dashboardLogVisibility.test.ts
+++ b/test/dashboardLogVisibility.test.ts
@@ -1,0 +1,24 @@
+// The one rule for why an agent's decision log is absent from a dashboard page (issue #69).
+//
+// Two pages say it -- the agent page and the board's log panel -- and they used to derive it
+// separately with opposite precedence for a self-hosted agent viewed by the audience. The reason
+// matters because each is a different claim: "audience" says the server withholds every
+// participant's log and pending bids while the competition runs (rules §2.6 / §7.2), "self-hosted"
+// says this one was never written here. Operator-run agents in the live week are the case the
+// issue was filed for: not external, yet their reasoning and bids must not reach a viewer.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decisionLogAbsence } from "../dashboard/src/data/logVisibility.js";
+
+test("an operator-run agent's log is withheld from the audience, with that reason", () => {
+  assert.equal(decisionLogAbsence(false, true), "audience");
+});
+
+test("the audience reason wins over self-hosted: the public view withholds everyone's log", () => {
+  assert.equal(decisionLogAbsence(true, true), "audience");
+});
+
+test("the operator sees a self-hosted agent's absence for what it is, and a local agent's log", () => {
+  assert.equal(decisionLogAbsence(true, false), "self-hosted");
+  assert.equal(decisionLogAbsence(false, false), null);
+});


### PR DESCRIPTION
## Summary

Issue #69 asked for a way to hide the decision-log tab and the mempool feed when agents are operator-run and the run is shown to an audience. The audience-mode work for #84 (`ERIS_DASHBOARD_AUDIENCE=1`) already does that for every agent the server serves; this PR audits each surface against the issue's two problems (pending bids on the feed, participant-written `reason`), fixes the one inconsistency, and locks the rule with a test so the issue can close with evidence.

## Audit (audience mode, operator-run agent = `external: false`)

| surface | behaviour with `ERIS_DASHBOARD_AUDIENCE=1` | status |
|---|---|---|
| runs API `agents/<id>.jsonl`, `agents/<id>.llm.jsonl`, `/tail/agents/…` | 404 (`audienceAllows`), covered by `test/dashboardRunsApi.test.ts` | already correct |
| runs API: anything derived server-side from agent logs into another artifact | none; `summary.json` only loses `stderrTail`, `events.jsonl` loses seeds / future windows / rigged truth | already correct |
| `runsProvider.agentLogsFor` (tape venue labels, arb markers, board log lines) | returns empty logs without fetching; `withheld: true` carried to the board | already correct |
| `liveRun.ts` tail loop | skips `refreshAgentLogs` and chain reads in audience mode | already correct |
| Agent page log tab (`AgentDetailPage.tsx`) | tab replaced by a sentence (`agent.audienceLog` / `agent.audienceLogNote`) | reason now from the shared rule |
| Board log panel (`WorldPanels.tsx`) | `world.logsWithheld` sentence | reason now from the shared rule |
| Market page submissions feed (`MarketPage.tsx`) | feed hidden, `market.submissionsAudience` says why (rules §2.6) | already correct |
| Board mempool rows (`WorldMap.tsx` `MEMPOOL_ROWS`) | reads included txs from `blocks.csv`, not self-reports; no bids | already correct |
| Mode not yet fetched (#84 U) | `UNKNOWN_MODE` is `audience: true, standings: false` | already correct |

The inconsistency: for a self-hosted agent viewed by the audience, the agent page said "on the participant's machine" while the board said "not served in the public view". Those are different claims.

## Change

- `dashboard/src/data/logVisibility.ts`: `decisionLogAbsence(external, audience)` → `"audience" | "self-hosted" | null`. The audience reason wins: the public view withholds every participant's reasoning and pending bids (rules §2.6 / §7.2) regardless of where the agent runs.
- `AgentDetailPage.tsx` and `WorldPanels.tsx` use it instead of inline derivations.
- `test/dashboardLogVisibility.test.ts` locks the precedence (3 tests).
- `docs/guide/dashboard.md` "Public view": states the withholding covers operator-run agents and points at the rule.

No i18n changes: both locales already carry every string used.

## Verification

- `npm run typecheck` and `dashboard` `tsc --noEmit`: clean.
- `npm run test`: 764 / 772 pass; the 1 failure (`selector recovery finds an un-gated rescue()`) reads `out/LeakyVault.sol/LeakyVault.json` and needs `npm run build:contracts` in a fresh worktree — unrelated to this change.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
