### PR TITLE
Calibrate background flow and venue depth to measured Base-scale numbers (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,37 @@ LP 建玉 10、bundle 内 action 5 — 全部消した。**引き上げではな
 - `npm run manifest` は**「上限は無い」と明記**する（節ごと省くと「未公開」と区別が付かない）
 - **CLAUDE.md と `docs/scoring-metric-measurements.md` の実測値は全部上限下で取ったもの**。数字は変わる
 
+### 背景フローと venue 深度の較正（issue #79。2026-09-07 実測の Base / Ethereum / Arbitrum に合わせた）
+
+**2026-09-13 以前に取った実測値は全部旧較正下のもの**（uninformed 0.9/block・σ 1.0・clamp 3・GM pool 200 WETH・
+Aave seed 9k USDC・SP 50k）。CLAUDE.md と `docs/scoring-metric-measurements.md` の数字は再計測まで読み替える。
+
+- **config 側（regime YAML + sdk 既定。dump 焼き直し不要）**: `flow.uninformedArrivalRate` 0.9 → **0.45**
+  （Base の主要 2 venue が 2 s あたり 0.41〜0.44 swap）/ `uninformedSizeSigma` 1.0 → **1.5**（`Rng.lognormal` は
+  平均保存なので平均 0.5 WETH は不変、median 0.30 → 0.16、mean/median 1.65 → 3.1 = 実測 3〜11 の内側）/
+  **`uninformedSizeClampMult`**（新設。`Math.min(3, …)` の定数をノブ化、既定 3 = バイト互換、レジームは 10。
+  σ 1.5 × 0.45/block で 3 WETH 超が venue・epoch あたり ~4 本、10 WETH 超が 2 epoch に 1 本。**到着を半減した分の
+  dislocation をこの tail が肩代わりする**）/ `flow.gmxMaxSizeUsd` 既定 $20k → **$100k**（注文 $500 / 平均 $2.5k /
+  最大 $10k = perp は spot の 1 桁上）。whale・Aave actor は据え置き（whale は「プール深度に対する割合」の規則を
+  値の隣に書いた）
+- **deployer 側（`npm run gen:state-dump` で焼き直し必須）**: GM pool 200 WETH + 600k → **1,500 WETH + 4.5M USDC**
+  （spot 比 0.2× → 1.5×。Arbitrum 実測 1.7×。impact factor 0 なので約定は不変、OI/pool = funding skew が小さくなる）/
+  Aave shared seed 9k USDC + 10 WETH → **5M USDC + 2,000 WETH**（Base の 20× は採らない。12 分のエポックで
+  利用率と金利カーブは効かず、agent 規模の借入が空リザーブに当たらない深さがあれば足りる）/
+  Stability Pool 50k → **125k eUSD** + genesis Trove **350 ETH / 350k eUSD**（上の Liquity 節）。
+  WETH 予算は tokens.ts の wrap 10,000 に対し 3,000 + 1,500 + 2,010 = 6,510 で収まる
+- **spot 深度（1,000 WETH + 3M USDC / venue）と価格アンカー（$3,000 / $60,000）は据え置き**。深度を倍にして
+  件数を半分にすると dislocation は 1/4 になり calm の 39bps が 30bps の informed 帯に入ってしまう
+- **受け入れは「レジームが発火する」**（α 予算の保存ではない）。8 regime × 5 seed を rule-based ロスターで 1 回。
+  calm の平均乖離と venue-arb の P は報告のみ。乖離が帯の内側に潰れたら clamp か σ を動かす（決定は動かさない）
+- **初回実測（2026-09-13、新 dump で calm#101 / crash#101 を 1 本ずつ、regime 既定ロスター noop / venue-arb / multi-arb）**:
+  calm の venue 乖離は平均 **40.1bps**（旧較正の 39bps と同水準。中央値 39.0、30bps 帯超が 61%）で、
+  到着を半減しても tail が dislocation を保った。uninformed は venue あたり **~0.9/block**（WETH 0.45 + WBTC 0.45 = base
+  ごとに Poisson を引くので 2 倍。360 ブロックで base あたり ~162）。venue-arb は net −136 / P −1,105（noop −863）、
+  multi-arb は net +23。crash#101 は 15.6% の gap + 59% の liquidityPull が発火・復元し、`stress_calibration_warning` /
+  `_capped` は 0。crash 後 ~100 ブロック、WBTC の curve が fair 比 +100〜250bps に居座り `no_arb_persistent_warning`
+  （balancer 買い / curve 売り 120bps × 10 ブロック）が 11 回出た。旧較正の crash#101 とは未比較なので、#79 由来かは未確定
+
 ### GMX の funding は localhost でも動く
 
 以前は**構造的に 0** だった。upstream の hardhat 用マーケット設定（localhost はこれを通る）は
@@ -543,7 +574,10 @@ ours なのは 2 つだけ（core は無改変）:
 - **較正**（実測。100k/100k・A=100 のプール）: 40k 売却で 114bps / 50k で 175bps / 60k で 282bps。
   償還手数料 floor 50bps + 償還 ETH を USDC に戻す ~30bps を超えて初めて α になる。
   プールの A は 2000 ではなく **100**（A=2000 だと半分売っても 4.4bps しか動かず、償還手数料を永久に超えない）。
-  eUSD 供給 250k に対し baseRate は 5k 償還ごとに約 +100bps 上がるので、**先に償還した者が後続の価格を決める**
+  eUSD 供給 350k に対し baseRate は 5k 償還ごとに約 +71bps 上がるので、**先に償還した者が後続の価格を決める**
+  （issue #79 以前は供給 250k・+100bps。genesis Trove 250 ETH / 250k eUSD → 350 ETH / 350k eUSD、Stability Pool
+  50k → 125k = Liquity 実測の供給比 50%。deployer の余剰 = 環境が `eusdDepeg` で売る在庫は 100k → 125k で、
+  cdp-incident の 85% 売却も cdp-recovery の `liquitySpSeedEusdWei` 100k も cap されない）
 - coordinator は `liquity_setup`（オラクル差し替えと drift 検証。Recovery Mode 開幕やデペグ済みチェーンは fail-fast）/
   `liquity_block`（毎ブロックの peg・TCR・手数料・最下位 ICR）/ `stress_eusd_depeg`（+ `_setup` / `_capped` /
   `_failed` / `_restored`）を emit する
@@ -558,7 +592,7 @@ ours なのは 2 つだけ（core は無改変）:
   借り手の防御が効くかは**借りた eUSD を使ったかどうか**で決まる（`ERIS_TROVE_SPEND_DEBT`）。実測で
   200% 保持組は無傷、125% で全額 post して eUSD を売った組は清算され −13,140（担保 20 ETH を失い USDC を残す）
 - **Recovery Mode は公式レジームの較正では到達不能**（実測: seed 501 で最小 TCR 2.244 対 CCR 1.5）。genesis Trove
-  が 250 ETH / 250k eUSD（300%）で TCR を支配するため。**到達させるのは victim cohort の仕事**（issue #59 →
+  が 350 ETH / 350k eUSD（300%。#79 以前は 250 / 250k）で TCR を支配するため。**到達させるのは victim cohort の仕事**（issue #59 →
   `config/regimes/cdp-recovery.yaml`、公式セット外）: `stress.liquityRecoveryTcr` を書くと coordinator が seed の引いた
   crash magnitude と現状の system から各 victim の担保を逆算し（`recoveryCohortCollateralWei`）、届かなければ setup で
   fail-fast。RM の清算（MCR〜TCR 帯）は SP が債務を全額吸収できる場合しか執行されないので `stress.liquitySpSeedEusdWei`

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -80,12 +80,14 @@ flow:
   #   informedArbFeeBps: makes the environment's arbitrage (informed flow) fee-aware. Closes the
   #     excess only when the gap exceeds the fee band (default 30bps), leaving a residual = fee (does
   #     not fully close to fair every block). 0 for the legacy behavior.
-  #   uninformedArrivalRate: makes uninformed flow Poisson-arriving (lambda, default 0.9). 0 reverts to a fixed count.
-  #   uninformedSizeSigma: makes uninformed flow size lognormal (sigma, default 1.0. heavy tail = occasional large orders).
+  #   uninformedArrivalRate: makes uninformed flow Poisson-arriving (lambda, default 0.45). 0 reverts to a fixed count.
+  #   uninformedSizeSigma: makes uninformed flow size lognormal (sigma, default 1.5. heavy tail = occasional large orders).
+  #   uninformedSizeClampMult: upper clamp on a lognormal size as a multiple of uninformedMax (default 3; the regimes set 10).
   # Note: Poisson/lognormal increase variance, so read run comparisons as aggregates over multiple seeds. Disable with 0.
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # Extend the same realistic flow to GMX / Aave (enabled by default. ADR 0015 Notes / amm-challenge).
   #   gmxArrivalRate: makes GMX position count Poisson(lambda) and size lognormal (default 0.75). 0
   #     reverts to the legacy Bernoulli(gmxActivityProb)+uniform burst+uniform size. gmxSizeSigma is the lognormal sigma (default 1.0).

--- a/config/liquity.yaml
+++ b/config/liquity.yaml
@@ -53,8 +53,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
 
 stress:
   events:
@@ -71,9 +72,12 @@ stress:
     # where the right move is to wait. A range where every draw pays would measure reaction time
     # rather than judgement.
     #
-    # One more thing this scale makes sharp: with a 250k eUSD supply, Liquity's baseRate rises about
-    # 100bps per 5k redeemed, so the *first* redemption is cheap and the next one may not clear at
-    # all. That is the venue's own timing pressure, not a calibration artefact.
+    # One more thing this scale makes sharp: with a 350k eUSD supply (issue #79 grew the genesis
+    # Trove from 250k with the Stability Pool, 50k -> 125k), Liquity's baseRate rises about 71bps per
+    # 5k redeemed (it was ~100bps at 250k), so the *first* redemption is cheap and the next one may
+    # not clear at all. That is the venue's own timing pressure, not a calibration artefact. The
+    # depeg calibration above is per 100k pool and does not move; what moved is the environment's
+    # sell inventory (the genesis surplus, 100k -> 125k), which is what keeps the 0.6 draw uncapped.
     - {
         type: eusdDepeg,
         magnitudeRange: [0.4, 0.6],

--- a/config/lst.yaml
+++ b/config/lst.yaml
@@ -106,8 +106,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # There is no LST flow bot yet: the secondary market moves only when agents trade it. That is
   # deliberate for phase 1 — an environment-driven depeg is phase 2's job. Consequence: from a
   # freshly deployed (at-par) chain the discount stays near zero, so lst-carry will stake and

--- a/config/regimes/agent-markets.yaml
+++ b/config/regimes/agent-markets.yaml
@@ -47,8 +47,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/b-harness.yaml
+++ b/config/regimes/b-harness.yaml
@@ -58,8 +58,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
 
 stress:
   events:

--- a/config/regimes/calm.yaml
+++ b/config/regimes/calm.yaml
@@ -49,13 +49,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -70,8 +72,9 @@ flow:
   curveMaxWethWei: "1000000000000000000"
   # Realistic flow (fee-aware informed + Poisson/lognormal. same calibration values as config/example.yaml)
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/cdp-incident.yaml
+++ b/config/regimes/cdp-incident.yaml
@@ -62,13 +62,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -82,8 +84,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/cdp-recovery.yaml
+++ b/config/regimes/cdp-recovery.yaml
@@ -5,7 +5,7 @@
 # field has agents that act inside Recovery Mode.
 # Run: npm run backtest -- --regime cdp-recovery --seed 101 [--agents <roster>]
 #
-# The genesis Trove (250 ETH / 250,000 eUSD, 300 %) dominates the system ratio, so no crash the
+# The genesis Trove (350 ETH / 350,000 eUSD, 300 %; 250 / 250k before issue #79) dominates the system ratio, so no crash the
 # regimes use reaches CCR 1.5 (issue #59 measured a minimum TCR of 2.24 on a 15-22 % crash). Lowering
 # the genesis Trove would invert the redemption order and thin the Stability Pool for every regime
 # (the issue's three reasons), so the debt that breaks the system comes from the environment's
@@ -63,8 +63,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/cex-drift.yaml
+++ b/config/regimes/cex-drift.yaml
@@ -53,13 +53,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -73,8 +75,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/crash.yaml
+++ b/config/regimes/crash.yaml
@@ -49,13 +49,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -69,8 +71,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/depeg-persist.yaml
+++ b/config/regimes/depeg-persist.yaml
@@ -62,13 +62,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -82,8 +84,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # There is no DAI flow bot. The pair sits at par unless the event below pushes it or an agent
   # trades it, which is the same arrangement the liquity regime uses and for the same reason: an
   # emergent depeg would make the regime's character a function of who entered.

--- a/config/regimes/depeg.yaml
+++ b/config/regimes/depeg.yaml
@@ -54,13 +54,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -74,8 +76,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # There is no DAI flow bot. The pair sits at par unless the event below pushes it or an agent
   # trades it, which is the same arrangement the liquity regime uses and for the same reason: an
   # emergent depeg would make the regime's character a function of who entered.

--- a/config/regimes/informed-flow.yaml
+++ b/config/regimes/informed-flow.yaml
@@ -49,13 +49,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -71,8 +73,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/lending-incident.yaml
+++ b/config/regimes/lending-incident.yaml
@@ -49,13 +49,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -69,8 +71,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/liquity-crash.yaml
+++ b/config/regimes/liquity-crash.yaml
@@ -47,8 +47,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
 
 stress:
   events:

--- a/config/regimes/liquity.yaml
+++ b/config/regimes/liquity.yaml
@@ -34,8 +34,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # There is no eUSD flow bot: the peg moves only when the stress event below pushes it or an agent
   # trades it. That is why the event is part of the regime rather than optional decoration — at par
   # the venue is correctly inert.

--- a/config/regimes/lst.yaml
+++ b/config/regimes/lst.yaml
@@ -52,8 +52,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   # No LST flow bot yet, so the secondary market moves only when agents trade it: from an at-par
   # start the discount stays near zero and the carry path does not fire. That is phase 2's
   # remaining gap, not a property of this regime.

--- a/config/regimes/lucky-drift.yaml
+++ b/config/regimes/lucky-drift.yaml
@@ -47,8 +47,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
 
 stress:
   events:

--- a/config/regimes/metric-calm.yaml
+++ b/config/regimes/metric-calm.yaml
@@ -36,8 +36,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-cex-drift.yaml
+++ b/config/regimes/metric-cex-drift.yaml
@@ -39,8 +39,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-crash.yaml
+++ b/config/regimes/metric-crash.yaml
@@ -36,8 +36,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-depeg.yaml
+++ b/config/regimes/metric-depeg.yaml
@@ -35,8 +35,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   baseMax:
     WBTC: "5000000"
 stress:

--- a/config/regimes/metric-informed-flow.yaml
+++ b/config/regimes/metric-informed-flow.yaml
@@ -36,8 +36,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-lending-incident.yaml
+++ b/config/regimes/metric-lending-incident.yaml
@@ -36,8 +36,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-vuln.yaml
+++ b/config/regimes/metric-vuln.yaml
@@ -39,8 +39,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/metric-whale.yaml
+++ b/config/regimes/metric-whale.yaml
@@ -36,8 +36,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/ruin-test.yaml
+++ b/config/regimes/ruin-test.yaml
@@ -52,8 +52,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
 
 stress:
   events:

--- a/config/regimes/spike.yaml
+++ b/config/regimes/spike.yaml
@@ -56,13 +56,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -76,8 +78,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/vuln.yaml
+++ b/config/regimes/vuln.yaml
@@ -56,13 +56,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -76,8 +78,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"

--- a/config/regimes/whale.yaml
+++ b/config/regimes/whale.yaml
@@ -49,13 +49,15 @@ funding:
   wethWei: "8000000000000000000" # 8 WETH
   base: { WBTC: "40000000" } # 0.4 WBTC (8 decimals)
   # The flow wallets' own inventory, sized so a flowTrend hold can be delivered rather than declared
-  # (issue #112). A x3 lean held for 30 blocks is ~51 WETH of one-way flow per venue wallet
-  # (0.5 WETH mean x 3 x 0.9 arrivals/block x 38 effective blocks), and informed-flow holds two such
-  # windows (~103 WETH); a wallet funded like an agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
+  # (issue #112). A x3 lean held for 30 blocks is ~26 WETH of one-way flow per venue wallet
+  # (0.5 WETH mean x 3 x 0.45 arrivals/block x 38 effective blocks; ~51 WETH before issue #79 halved
+  # the arrival rate), and informed-flow holds two such windows (~51 WETH); a wallet funded like an
+  # agent (0 WETH / 25k USDC = ~8 WETH at $3,000) runs dry within
   # the ramp on either side -- sells flip to buys once the WETH bought earlier in the window is gone,
   # buys are capped at the USDC left -- and the measured lean was x1.4 for 3 blocks against the
   # declared x2-3 for 12. 150 WETH and its USDC equivalent cover two same-direction windows with
-  # margin; against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
+  # margin (kept at the pre-#79 size: the 10x size clamp means a single tail print can be 10 WETH);
+  # against ~$6M of depth per venue that is a 7.5 % depth question, not a fairness one (the
   # flow is machinery and unscored). WBTC is the same fix one issue earlier (#99: every WBTC sell was
   # submitted against a zero balance, ~90 % of the WBTC informed rows reverted).
   flowWethWei: "150000000000000000000" # 150 WETH per flow wallet
@@ -69,8 +71,9 @@ flow:
   balancerMaxWethWei: "1000000000000000000"
   curveMaxWethWei: "1000000000000000000"
   informedArbFeeBps: 30
-  uninformedArrivalRate: "0.9"
-  uninformedSizeSigma: "1.0"
+  uninformedArrivalRate: "0.45" # issue #79: Base measures 0.41-0.44 swaps per 2 s block on its two main WETH/USDC venues
+  uninformedSizeSigma: "1.5" # issue #79: mean-preserving; median 0.30 -> 0.16 WETH, mean / median 1.65 -> 3.1 (measured 3-11)
+  uninformedSizeClampMult: "10" # issue #79: was a constant 3. ~4 prints > 3 WETH per venue per epoch, ~1 > 10 WETH every two epochs
   gmxArrivalRate: "0.75"
   gmxSizeSigma: "1.0"
   aaveActorSizeSigma: "1.0"
@@ -84,6 +87,11 @@ flow:
 stress:
   # Ranges, not values: the seed samples both the size and the block (ADR 0009). The windows are
   # disjoint so the four prints land spread out rather than clustering into one shock.
+  #
+  # The magnitude is WETH and is meaningful only against the pool's depth (events.ts says so):
+  # 25-60 WETH is 2.5-6 % of a 1,000 WETH full-range side. Issue #79 left spot depth at 1,000 WETH
+  # + 3M USDC per venue and left this range alone; if depth ever changes, scale the range with it
+  # so a print stays 2.5-6 % of a side rather than a fixed number of WETH.
   events:
     - { type: whale, magnitudeRange: [25, 60], windowFrac: [0.10, 0.25] }
     - {

--- a/core/src/coordinator.ts
+++ b/core/src/coordinator.ts
@@ -225,6 +225,7 @@ export async function buildFlowContext(
       informedArbFeeBps: String(ctx.config.informedArbFeeBps),
       uninformedArrivalRate: String(ctx.config.uninformedFlowArrivalRate),
       uninformedSizeSigma: String(ctx.config.uninformedFlowSizeSigma),
+      uninformedSizeClampMult: String(ctx.config.uninformedFlowSizeClampMult),
       gmxArrivalRate: String(ctx.config.gmxFlowArrivalRate),
       gmxSizeSigma: String(ctx.config.gmxFlowSizeSigma),
       aaveActorSizeSigma: String(ctx.config.aaveFlowActorSizeSigma),

--- a/core/src/flow/logic.ts
+++ b/core/src/flow/logic.ts
@@ -60,6 +60,10 @@ export type FlowLimits = {
   // λ=0=off (fixed count + uniform).
   uninformedArrivalRate: number;
   uninformedSizeSigma: number;
+  // Issue #79: the upper clamp on a lognormal uninformed size, as a multiple of uninformedMax.
+  // 3 is the constant the clamp used to be (byte-compatible); the official regimes set 10 so
+  // the tail prints that replace the halved arrival count as the source of dislocations exist.
+  uninformedSizeClampMult: number;
   // ADR 0015 Notes: extend the above to GMX/Aave. gmxArrivalRate=0 / aaveActorSizeSigma=0 is the legacy behavior.
   gmxArrivalRate: number;
   gmxSizeSigma: number;
@@ -131,6 +135,8 @@ export type FlowContextWire = {
     // ADR 0015 Notes / amm-challenge retail: uninformed arrivals Poisson(λ) / lognormal σ. unset/"0"=off.
     uninformedArrivalRate?: string;
     uninformedSizeSigma?: string;
+    // Issue #79: size clamp multiple. unset = 3 (the old constant).
+    uninformedSizeClampMult?: string;
     // ADR 0015 Notes: GMX/Aave extension. unset/"0"=off (legacy behavior).
     gmxArrivalRate?: string;
     gmxSizeSigma?: string;
@@ -321,6 +327,10 @@ export function buildAmmFlow(
   // Seed the persisted trend so its direction is not a pure function of the block window (see
   // trendBit). Comes from FlowContextWire.flowSeed; 0 is only reached by a direct unit-test call.
   trendSeed = 0,
+  // Issue #79: the lognormal size clamp as a multiple of uninformedMax. 3 = the constant this
+  // used to be. Only the upper clamp is a knob; the 2% floor stays (it keeps a size from rounding
+  // to nothing, not the pool from breaking).
+  uninformedSizeClampMult = 3,
 ): FlowOrder[] {
   const orders: FlowOrder[] = [];
   const swapType =
@@ -379,13 +389,17 @@ export function buildAmmFlow(
     let uninformedTokenIn: TokenSymbol =
       trendTokenIn ?? (rng.bool() ? base : "USDC");
     // Poisson mode makes size lognormal (heavy-tailed = occasionally large). Mean = uninformedMax×0.5,
-    // about the same level as the old uniform (mean ~52.5%). Outliers are clamped to [2%, 300%] so the pool isn't broken.
+    // about the same level as the old uniform (mean ~52.5%). Outliers are clamped to
+    // [2%, uninformedSizeClampMult × 100%]. The clamp used to be a constant 3; with the calibrated
+    // σ = 1.5 and 0.45 arrivals/block (issue #79) a 10× clamp lets ~4 prints per venue per epoch
+    // exceed 3 WETH (~60 bps of impact each on a 1,000 WETH full-range side) and about one every two
+    // epochs exceed 10 WETH -- the tail that stands in for the halved count.
     const uninformedWethEquiv =
       uninformedArrivalRate > 0
         ? scaleFraction(
             uninformedMaxWethWei,
             Math.min(
-              3,
+              uninformedSizeClampMult,
               Math.max(0.02, rng.lognormal(0.5, uninformedSizeSigma)),
             ),
           )
@@ -790,6 +804,10 @@ export function decodeFlowLimits(wire: FlowContextWire["limits"]): FlowLimits {
       Number(wire.uninformedArrivalRate ?? "0"),
     ),
     uninformedSizeSigma: Math.max(0, Number(wire.uninformedSizeSigma ?? "1")),
+    uninformedSizeClampMult: Math.max(
+      0.02,
+      Number(wire.uninformedSizeClampMult ?? "3"),
+    ),
     gmxArrivalRate: Math.max(0, Number(wire.gmxArrivalRate ?? "0")),
     gmxSizeSigma: Math.max(0, Number(wire.gmxSizeSigma ?? "1")),
     aaveActorSizeSigma: Math.max(0, Number(wire.aaveActorSizeSigma ?? "0")),
@@ -852,6 +870,7 @@ export function buildFlowOrders(
           limits.uninformedSizeSigma,
           limits.uninformedFlowTrendCorrelation,
           ctx.flowSeed ?? 0,
+          limits.uninformedSizeClampMult,
         ),
       );
     } else if (protocol === "aave") {
@@ -961,6 +980,7 @@ export function buildFlowOrders(
           limits.uninformedSizeSigma,
           limits.uninformedFlowTrendCorrelation,
           ctx.flowSeed ?? 0,
+          limits.uninformedSizeClampMult,
         ),
       );
     }

--- a/deployer/src/protocols/aave-v3.ts
+++ b/deployer/src/protocols/aave-v3.ts
@@ -612,8 +612,17 @@ async function supplySharedAsset(
 }
 
 /**
- * Sanity-check the shared mock token (WETH/USDC) reserves with one supply -> borrow round trip.
+ * Seed the shared mock token (WETH/USDC) reserves and sanity-check them with one borrow.
  * No faucet needed: the deployer holds WETH (wrap) and USDC (mint) balances from deployTokens.
+ *
+ * Issue #79: 5M USDC + 2,000 WETH supplied (was 9,000 USDC + 10 WETH, 0.005x the spot pool
+ * against 20-50x on Base / Ethereum). Deliberately not the Base ratio: utilization and the rate
+ * curve do nothing inside a 12-minute epoch (EVM time is not warped), so depth only has to make
+ * agent-scale draws execute -- a 25k-100k USDC borrow, levered-long's supply loop -- instead of
+ * hitting an empty reserve. The 1,000 USDC borrow stays as the sanity check.
+ *
+ * WETH budget: tokens.ts wraps 10,000 WETH at deploy. The venues take 1,000 each on uniswap /
+ * balancer / curve, 1,500 on the GM pool (#79) and 2,010 here (#79) = 6,510; lst.ts wraps its own.
  */
 async function seedSharedSupplyBorrow() {
   const reg = getRegistry();
@@ -626,10 +635,14 @@ async function seedSharedSupplyBorrow() {
   info("Aave V3: supply shared USDC/WETH -> borrow shared USDC");
   await supplySharedAsset(
     usdc,
-    9000n * 10n ** 6n,
-    "9000 USDC (liquidity+collateral)",
+    5_000_000n * 10n ** 6n,
+    "5,000,000 USDC (liquidity+collateral)",
   );
-  await supplySharedAsset(weth, 10n * 10n ** 18n, "10 WETH (collateral)");
+  await supplySharedAsset(
+    weth,
+    2_000n * 10n ** 18n,
+    "2,000 WETH (liquidity+collateral)",
+  );
   await borrowAsset(usdc, 1000n * 10n ** 6n, "1000 USDC");
 
   const acct = await accountData();

--- a/deployer/src/protocols/gmx-v2.ts
+++ b/deployer/src/protocols/gmx-v2.ts
@@ -163,7 +163,11 @@ async function seedGmMarket(
     DepositHandler: core.DepositHandler,
   };
 
-  // WETH/USDC: at $3000/WETH, seed 200 WETH + 600k USDC ($1.2M, consistent with the AMM venue)
+  // WETH/USDC: at $3000/WETH, seed 1,500 WETH + 4.5M USDC ($9M). Issue #79: the pool used to be
+  // 200 WETH + 600k USDC, 0.2x the spot pool, where Arbitrum's GM pool measures 1.7x its main spot
+  // pool; this puts it at 1.5x. Position impact is 0 on this deploy, so fills do not change -- what
+  // changes is OI / pool, hence the funding skew (smaller; #78 reads it from chain either way). The
+  // WBTC market below already takes a 3M USDC deposit, so the hardhat-profile pool caps do not bind.
   const wethMarket = markets.find(
     (m) =>
       m.longToken.toLowerCase() === weth.toLowerCase() &&
@@ -179,8 +183,8 @@ async function seedGmMarket(
         longToken: wethMarket.longToken,
         shortToken: wethMarket.shortToken,
       },
-      200n * 10n ** 18n,
-      600_000n * 10n ** 6n,
+      1_500n * 10n ** 18n,
+      4_500_000n * 10n ** 6n,
       [
         { token: weth, usd: 3000, decimals: 18 },
         { token: usdc, usd: 1, decimals: 6 },

--- a/deployer/src/protocols/liquity.ts
+++ b/deployer/src/protocols/liquity.ts
@@ -48,13 +48,22 @@ const GENESIS_PRICE_USD = 3000n;
 /// It mints more than the market and the Stability Pool need, and the surplus is the point: eUSD
 /// only exists if it came out of a Trove, so the environment's own inventory -- what the `eusdDepeg`
 /// stress event sells to push the peg off par (issue #39 phase 5) -- has to be minted here too.
-const GENESIS_COLL_ETH = 250n;
-const GENESIS_DEBT_EUSD = 250_000n; // 250 * 3000 / 250000 = 300% ICR
+///
+/// Issue #79 grew it from 250 ETH / 250,000 eUSD with the Stability Pool: the surplus after the
+/// market (100k) and the pool (125k) has to stay >= the largest eusdDepeg draw (cdp-incident sells
+/// up to 85 % of the 100k pool depth) and >= cdp-recovery's 100k `liquitySpSeedEusdWei`, or the
+/// event caps (`stress_eusd_depeg_capped`) on every seed. 350k leaves 125k. Side effects, written
+/// into the regime comments: the redemption fee curve softens (baseRate per 5k redeemed ~ +100 bps
+/// at 250k supply -> ~ +71 bps at 350k), Recovery Mode moves further away (#59 reaches it through
+/// the victim cohort, not the genesis Trove), and sp-underwriter's pro-rata share of a liquidation
+/// for a 25k deposit falls from 33 % to 17 %.
+const GENESIS_COLL_ETH = 350n;
+const GENESIS_DEBT_EUSD = 350_000n; // 350 * 3000 / 350000 = 300% ICR
 
 /// How the minted supply is placed. What is left stays with the deployer, which is where the
 /// coordinator can draw from if a run needs to top anything up.
 const POOL_EUSD = 100_000n; // eUSD/USDC curve pool, matched with USDC
-const STABILITY_POOL_EUSD = 50_000n; // pre-seeded underwriting depth
+const STABILITY_POOL_EUSD = 125_000n; // pre-seeded underwriting depth: 50 % of supply, as on Liquity (issue #79; was 50k)
 
 /// Redemptions revert during Liquity's 14-day BOOTSTRAP_PERIOD, measured from a constructor-set
 /// deployment timestamp. Warping past it costs nothing and keeps the fork diff at zero -- the

--- a/docs/scoring-metric-measurements.md
+++ b/docs/scoring-metric-measurements.md
@@ -1,3 +1,5 @@
+> **Calibration note (2026-09-13, issue #79).** Every figure in this document was taken under the pre-#79 flow and depth (uninformed 0.9 arrivals/block, σ 1.0, size clamp 3, GM pool 200 WETH + 600k USDC, Aave seed 9k USDC + 10 WETH, Stability Pool 50k eUSD). The official regimes now run 0.45 / 1.5 / clamp 10 and the deployer seeds 1,500 WETH + 4.5M USDC / 5M USDC + 2,000 WETH / 125k eUSD. Numbers here are the record of the choice, not the current environment.
+>
 > **Superseded (2026-09-06).** The competition is scored by the deviation score of rules §4.4 (ADR 0023); the candidate metrics measured here (M1…M27, λ, the aggregators) are no longer computed by the repository. Kept as the record of how the choice was narrowed.
 
 # 採点メトリクスの実測記録

--- a/docs/spec/07-configuration.md
+++ b/docs/spec/07-configuration.md
@@ -129,12 +129,13 @@ USDC-only を維持しているのは **`metric-*` レジームだけ**で、こ
 | `uninformedTrendCorrelation` | 0 | 市場共通方向に従う確率 |
 | `informedMaxWethWei` | 2 WETH | informed のサイズ基準 |
 | `balancerMaxWethWei` / `curveMaxWethWei` | 1 WETH | venue 別 |
-| `gmxMaxSizeUsd` | 20,000 USD | |
+| `gmxMaxSizeUsd` | 100,000 USD | issue #79（旧 20,000）。注文は $500 / 平均 $2,500 / 最大 $10,000 |
 | `gmxActivityProb` / `gmxMaxBurst` | 0.5 / 2 | legacy モード用 |
 | `aaveMaxWethWei` | 2 WETH | |
 | `aaveActivityProb` / `aaveActorCount` | 0.5 / 4 | アクタープール |
 | `informedArbFeeBps` | **30** | 裁定の手数料帯（0 で無効） |
-| `uninformedArrivalRate` / `uninformedSizeSigma` | **0.9 / 1.0** | Poisson 到着 / lognormal サイズ |
+| `uninformedArrivalRate` / `uninformedSizeSigma` | **0.45 / 1.5** | Poisson 到着 / lognormal サイズ（issue #79 で Base 実測に較正。旧 0.9 / 1.0） |
+| `uninformedSizeClampMult` | 3（レジームは 10） | lognormal サイズの上限（uninformedMax の倍率。issue #79） |
 | `gmxArrivalRate` / `gmxSizeSigma` | **0.75 / 1.0** | 同上（GMX） |
 | `aaveActorSizeSigma` | **1.0** | アクターの担保サイズ分布 |
 | `baseMax` | `{WETH: 0}` | 追加 base の AMM フロー上限（0 = そのbaseのフロー無効） |

--- a/docs/spec/en/07-configuration.md
+++ b/docs/spec/en/07-configuration.md
@@ -129,12 +129,13 @@ The template (`config/example.yaml`) hands out WETH for the same reason — it i
 | `uninformedTrendCorrelation` | 0 | Probability of following the market-wide direction |
 | `informedMaxWethWei` | 2 WETH | Size basis for the informed side |
 | `balancerMaxWethWei` / `curveMaxWethWei` | 1 WETH | Per venue |
-| `gmxMaxSizeUsd` | 20,000 USD | |
+| `gmxMaxSizeUsd` | 100,000 USD | issue #79 (was 20,000); orders run $500 / $2,500 mean / $10,000 max |
 | `gmxActivityProb` / `gmxMaxBurst` | 0.5 / 2 | Legacy mode |
 | `aaveMaxWethWei` | 2 WETH | |
 | `aaveActivityProb` / `aaveActorCount` | 0.5 / 4 | The actor pool |
 | `informedArbFeeBps` | **30** | The arbitrage fee band (0 disables) |
-| `uninformedArrivalRate` / `uninformedSizeSigma` | **0.9 / 1.0** | Poisson arrivals / lognormal sizes |
+| `uninformedArrivalRate` / `uninformedSizeSigma` | **0.45 / 1.5** | Poisson arrivals / lognormal sizes (calibrated to Base in issue #79; were 0.9 / 1.0) |
+| `uninformedSizeClampMult` | 3 (regimes set 10) | Upper clamp on a lognormal size, as a multiple of uninformedMax (issue #79) |
 | `gmxArrivalRate` / `gmxSizeSigma` | **0.75 / 1.0** | Same for GMX |
 | `aaveActorSizeSigma` | **1.0** | Spread of actor collateral |
 | `baseMax` | `{WETH: 0}` | AMM flow cap for other bases (0 = no flow for that base) |

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -298,11 +298,18 @@ export type SimConfig = {
   // 0 reverts to the legacy gap-linear informed flow.
   informedArbFeeBps: number;
   // ADR 0015 Notes / amm-challenge retail: Poisson(λ) uninformed arrivals with lognormal sizes.
-  // Default λ=0.9 = on (count per block is Poisson(λ), each size is lognormal (mean = uninformedMax×0.5,
+  // Default λ=0.45 = on (count per block is Poisson(λ), each size is lognormal (mean = uninformedMax×0.5,
   // σ=uninformedFlowSizeSigma) = bursty, heavy-tailed realistic flow). 0 reverts to the legacy fixed count + uniform.
+  // Issue #79 anchored the defaults to measured venues (2026-09-07): Base's two main WETH/USDC pools
+  // see 0.41-0.44 swaps per 2 s block, and the swap-size distribution has mean ÷ median of 3-11
+  // (σ = 1.5 gives 3.1; the old 1.0 gave 1.65). `Rng.lognormal` is mean-preserving, so the mean
+  // order stays 0.5 × uninformedMax and only the tail moves.
   // Note: variance rises, so read run comparisons as an aggregate over multiple seeds.
   uninformedFlowArrivalRate: number;
   uninformedFlowSizeSigma: number;
+  // Upper clamp on a lognormal uninformed size, as a multiple of uninformedMax (issue #79). 3 is
+  // what the clamp was as a constant; the regimes set 10 so the tail exists.
+  uninformedFlowSizeClampMult: number;
   // Extends amm-challenge retail to GMX/Aave.
   // gmxFlowArrivalRate: >0 makes GMX open counts Poisson(λ) and sizes lognormal (default 0.75=on). 0 = legacy.
   // gmxFlowSizeSigma: σ of the GMX lognormal size (default 1.0).
@@ -512,9 +519,12 @@ export function loadConfig(env = process.env): SimConfig {
       env.CURVE_FLOW_MAX_WETH_WEI,
       1_000_000_000_000_000_000n,
     ),
+    // Issue #79: $100,000 (was $20,000). The lognormal size is 2.5% of max, clamped to [0.5%, 10%],
+    // so orders run $500 / $2,500 mean / $10,000 max -- an order of magnitude above spot swaps,
+    // which is what every perp venue measured shows.
     gmxFlowMaxSizeUsd: bigintEnv(
       env.GMX_FLOW_MAX_SIZE_USD,
-      20_000n * 10n ** 30n,
+      100_000n * 10n ** 30n,
     ),
     // Per-block probability of emitting gmx flow (default 0.5). Decided each block via rng, sent sporadically.
     gmxFlowActivityProb: floatEnv(env.GMX_FLOW_ACTIVITY_PROB, 0.5),
@@ -531,15 +541,20 @@ export function loadConfig(env = process.env): SimConfig {
     // amm-challenge arbitrage fee boundary (default 30bps = on. Real arbitrage does not take a gap
     // below the fee; matched to the venue fee ~30bps). 0 disables it = revert to the legacy gap-linear informed flow.
     informedArbFeeBps: Math.max(0, intEnv(env.ERIS_INFORMED_ARB_FEE_BPS, 30)),
-    // amm-challenge retail arrivals (default λ=0.9 = on. Poisson arrivals + lognormal sizes = bursty,
-    // heavy-tailed realistic flow. Calibrated to roughly the same mean as the legacy fixed count). 0 disables it = revert to fixed count + uniform.
+    // amm-challenge retail arrivals (default λ=0.45 = on. Poisson arrivals + lognormal sizes = bursty,
+    // heavy-tailed realistic flow; issue #79 anchored λ and σ to Base). 0 disables it = revert to fixed count + uniform.
     uninformedFlowArrivalRate: Math.max(
       0,
-      floatEnv(env.ERIS_UNINFORMED_ARRIVAL_RATE, 0.9),
+      floatEnv(env.ERIS_UNINFORMED_ARRIVAL_RATE, 0.45),
     ),
     uninformedFlowSizeSigma: Math.max(
       0,
-      floatEnv(env.ERIS_UNINFORMED_SIZE_SIGMA, 1),
+      floatEnv(env.ERIS_UNINFORMED_SIZE_SIGMA, 1.5),
+    ),
+    // Default 3 = the constant the clamp used to be; the regime YAMLs set 10.
+    uninformedFlowSizeClampMult: Math.max(
+      0.02,
+      floatEnv(env.ERIS_UNINFORMED_SIZE_CLAMP_MULT, 3),
     ),
     // Extends amm-challenge retail to GMX/Aave (default on. 0 reverts to legacy behavior).
     gmxFlowArrivalRate: Math.max(0, floatEnv(env.ERIS_GMX_ARRIVAL_RATE, 0.75)),

--- a/sdk/src/runConfig.ts
+++ b/sdk/src/runConfig.ts
@@ -146,6 +146,7 @@ const SCHEMA: Record<string, string> = {
   "flow.informedArbFeeBps": "ERIS_INFORMED_ARB_FEE_BPS",
   "flow.uninformedArrivalRate": "ERIS_UNINFORMED_ARRIVAL_RATE",
   "flow.uninformedSizeSigma": "ERIS_UNINFORMED_SIZE_SIGMA",
+  "flow.uninformedSizeClampMult": "ERIS_UNINFORMED_SIZE_CLAMP_MULT",
   "flow.gmxArrivalRate": "ERIS_GMX_ARRIVAL_RATE",
   "flow.gmxSizeSigma": "ERIS_GMX_SIZE_SIGMA",
   "flow.aaveActorSizeSigma": "ERIS_AAVE_ACTOR_SIZE_SIGMA",

--- a/test/flow.test.ts
+++ b/test/flow.test.ts
@@ -363,6 +363,52 @@ test("uninformedArrivalRate: Poisson mode also produces zero-count blocks (count
   assert.ok(counts.size > 1, "with Poisson the count varies (not fixed)");
 });
 
+// Issue #79: the upper clamp on a lognormal uninformed size is a knob. Unset it is the constant 3
+// the clamp used to be, so no order ever exceeds 3 x uninformedMax; at 10 the same draws produce
+// prints between 3x and 10x -- the tail that stands in for the halved arrival count.
+test("uninformedSizeClampMult: unset clamps at 3x (byte-compatible), 10 lets the tail through", () => {
+  const MAX = 1_000_000_000_000_000_000n;
+  const sizes = (clamp: string | undefined): bigint[] => {
+    const c = ctx(1);
+    c.protocols = ["uniswap"];
+    c.limits.uninformedArrivalRate = "2";
+    c.limits.uninformedSizeSigma = "1.5";
+    if (clamp !== undefined) c.limits.uninformedSizeClampMult = clamp;
+    const rng = new Rng(5);
+    const out: bigint[] = [];
+    for (let round = 1; round <= 300; round++) {
+      for (const o of buildFlowOrders(rng, { ...c, round })) {
+        if (o.kind !== "uninformed" || o.protocol !== "uniswap") continue;
+        if (o.action.type !== "swap" || o.action.tokenIn !== "WETH") continue;
+        out.push(BigInt(o.action.amountIn));
+      }
+    }
+    return out;
+  };
+  const legacy = sizes(undefined);
+  const explicit3 = sizes("3");
+  const wide = sizes("10");
+  assert.ok(legacy.length > 100, "enough WETH-side uninformed orders to read the tail");
+  assert.deepEqual(explicit3, legacy, "an explicit 3 is the unset behaviour");
+  assert.ok(
+    legacy.every((s) => s <= 3n * MAX),
+    "unset: no order exceeds 3 x uninformedMax",
+  );
+  assert.ok(
+    legacy.some((s) => s === 3n * MAX),
+    "unset: with sigma 1.5 the 3x clamp is actually hit",
+  );
+  assert.ok(
+    wide.some((s) => s > 3n * MAX),
+    "clamp 10: prints above 3 x uninformedMax exist",
+  );
+  assert.ok(
+    wide.every((s) => s <= 10n * MAX),
+    "clamp 10: no order exceeds 10 x uninformedMax",
+  );
+  assert.equal(wide.length, legacy.length, "the clamp changes sizes, not the arrival count");
+});
+
 test("gmxArrivalRate: the GMX position count varies in Poisson mode", () => {
   const c = ctx(1);
   c.protocols = ["gmx"]; // narrow to gmx only

--- a/test/flowTrendInventory.test.ts
+++ b/test/flowTrendInventory.test.ts
@@ -66,9 +66,12 @@ function worstCaseOneWayWeth(doc: Doc): number {
   return total;
 }
 
-test("informed-flow's two x3 windows are ~103 WETH of one-way flow per venue wallet", () => {
+// ~103 WETH before issue #79 halved the arrival rate (0.9 -> 0.45); the mean order is unchanged
+// (lognormal is mean-preserving in sigma) so the bound scales with the rate alone. The funding
+// stays at 150 WETH: the 10x size clamp the same issue added means a single tail print is 10 WETH.
+test("informed-flow's two x3 windows are ~51 WETH of one-way flow per venue wallet", () => {
   const w = worstCaseOneWayWeth(load("informed-flow"));
-  assert.ok(w > 100 && w < 106, `one-way WETH ${w}`);
+  assert.ok(w > 50 && w < 53, `one-way WETH ${w}`);
 });
 
 for (const name of OFFICIAL) {

--- a/test/run-config.test.ts
+++ b/test/run-config.test.ts
@@ -75,6 +75,33 @@ test("market.*: the OU parameters reach SimConfig from YAML (ADR 0017 regime 1)"
   assert.deepEqual(config.ou.perBase.WETH, config.ou.global);
 });
 
+test("flow.*: the issue #79 knobs reach SimConfig from YAML, and unset gives the calibrated defaults", () => {
+  const source = buildSource({
+    flow: {
+      uninformedArrivalRate: "0.45",
+      uninformedSizeSigma: "1.5",
+      uninformedSizeClampMult: "10",
+      gmxMaxSizeUsd: (100_000n * 10n ** 30n).toString(),
+    },
+  });
+  assert.equal(source.ERIS_UNINFORMED_ARRIVAL_RATE, "0.45");
+  assert.equal(source.ERIS_UNINFORMED_SIZE_SIGMA, "1.5");
+  assert.equal(source.ERIS_UNINFORMED_SIZE_CLAMP_MULT, "10");
+  const config = loadConfig(source);
+  assert.equal(config.uninformedFlowArrivalRate, 0.45);
+  assert.equal(config.uninformedFlowSizeSigma, 1.5);
+  assert.equal(config.uninformedFlowSizeClampMult, 10);
+  assert.equal(config.gmxFlowMaxSizeUsd, 100_000n * 10n ** 30n);
+
+  // Defaults: arrival and sigma are the Base-anchored values; the clamp default is the constant it
+  // replaced (3), so a config that never heard of the knob generates the same sizes as before.
+  const bare = loadConfig(buildSource({}));
+  assert.equal(bare.uninformedFlowArrivalRate, 0.45);
+  assert.equal(bare.uninformedFlowSizeSigma, 1.5);
+  assert.equal(bare.uninformedFlowSizeClampMult, 3);
+  assert.equal(bare.gmxFlowMaxSizeUsd, 100_000n * 10n ** 30n);
+});
+
 test("market.*: unset falls back to the calm defaults", () => {
   const config = loadConfig(buildSource({ run: { seed: 1 } }));
   assert.deepEqual(config.ou.global, {


### PR DESCRIPTION
## Summary

Recalibrates the environment's background flow and the deployer-seeded venues to the numbers measured in #79 (2026-09-07, Base / Ethereum / Arbitrum). Spot depth and price anchors stay; count and tails move on the flow side, and GMX / Aave / the Stability Pool are deepened on the deployer side.

Refs #79 — code, config, docs and a rebaked state dump are done and one scenario per regime type was run live (below). The full 8 × 5 acceptance matrix is still pending, so this does not close the issue by itself.

## A. Config side (no rebake)

| knob | before | after |
|---|---|---|
| `flow.uninformedArrivalRate` | 0.9 | **0.45** (Base: 0.41–0.44 swaps / 2 s block) |
| `flow.uninformedSizeSigma` | 1.0 | **1.5** (mean-preserving; mean ÷ median 1.65 → 3.1) |
| `flow.uninformedSizeClampMult` | constant 3 in `logic.ts` | **new knob**, default 3 (byte-compatible), regimes set **10** |
| `flow.gmxMaxSizeUsd` default | $20,000 | **$100,000** ($500 / $2,500 mean / $10,000 max) |
| `whale` | — | unchanged; the depth-fraction rule is now written beside the range |

Applied to every regime YAML (official and venue-verification), `config/example.yaml` and the `sdk/src/config.ts` defaults. The knob is wired YAML → `runConfig` SCHEMA → `SimConfig` → coordinator wire → `buildAmmFlow`, the same path as `uninformedSizeSigma`. The #112 flow-wallet inventory comments are restated at the halved rate; funding stays at 150 WETH.

## B. Deployer side (rebake required — done locally, see below)

- GMX ETH/USD GM pool: 200 WETH + 600k USDC → **1,500 WETH + 4.5M USDC** (`gmx-v2.ts`)
- Aave shared seed: 9,000 USDC + 10 WETH → **5M USDC + 2,000 WETH**, 1,000 USDC sanity borrow kept (`aave-v3.ts`). The 10,000 WETH wrap covers the venues' 6,510.
- Stability Pool 50k → **125k eUSD**, genesis Trove 250 / 250k → **350 ETH / 350k eUSD** (`liquity.ts`) so the deployer's surplus stays 125k (cdp-incident sells up to 85k, cdp-recovery seeds 100k into the SP).

## Docs

CLAUDE.md (new calibration section with the first measurements + Liquity numbers), `docs/spec/07-configuration.md` (ja/en), `config/liquity.yaml`, `config/regimes/cdp-recovery.yaml`, `docs/scoring-metric-measurements.md` header: every measured figure predating this change was taken under the old flow.

## Tests

- `test/flow.test.ts`: clamp unset == explicit 3 (byte-compatible), no order above 3× / the 3× clamp is hit at σ 1.5; clamp 10 admits prints in (3×, 10×] without changing the arrival count
- `test/run-config.test.ts`: the four knobs reach `SimConfig` from YAML; bare config gives 0.45 / 1.5 / 3 / $100k
- `test/flowTrendInventory.test.ts`: the #112 bound at the halved rate (~51 WETH)

`npm run typecheck` ✔ · `npm run test` 763 pass / 0 fail / 7 skipped (one test needs `npm run build:contracts` first, passes after) · `npm run check:boundaries` ✔ · `deployer` `tsc --noEmit` ✔

## Live validation (this worktree, fresh anvil on :8565, full deploy with the new seeds)

**Deploy succeeded** (`npm run deploy -- --keep-fresh`, all 8 protocol groups). Read back from chain:

| what | read back |
|---|---|
| GM WETH/USDC market token holds | 1,500.00 WETH / 4,500,000.00 USDC |
| Aave shared reserves (aToken supply) | 2,000.00 WETH / 5,000,000.00 USDC (4,999,000 USDC left in the reserve after the sanity borrow) |
| Stability Pool | 125,000.00 eUSD |
| genesis Trove | 350.00 ETH / 351,950 eUSD debt (350k + 0.5 % fee + 200 gas comp) |
| deployer eUSD surplus | 125,000.00 |
| deployer WETH left | 3,510 of 10,000 (budget holds) |
| spot pools | unchanged, 1,000 WETH / 3,000,000 USDC |

State dump rebaked with `npm run gen:state-dump` (commit 1299d30, fingerprint b37ea813…); `market.jsonl` of the runs reads Aave WETH supplied $6.0M / USDC $5.0M from it.

**calm#101** (`npm run backtest -- --regime calm --seed 101 --agent-sandbox process`, regime default roster noop / venue-arb / multi-arb, 360 blocks, 716 s):

| measured | value | baseline in #79 |
|---|---|---|
| mean \|venue mid − fair\| (WETH) | **40.1 bps** (median 39.0; uniswap 38.4 / balancer 38.1 / curve 43.8) | 39 bps |
| share of venue-blocks above the 30 bps band | 61 % | (reported, not gated) |
| uninformed submissions per venue | 317–343 per 360 blocks ≈ **0.9 / block** | expected ≈162 per base: WETH and WBTC each draw Poisson(0.45), so the per-venue total is 2 × 162 |
| GMX uninformed | 256 per 360 blocks (0.75 arrival, unchanged) | |
| `stress_calibration_warning` / `_capped` | 0 / 0 | |
| venue-arb | net −136.4, P −1,104.8 (noop P −862.6, so −242 vs baseline) | −289 |
| multi-arb | net +23.4, P −681.0 | |

Halving arrivals did not collapse the calm gap: the 10× tail carries it. venue-arb's P vs noop is the same order as before.

**crash#101** (same command, `--regime crash`): crash drew 15.6 % over blocks 159–176 with a 59 % `liquidityPull` aligned to it on all three venues; 45 `stress_liquidity_pull` reconciles and 3 `stress_liquidity_restored`, no `_incomplete`, no `stress_calibration_warning`, no `_capped`. Mean gap 78.4 bps (median 31.6), max ~900 bps inside the window. P: noop +1,859, venue-arb +2,372, multi-arb +6,514. (crash.yaml has no Aave victims; that check belongs to lending-incident, not run here.)

One thing to flag: for ~100 blocks after the window the WBTC leg on curve sat +100–250 bps above fair and `no_arb_persistent_warning` fired 11 times (buy balancer / sell curve, ~120 bps, 10 consecutive blocks). No pre-#79 crash#101 was run for comparison, so whether the tail prints (0.05 BTC × 10) or the curve crypto pool's repricing after a 15 % gap is behind it is not established here.

## Not done here

**Acceptance matrix** (issue "Acceptance"): the remaining 8 official regimes × 5 public seeds with the rule-based roster, checking per regime from `events.jsonl` that the regimes fire (lending-incident victims breach + `stress_liquidation`, depeg clears the floor with no `_capped`, whale moves the pool, vuln pools found). The two runs above are one draw each. If the calm gap collapses inside the 30 bps band on the other seeds, the clamp or σ moves, not the decision.

The rebaked `backtest/state` is local to this worktree (gitignored); the operator box needs the same `deploy --keep-fresh` → `gen:local-constants` → `gen:state-dump` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
